### PR TITLE
[MM-42101] Implement option to enable calls by default

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -45,8 +45,16 @@
           "key": "AllowEnableCalls",
           "display_name": "Allow Enable Calls",
           "type": "bool",
-          "help_text": "When set to true, it allows channel admins to enable calls in their channels. It also allows participants of DMs/GMs to enable calls.",
+          "help_text": "When set to true, it allows channel admins to enable or disable calls in their channels. It also allows participants of DMs/GMs to enable or disable calls.",
           "default": false
-        }]
+        },
+        {
+          "key": "DefaultEnabled",
+          "display_name": "Default Enabled Calls",
+          "type": "bool",
+          "help_text": "When set to true, calls will be possible in all channels where they are not explicitly disabled.",
+          "default": true
+        }
+        ]
     }
 }

--- a/server/api.go
+++ b/server/api.go
@@ -57,6 +57,14 @@ func (p *Plugin) handleGetChannel(w http.ResponseWriter, r *http.Request, channe
 	info := ChannelState{
 		ChannelID: channelID,
 	}
+
+	cfg := p.getConfiguration()
+	if state == nil && cfg.DefaultEnabled != nil && *cfg.DefaultEnabled {
+		state = &channelState{
+			Enabled: true,
+		}
+	}
+
 	if state != nil {
 		info.Enabled = state.Enabled
 		if state.Call != nil {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -32,9 +32,11 @@ type configuration struct {
 type clientConfig struct {
 	// A comma separated list of ICE servers URLs (STUN/TURN) to use.
 	ICEServers ICEServers
-	// When set to true, it allows channel admins to enable calls in their channels.
-	// It also allows participants of DMs/GMs to enable calls.
+	// When set to true, it allows channel admins to enable or disable calls in their channels.
+	// It also allows participants of DMs/GMs to enable or disable calls.
 	AllowEnableCalls *bool
+	// When set to true, calls will be possible in all channels where they are not explicitly disabled.
+	DefaultEnabled *bool
 }
 
 type ICEServers []string
@@ -96,6 +98,7 @@ func (pr PortsRange) IsValid() error {
 func (c *configuration) getClientConfig() clientConfig {
 	return clientConfig{
 		AllowEnableCalls: c.AllowEnableCalls,
+		DefaultEnabled:   c.DefaultEnabled,
 		ICEServers:       c.ICEServers,
 	}
 }
@@ -106,6 +109,10 @@ func (c *configuration) SetDefaults() {
 	}
 	if c.AllowEnableCalls == nil {
 		c.AllowEnableCalls = new(bool)
+	}
+	if c.DefaultEnabled == nil {
+		c.DefaultEnabled = new(bool)
+		*c.DefaultEnabled = true
 	}
 }
 
@@ -138,6 +145,10 @@ func (c *configuration) Clone() *configuration {
 
 	if c.AllowEnableCalls != nil {
 		cfg.AllowEnableCalls = model.NewBool(*c.AllowEnableCalls)
+	}
+
+	if c.DefaultEnabled != nil {
+		cfg.DefaultEnabled = model.NewBool(*c.DefaultEnabled)
 	}
 
 	if c.ICEServers != nil {

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -75,7 +75,10 @@ func TestGetClientConfig(t *testing.T) {
 	cfg.SetDefaults()
 	clientCfg := cfg.getClientConfig()
 	require.Equal(t, cfg.AllowEnableCalls, clientCfg.AllowEnableCalls)
+	require.Equal(t, cfg.DefaultEnabled, clientCfg.DefaultEnabled)
 	*cfg.AllowEnableCalls = true
+	*cfg.DefaultEnabled = true
 	clientCfg = cfg.getClientConfig()
 	require.Equal(t, cfg.AllowEnableCalls, clientCfg.AllowEnableCalls)
+	require.Equal(t, cfg.DefaultEnabled, clientCfg.DefaultEnabled)
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -62,9 +62,17 @@ const manifestStr = `
         "key": "AllowEnableCalls",
         "display_name": "Allow Enable Calls",
         "type": "bool",
-        "help_text": "When set to true, it allows channel admins to enable calls in their channels. It also allows participants of DMs/GMs to enable calls.",
+        "help_text": "When set to true, it allows channel admins to enable or disable calls in their channels. It also allows participants of DMs/GMs to enable or disable calls.",
         "placeholder": "",
         "default": false
+      },
+      {
+        "key": "DefaultEnabled",
+        "display_name": "Default Enabled Calls",
+        "type": "bool",
+        "help_text": "When set to true, calls will be possible in all channels where they are not explicitly disabled.",
+        "placeholder": "",
+        "default": true
       }
     ]
   }

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -112,8 +112,7 @@ export default class CallsClient extends EventEmitter {
         this.ws = ws;
 
         ws.on('error', (err) => {
-            console.log(`ws error: ${err}`);
-            this.ws = null;
+            console.log('ws error', err);
             this.disconnect();
         });
 
@@ -168,7 +167,7 @@ export default class CallsClient extends EventEmitter {
                 }
             });
             peer.on('error', (err) => {
-                console.log(`peer error: ${err}`);
+                console.log('peer error', err);
                 this.disconnect();
             });
             peer.on('stream', (remoteStream) => {


### PR DESCRIPTION
#### Summary

We are adding a new `DefaultEnabled` config option that controls whether Calls should be enabled in all channels by default (opt-out model). 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42101