### PR TITLE
[MM-42457] Update default STUN server

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -39,7 +39,7 @@
           "display_name": "ICE Servers",
           "type": "text",
           "help_text": "A comma separated list of ICE servers URLs (STUN/TURN) to use.",
-          "default": "stun:stun.l.google.com:19302,stun:global.stun.twilio.com:3478",
+          "default": "stun:stun.global.calls.mattermost.com:3478",
           "placeholder": "stun:example.com:3478"
         },
         {


### PR DESCRIPTION
#### Summary

No more 3rd parties! Updating the default STUN server URL to our very own, Mattermost hosted one.

Huge thanks to @DSchalla for making this happen :raised_hands: 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42457

