### PR TITLE
Remove object logging

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -455,7 +455,6 @@ export default class Plugin {
                 if (resp.data.enabled && connectedChannelID(store.getState()) !== channelID) {
                     this.registerChannelHeaderMenuButton();
                 }
-                console.log(resp.data);
                 store.dispatch({
                     type: resp.data.enabled ? VOICE_CHANNEL_ENABLE : VOICE_CHANNEL_DISABLE,
                 });


### PR DESCRIPTION
#### Summary
Every now and then I see an object being logged without any context. Looks like it might be some debugging that was left and never removed.

Disregard this if it is actually still being used, although on that case I'd suggest to add some context to the log.
