### PR TITLE
[MM-42078] Fix possible multiple component registrations

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -235,7 +235,8 @@ export default class Plugin {
 
     public async initialize(registry: PluginRegistry, store: Store<GlobalState>): Promise<void> {
         registry.registerReducer(reducer);
-        registry.registerSidebarChannelLinkLabelComponent(ChannelLinkLabel);
+        const sidebarChannelLinkLabelComponentID = registry.registerSidebarChannelLinkLabelComponent(ChannelLinkLabel);
+        this.unsubscribers.push(() => registry.unregisterComponent(sidebarChannelLinkLabelComponentID));
         registry.registerChannelToastComponent(ChannelCallToast);
         registry.registerPostTypeComponent('custom_calls', PostType);
         registry.registerNeedsTeamRoute('/expanded', ExpandedView);
@@ -416,14 +417,14 @@ export default class Plugin {
             const roles = getMyRoles(store.getState());
             const cms = getMyChannelMemberships(store.getState());
 
-            registry.unregisterComponent(channelHeaderMenuID);
-
             try {
                 const resp = await axios.get(`${getPluginPath()}/config`);
+                registry.unregisterComponent(channelHeaderMenuID);
                 if (hasPermissionsToEnableCalls(channel, cms[channelID], roles, resp.data.AllowEnableCalls)) {
                     registerChannelHeaderMenuAction();
                 }
             } catch (err) {
+                registry.unregisterComponent(channelHeaderMenuID);
                 console.log(err);
             }
 


### PR DESCRIPTION
#### Summary

I originally thought this bug was somehow due to the how community operates (pods rolling during upgrades) cause I wasn't able to reproduce but after a good amount of pure try and fail I was able to figure out it was switching channels/teams very quickly that caused it. This is because I failed to account of an async call which was delaying registering operations eventually leading to a leak.

The other issue (duplicate call icon next to channel name) is still a bit of a mystery since the component is only ever registered at plugin initialization so trying to force an unsubscribe although I don't believe it to be necessary. Will monitor for further occurrences.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42078