### PR TITLE
[MM-42419] Implement channel link in call widget

### DIFF
--- a/webapp/src/components/call_widget/component.scss
+++ b/webapp/src/components/call_widget/component.scss
@@ -87,3 +87,48 @@
   white-space: pre;
   margin-top: 4px;
 }
+
+a.calls-channel-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  color: rgba(var(--center-channel-color-rgb), 0.64);
+  padding: 0px 4px;
+  text-decoration: none;
+
+  i {
+    &::before {
+      color: rgba(var(--center-channel-color-rgb), 0.56);
+    }
+  }
+
+  &:visited {
+    color: rgba(var(--center-channel-color-rgb), 0.64);
+    text-decoration: none;
+  }
+
+  &:hover {
+    color: rgba(var(--center-channel-color-rgb), 0.72);
+    background: rgba(var(--center-channel-color-rgb), 0.08);
+    text-decoration: none;
+
+    i {
+      &::before {
+        color: rgba(var(--center-channel-color-rgb), 0.72);
+      }
+    }
+  }
+
+  &:active {
+    color: rgb(var(--button-bg-rgb));
+    background: rgba(var(--button-bg-rgb), 0.08);
+    text-decoration: none;
+
+    i {
+      &::before {
+        color: rgb(var(--button-bg-rgb));
+      }
+    }
+  }
+}

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -86,6 +86,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             display: 'flex',
             bottom: '12px',
             left: '12px',
+            lineHeight: '16px',
             zIndex: '1000',
             border: `1px solid ${changeOpacity(this.props.theme.centerChannelColor, 0.3)}`,
             userSelect: 'none',
@@ -144,7 +145,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         callInfo: {
             display: 'flex',
             fontSize: '11px',
-            opacity: '0.64',
+            color: changeOpacity(this.props.theme.centerChannelColor, 0.64),
         },
         profiles: {
             display: 'flex',
@@ -1022,21 +1023,33 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         }
     }
 
+    onChannelLinkClick = (ev: React.MouseEvent<HTMLElement>) => {
+        ev.preventDefault();
+        window.postMessage({type: 'browser-history-push-return', message: {pathName: this.props.channelURL}}, window.origin);
+    }
+
     renderChannelName = (hasTeamSidebar: boolean) => {
         return (
             <React.Fragment>
                 <div style={{margin: '0 2px 0 4px'}}>{'•'}</div>
-                {isPublicChannel(this.props.channel) ? <CompassIcon icon='globe'/> : <CompassIcon icon='lock'/>}
-                <span
-                    style={{
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        maxWidth: hasTeamSidebar ? '24ch' : '14ch',
-                    }}
+
+                <a
+                    href={this.props.channelURL}
+                    onClick={this.onChannelLinkClick}
+                    className='calls-channel-link'
                 >
-                    {this.props.channel.display_name}
-                </span>
+                    {isPublicChannel(this.props.channel) ? <CompassIcon icon='globe'/> : <CompassIcon icon='lock'/>}
+                    <span
+                        style={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            maxWidth: hasTeamSidebar ? '24ch' : '14ch',
+                        }}
+                    >
+                        {this.props.channel.display_name}
+                    </span>
+                </a>
             </React.Fragment>
         );
     }


### PR DESCRIPTION
#### Summary

PR implements the channel link in call widget. Upon clicking the channel is switched without causing a reload. It will also work if currently focusing a different product (on browser that is). I've tested on Desktop App as well and working as expected.

https://user-images.githubusercontent.com/1832946/157699676-3b5df2df-2d24-415a-b49c-02b44f82e8b5.mp4


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42419
