### PR TITLE
[MM-42347] Fix UDP conn not respecting deadlines

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -27,6 +27,10 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	cfg := p.getConfiguration()
+	if err := cfg.IsValid(); err != nil {
+		p.LogError(err.Error())
+		return err
+	}
 
 	udpServerConn, err := net.ListenUDP("udp4", &net.UDPAddr{
 		Port: *cfg.UDPServerPort,
@@ -52,17 +56,27 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 	defer connFile.Close()
-	writeBufSize, err := syscall.GetsockoptInt(int(connFile.Fd()), syscall.SOL_SOCKET, syscall.SO_SNDBUF)
+
+	sysConn, err := connFile.SyscallConn()
 	if err != nil {
 		p.LogError(err.Error())
 		return err
 	}
-	readBufSize, err := syscall.GetsockoptInt(int(connFile.Fd()), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	err = sysConn.Control(func(fd uintptr) {
+		writeBufSize, err := syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF)
+		if err != nil {
+			p.LogError(err.Error())
+		}
+		readBufSize, err := syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+		if err != nil {
+			p.LogError(err.Error())
+		}
+		p.LogInfo("UDP buffers", "writeBufSize", writeBufSize, "readBufSize", readBufSize)
+	})
 	if err != nil {
 		p.LogError(err.Error())
 		return err
 	}
-	p.LogInfo("UDP buffers", "writeBufSize", writeBufSize, "readBufSize", readBufSize)
 
 	hostIP, err := getPublicIP(udpServerConn, cfg.ICEServers)
 	if err != nil {

--- a/server/activate.go
+++ b/server/activate.go
@@ -109,9 +109,9 @@ func (p *Plugin) OnDeactivate() error {
 		p.udpServerMux.Close()
 	}
 
-	// Purpusely not closing the UDP server connection here as it will cause
-	// a deadlock (see https://go.dev/play/p/ywju17IO9ZZ).
-	// The plugin's process will exit anyway so no need to explicitly do it here.
+	if p.udpServerConn != nil {
+		p.udpServerConn.Close()
+	}
 
 	if err := p.cleanUpState(); err != nil {
 		p.LogError(err.Error())


### PR DESCRIPTION
#### Summary

PR fixes an issue with the UDP server connection not respecting the defined deadlines and hence potentially getting stuck indefinitely in case of an unreachable host.

After some testing and looking into the standard library I've figure out this was actually caused by the call on [`File.Fd()`](https://pkg.go.dev/os#File.Fd) we do here:

https://github.com/mattermost/mattermost-plugin-calls/blob/4ac8eb9ee52ed2d83a76a7ed8e6740c2ec54d34c/server/activate.go#L55-L64

As suggested in the official documentation we are now using [`File.SyscallConn()`](https://pkg.go.dev/os#File.SyscallConn) instead which seems to avoid this problem.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42347