### PR TITLE
Add userID to call started telemetry event

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -289,6 +289,7 @@ func (p *Plugin) handleJoin(userID, connID, channelID string) error {
 		p.mut.Unlock()
 
 		p.track(evCallStarted, map[string]interface{}{
+			"UserID":      userID,
 			"CallID":      state.Call.ID,
 			"ChannelID":   channelID,
 			"ChannelType": channel.Type,


### PR DESCRIPTION
#### Summary

This didn't get included originally cause I thought we could figure it out by looking at the first user who joined a call but a little redundancy makes for easier queries on the analytics side so we are adding it here as well.
