### PR TITLE
[MM-42433] Fix: Calls mobile: microphone state gets reset when app switching

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -155,10 +155,12 @@ func (p *Plugin) handleGetAllChannels(w http.ResponseWriter, r *http.Request) {
 				Enabled:   state.Enabled,
 			}
 			if state.Call != nil {
+				users, states := state.Call.getUsersAndStates()
 				info.Call = &Call{
 					ID:              state.Call.ID,
 					StartAt:         state.Call.StartAt,
-					Users:           state.Call.getUsers(),
+					Users:           users,
+					States:          states,
 					ThreadID:        state.Call.ThreadID,
 					ScreenSharingID: state.Call.ScreenSharingID,
 				}

--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -43,16 +43,6 @@ func (cs *callState) getUsersAndStates() ([]string, []userState) {
 	return users, states
 }
 
-func (cs *callState) getUsers() []string {
-	var i int
-	users := make([]string, len(cs.Users))
-	for id := range cs.Users {
-		users[i] = id
-		i++
-	}
-	return users
-}
-
 func (p *Plugin) kvGetChannelState(channelID string) (*channelState, error) {
 	p.metrics.StoreOpCounters.With(prometheus.Labels{"type": "KVGet"}).Inc()
 	data, appErr := p.API.KVGet(channelID)


### PR DESCRIPTION
#### Summary
- Turns out this was caused by forgetting to send over the state for each user in the GET `/channels` route 😄 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-42433

