### PR TITLE
[MM-42086] Use messaging to get screenshare sources for Desktop App

### DIFF
--- a/e2e/tests/start_call.spec.ts
+++ b/e2e/tests/start_call.spec.ts
@@ -9,7 +9,6 @@ declare global {
     interface Window {
         callsClient: any,
         desktop: any,
-        desktopCapturer: any,
     }
 }
 
@@ -70,16 +69,21 @@ test.describe('desktop', () => {
         const sourceURI = `data:image/png;base64,${data}`;
         await page.evaluate((thumbnailURL) => {
             window.desktop = {version: '5.1.0'};
-            const desktopCapturer = {
-                getSources: async () => {
-                    return [
+            window.addEventListener('message', (event) => {
+                if (event.data.type !== 'get-desktop-sources') {
+                    return;
+                }
+
+                window.postMessage({
+                    type: 'desktop-sources-result',
+                    data: [
                         {id: '1', name: 'source_1', thumbnailURL},
                         {id: '2', name: 'source_2', thumbnailURL},
                         {id: '3', name: 'source_3', thumbnailURL},
-                    ];
+                    ],
                 },
-            };
-            window.desktopCapturer = desktopCapturer;
+                window.location.origin);
+            });
         }, sourceURI);
 
         const devPage = new PlaywrightDevPage(page);

--- a/webapp/src/components/screen_source_modal/component.tsx
+++ b/webapp/src/components/screen_source_modal/component.tsx
@@ -189,7 +189,7 @@ export default class ScreenSourceModal extends React.PureComponent<Props, State>
         }
     }
 
-    handleDesktopCapturerMessage = (event) => {
+    handleDesktopCapturerMessage = (event: MessageEvent) => {
         if (event.data.type !== 'desktop-sources-result') {
             return;
         }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -544,7 +544,6 @@ declare global {
         webkitAudioContext: AudioContext,
         basename: string,
         desktop: any,
-        desktopCapturer: any,
     }
 
     interface HTMLVideoElement {


### PR DESCRIPTION
#### Summary
`desktopCapturer.getSources` has been deprecated for use in the renderer process in Electron v17: https://www.electronjs.org/docs/latest/breaking-changes#removed-desktopcapturergetsources-in-the-renderer 

So as part of the upgrade, we need to remove the use of the library in Calls and just pass a message up through the preload script like we do for notifications.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42086

