### PR TITLE
[MM-42590] Allow sending audio track along with screensharing

### DIFF
--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -17,12 +17,14 @@ type callStats struct {
 }
 
 type callState struct {
-	ID              string                `json:"id"`
-	StartAt         int64                 `json:"create_at"`
-	Users           map[string]*userState `json:"users,omitempty"`
-	ThreadID        string                `json:"thread_id"`
-	ScreenSharingID string                `json:"screen_sharing_id"`
-	Stats           callStats             `json:"stats"`
+	ID                 string                `json:"id"`
+	StartAt            int64                 `json:"create_at"`
+	Users              map[string]*userState `json:"users,omitempty"`
+	ThreadID           string                `json:"thread_id"`
+	ScreenSharingID    string                `json:"screen_sharing_id"`
+	ScreenTrackID      string                `json:"screen_track_id"`
+	ScreenAudioTrackID string                `json:"screen_audio_track_id"`
+	Stats              callStats             `json:"stats"`
 }
 
 type channelState struct {

--- a/server/session.go
+++ b/server/session.go
@@ -34,6 +34,7 @@ type session struct {
 	outVoiceTrack        *webrtc.TrackLocalStaticRTP
 	outVoiceTrackEnabled bool
 	outScreenTrack       *webrtc.TrackLocalStaticRTP
+	outScreenAudioTrack  *webrtc.TrackLocalStaticRTP
 	remoteScreenTrack    *webrtc.TrackRemote
 	rtcConn              *webrtc.PeerConnection
 	tracksCh             chan *webrtc.TrackLocalStaticRTP
@@ -120,6 +121,8 @@ func (p *Plugin) removeUserSession(userID, channelID string) (channelState, chan
 
 		if state.Call.ScreenSharingID == userID {
 			state.Call.ScreenSharingID = ""
+			state.Call.ScreenTrackID = ""
+			state.Call.ScreenAudioTrackID = ""
 			if call := p.getCall(channelID); call != nil {
 				call.setScreenSession(nil)
 			}

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -24,7 +24,10 @@ func getAutocompleteData() *model.AutocompleteData {
 	data.AddCommand(model.NewAutocompleteData(joinCommandTrigger, "", "Joins or starts a call in the current channel"))
 	data.AddCommand(model.NewAutocompleteData(leaveCommandTrigger, "", "Leaves a call in the current channel"))
 	data.AddCommand(model.NewAutocompleteData(linkCommandTrigger, "", "Generates a link to join a call in the current channel"))
-	data.AddCommand(model.NewAutocompleteData(experimentalCommandTrigger, "", "Turns on/off experimental features"))
+
+	experimentalCmdData := model.NewAutocompleteData(experimentalCommandTrigger, "", "Turns on/off experimental features")
+	experimentalCmdData.AddTextArgument("Available options: on, off", "", "on|off")
+	data.AddCommand(experimentalCmdData)
 	return data
 }
 

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -10,7 +10,7 @@ import {IDMappedObjects} from 'mattermost-redux/types/utilities';
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
 
 import {UserState} from 'src/types/types';
-import {getUserDisplayName, isPublicChannel, isPrivateChannel, isDMChannel, isGMChannel} from 'src/utils';
+import {getUserDisplayName, isPublicChannel, isPrivateChannel, isDMChannel, isGMChannel, hasExperimentalFlag} from 'src/utils';
 
 import Avatar from '../avatar/avatar';
 import {pluginId} from '../../manifest';
@@ -366,7 +366,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             if (window.desktop && compareSemVer(window.desktop.version, '5.1.0') >= 0) {
                 this.props.showScreenSourceModal();
             } else {
-                const stream = await window.callsClient.shareScreen();
+                const stream = await window.callsClient.shareScreen('', hasExperimentalFlag());
                 state.screenStream = stream;
             }
         }

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -6,7 +6,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {UserProfile} from 'mattermost-redux/types/users';
 import {Channel} from 'mattermost-redux/types/channels';
 
-import {getUserDisplayName, getScreenStream, isDMChannel} from 'src/utils';
+import {getUserDisplayName, getScreenStream, isDMChannel, hasExperimentalFlag} from 'src/utils';
 import {UserState} from 'src/types/types';
 
 import Avatar from '../avatar/avatar';
@@ -102,7 +102,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             if (window.desktop && compareSemVer(window.desktop.version, '5.1.0') >= 0) {
                 this.props.showScreenSourceModal();
             } else {
-                const stream = await getScreenStream();
+                const stream = await getScreenStream('', hasExperimentalFlag());
                 if (window.opener && stream) {
                     window.screenSharingTrackId = stream.getVideoTracks()[0].id;
                 }

--- a/webapp/src/components/screen_source_modal/component.tsx
+++ b/webapp/src/components/screen_source_modal/component.tsx
@@ -6,6 +6,8 @@ import {Channel} from 'mattermost-redux/types/channels';
 
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
 
+import {hasExperimentalFlag} from '../../utils';
+
 import CompassIcon from '../../components/icons/compassIcon';
 
 import './component.scss';
@@ -152,7 +154,7 @@ export default class ScreenSourceModal extends React.PureComponent<Props, State>
     }
 
     private shareScreen = () => {
-        window.callsClient.shareScreen(this.state.selected);
+        window.callsClient.shareScreen(this.state.selected, hasExperimentalFlag());
         this.hide();
     }
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -190,7 +190,7 @@ export function stateSortProfiles(profiles: UserProfile[], statuses: {[key: stri
     };
 }
 
-export async function getScreenStream(sourceID?: string): Promise<MediaStream|null> {
+export async function getScreenStream(sourceID?: string, withAudio?: boolean): Promise<MediaStream|null> {
     let screenStream: MediaStream|null = null;
 
     if (window.desktop) {
@@ -203,10 +203,10 @@ export async function getScreenStream(sourceID?: string): Promise<MediaStream|nu
                 options.chromeMediaSourceId = sourceID;
             }
             screenStream = await navigator.mediaDevices.getUserMedia({
-                audio: false,
                 video: {
                     mandatory: options,
                 } as any,
+                audio: withAudio ? {mandatory: options} as any : false,
             });
         } catch (err) {
             console.log(err);
@@ -217,7 +217,7 @@ export async function getScreenStream(sourceID?: string): Promise<MediaStream|nu
         try {
             screenStream = await navigator.mediaDevices.getDisplayMedia({
                 video: true,
-                audio: false,
+                audio: Boolean(withAudio),
             });
         } catch (err) {
             console.log(err);


### PR DESCRIPTION
#### Summary

PR adds support for sending an audio track when screensharing. Turned out to be slightly more involved than anticipated due to this new track potentially conflicting with pre-existing voice tracks. We are now making the client send track ids so we can be certain of what's coming server side which makes it easy to handle everything properly.

This feature is only active if experimental features are enabled client-side. It also comes with some browser/platform limitations:

- Sharing audio only works on Chrome based browsers (no Firefox, no Safari) and only if sharing a tab, in which case only the audio from that tab is shared.
- Global system audio only works in Windows when sharing the whole screen. This applies to the Desktop App as well.

More details about audio support when screensharing can be found at https://caniuse.com/mdn-api_mediadevices_getdisplaymedia_audio_capture_support

@cpoile I haven't tested yet how this affects mobile. I am thinking it should work out of the box given we are just sending an additional audio track but please let me know if you encounter issues on that side.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42590