### PR TITLE
[MM-42497] Implement audio ouputs selection

### DIFF
--- a/e2e/tests/start_call.spec.ts
+++ b/e2e/tests/start_call.spec.ts
@@ -157,10 +157,10 @@ test.describe('setting audio input device', () => {
         await devPage.startCall();
         await devPage.wait(1000);
 
-        const currentAudioDevice = await page.evaluate(() => {
-            return window.callsClient.currentAudioDevice?.deviceId;
+        const currentAudioInputDevice = await page.evaluate(() => {
+            return window.callsClient.currentAudioInputDevice?.deviceId;
         });
-        if (currentAudioDevice) {
+        if (currentAudioInputDevice) {
             test.fail();
             return;
         }
@@ -178,10 +178,10 @@ test.describe('setting audio input device', () => {
         await page.locator('#calls-widget-audio-input-button').click();
         await expect(page.locator('#calls-widget-audio-inputs-menu')).toBeVisible();
 
-        let currentAudioDevice = await page.evaluate(() => {
-            return window.callsClient.currentAudioDevice?.deviceId;
+        let currentAudioInputDevice = await page.evaluate(() => {
+            return window.callsClient.currentInputAudioDevice?.deviceId;
         });
-        if (currentAudioDevice) {
+        if (currentAudioInputDevice) {
             test.fail();
             return;
         }
@@ -189,10 +189,10 @@ test.describe('setting audio input device', () => {
         await page.locator('#calls-widget-audio-inputs-menu button:has-text("Fake Audio Input 1")').click();
         await expect(page.locator('#calls-widget-audio-inputs-menu')).toBeHidden();
 
-        currentAudioDevice = await page.evaluate(() => {
-            return window.callsClient.currentAudioDevice?.deviceId;
+        currentAudioInputDevice = await page.evaluate(() => {
+            return window.callsClient.currentAudioInputDevice?.deviceId;
         });
-        if (!currentAudioDevice) {
+        if (!currentAudioInputDevice) {
             test.fail();
             return;
         }
@@ -202,10 +202,10 @@ test.describe('setting audio input device', () => {
         await devPage.startCall();
         await devPage.wait(1000);
 
-        const currentAudioDevice2 = await page.evaluate(() => {
-            return window.callsClient.currentAudioDevice?.deviceId;
+        const currentAudioInputDevice2 = await page.evaluate(() => {
+            return window.callsClient.currentAudioInputDevice?.deviceId;
         });
-        if (currentAudioDevice2 !== currentAudioDevice) {
+        if (currentAudioInputDevice2 !== currentAudioInputDevice) {
             test.fail();
             return;
         }
@@ -222,3 +222,75 @@ test.describe('setting audio input device', () => {
     });
 });
 
+test.describe('setting audio output device', () => {
+    test.use({storageState: userState.users[0].storageStatePath});
+
+    test('no default', async ({page}) => {
+        const devPage = new PlaywrightDevPage(page);
+        await devPage.startCall();
+        await devPage.wait(1000);
+
+        const currentAudioOutputDevice = await page.evaluate(() => {
+            return window.callsClient.currentAudioOutputDevice?.deviceId;
+        });
+        if (currentAudioOutputDevice) {
+            test.fail();
+            return;
+        }
+
+        await devPage.leaveCall();
+    });
+
+    test.only('setting default', async ({page}) => {
+        const devPage = new PlaywrightDevPage(page);
+        await devPage.startCall();
+        await devPage.wait(1000);
+
+        await page.locator('#calls-widget-toggle-menu-button').click();
+        await expect(page.locator('#calls-widget-audio-output-button')).toBeVisible();
+        await page.locator('#calls-widget-audio-output-button').click();
+        await expect(page.locator('#calls-widget-audio-outputs-menu')).toBeVisible();
+
+        let currentAudioOutputDevice = await page.evaluate(() => {
+            return window.callsClient.currentAudioOutputDevice?.deviceId;
+        });
+        if (currentAudioOutputDevice) {
+            test.fail();
+            return;
+        }
+
+        await page.locator('#calls-widget-audio-outputs-menu button:has-text("Fake Audio Output 1")').click();
+        await expect(page.locator('#calls-widget-audio-outputs-menu')).toBeHidden();
+
+        currentAudioOutputDevice = await page.evaluate(() => {
+            return window.callsClient.currentAudioOutputDevice?.deviceId;
+        });
+        if (!currentAudioOutputDevice) {
+            test.fail();
+            return;
+        }
+
+        await devPage.leaveCall();
+
+        await devPage.startCall();
+        await devPage.wait(1000);
+
+        const currentAudioOutputDevice2 = await page.evaluate(() => {
+            return window.callsClient.currentAudioOutputDevice?.deviceId;
+        });
+        if (currentAudioOutputDevice2 !== currentAudioOutputDevice) {
+            test.fail();
+            return;
+        }
+
+        await devPage.leaveCall();
+
+        await page.reload();
+        const deviceID = await page.evaluate(() => {
+            return window.localStorage.getItem('calls_default_audio_output');
+        });
+        if (!deviceID) {
+            test.fail();
+        }
+    });
+});

--- a/webapp/src/components/icons/speaker_icon.tsx
+++ b/webapp/src/components/icons/speaker_icon.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {CSSProperties} from 'react';
+
+type Props = {
+    className?: string,
+    fill?: string,
+    style?: CSSProperties,
+}
+
+export default function SpeakerIcon(props: Props) {
+    return (
+        <svg
+            {...props}
+            width='24px'
+            height='24px'
+            viewBox='0 0 24 24'
+            role='img'
+        >
+            <path d='M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z'/>
+        </svg>
+    );
+}
+


### PR DESCRIPTION
#### Summary

PR implements a new menu to select audio output devices. 

Again this is not something universally supported as the underlying API call [`HTMLMediaElement.setSinkId`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId) is considered experimental.

- Chrome based browsers will support it natively, which also means Desktop App is covered
- On Firefox it needs to be enabled through a flag, more info at https://caniuse.com/mdn-api_htmlmediaelement_setsinkid
- No support on Safari

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42497

#### Screenshot

![image](https://user-images.githubusercontent.com/1832946/158867721-9ca7c884-8c33-45c0-b205-fc1047f8c815.png)

