### PR TITLE
Fix setting pop-out window title

### DIFF
--- a/e2e/tests/popout.spec.ts
+++ b/e2e/tests/popout.spec.ts
@@ -25,7 +25,7 @@ test.describe('popout window', () => {
         await devPage.leaveCall();
     });
 
-    test.only('window title matches', async ({page, context}) => {
+    test('window title matches', async ({page, context}) => {
         const devPage = new PlaywrightDevPage(page);
         await devPage.goto();
         await devPage.startCall();

--- a/e2e/tests/popout.spec.ts
+++ b/e2e/tests/popout.spec.ts
@@ -25,7 +25,7 @@ test.describe('popout window', () => {
         await devPage.leaveCall();
     });
 
-    test('window title matches', async ({page, context}) => {
+    test.only('window title matches', async ({page, context}) => {
         const devPage = new PlaywrightDevPage(page);
         await devPage.goto();
         await devPage.startCall();
@@ -37,6 +37,7 @@ test.describe('popout window', () => {
         await expect(popOut.locator('#calls-expanded-view')).toBeVisible();
         const idx = parseInt(process.env.TEST_PARALLEL_INDEX as string, 10) * 2;
         await expect(popOut).toHaveTitle(`Call - calls${idx}`);
+        await expect(page).not.toHaveTitle(`Call - calls${idx}`);
 
         await devPage.leaveCall();
     });

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -130,12 +130,13 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
     }
 
     public componentDidUpdate(prevProps: Props, prevState: State) {
-        if (document.title.indexOf('Call') === -1 && this.props.channel) {
-            console.log('missing title');
-            if (isDMChannel(this.props.channel) && this.props.connectedDMUser) {
-                document.title = `Call - ${getUserDisplayName(this.props.connectedDMUser)}`;
-            } else if (!isDMChannel(this.props.channel)) {
-                document.title = `Call - ${this.props.channel.display_name}`;
+        if (window.opener) {
+            if (document.title.indexOf('Call') === -1 && this.props.channel) {
+                if (isDMChannel(this.props.channel) && this.props.connectedDMUser) {
+                    document.title = `Call - ${getUserDisplayName(this.props.connectedDMUser)}`;
+                } else if (!isDMChannel(this.props.channel)) {
+                    document.title = `Call - ${this.props.channel.display_name}`;
+                }
             }
         }
 


### PR DESCRIPTION
#### Summary

Small bug: we were also setting the parent window's title due to the component being loaded there as well. Added a check to avoid this from happening and updated the e2e test.

