### PR TITLE
[MM-42198] Fix wrapping of long channel names

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1030,7 +1030,15 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             <React.Fragment>
                 <div style={{margin: '0 2px 0 4px'}}>{'•'}</div>
                 {isPublicChannel(this.props.channel) ? <CompassIcon icon='globe'/> : <CompassIcon icon='lock'/>}
-                {this.props.channel.display_name}
+                <span
+                    style={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    }}
+                >
+                    {this.props.channel.display_name}
+                </span>
             </React.Fragment>
         );
     }

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1025,7 +1025,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         }
     }
 
-    renderChannelName = () => {
+    renderChannelName = (hasTeamSidebar: boolean) => {
         return (
             <React.Fragment>
                 <div style={{margin: '0 2px 0 4px'}}>{'•'}</div>
@@ -1035,6 +1035,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
+                        maxWidth: hasTeamSidebar ? '24ch' : '14ch',
                     }}
                 >
                     {this.props.channel.display_name}
@@ -1099,7 +1100,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                             {this.renderSpeaking()}
                             <div style={this.style.callInfo}>
                                 <div style={{fontWeight: 600}}>{this.getCallDuration()}</div>
-                                {(isPublicChannel(this.props.channel) || isPrivateChannel(this.props.channel)) && this.renderChannelName()}
+                                {(isPublicChannel(this.props.channel) || isPrivateChannel(this.props.channel)) && this.renderChannelName(hasTeamSidebar)}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
#### Summary

PR fixes the issue although I am also looking for some general feedback to see if we need to plan extra changes.

As things stand we have space for up to 17 characters in single team mode and 26 with the sidebar. If we don't set a max width very long names tend to go a bit over the right almost touching the expand icon which may feel a little compressed (see picture). 

Test string was `Some very very long channel name`.

#### Single team, no sidebar

![image](https://user-images.githubusercontent.com/1832946/156356308-7ede85f7-e32a-4c9b-8898-df2537e8df03.png)

#### With sidebar

![image](https://user-images.githubusercontent.com/1832946/156355748-abd844d5-4135-4a76-8ac8-00a21e25b2c3.png)

/cc @itao 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42198

