### PR TITLE
[MM-42498] Disable STUN if ICE host override is set

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -78,10 +78,13 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
-	hostIP, err := getPublicIP(udpServerConn, cfg.ICEServers)
-	if err != nil {
-		p.LogError(err.Error())
-		return err
+	publicHost := cfg.ICEHostOverride
+	if publicHost == "" {
+		publicHost, err = getPublicIP(udpServerConn, cfg.ICEServers)
+		if err != nil {
+			p.LogError(err.Error())
+			return err
+		}
 	}
 
 	udpServerMux := webrtc.NewICEUDPMux(nil, udpServerConn)
@@ -90,10 +93,10 @@ func (p *Plugin) OnActivate() error {
 	p.nodeID = status.ClusterId
 	p.udpServerMux = udpServerMux
 	p.udpServerConn = udpServerConn
-	p.hostIP = hostIP
+	p.hostIP = publicHost
 	p.mut.Unlock()
 
-	p.LogDebug("activate", "ClusterID", status.ClusterId, "HostIP", hostIP)
+	p.LogDebug("activate", "ClusterID", status.ClusterId, "PublicHost", publicHost)
 
 	go p.clusterEventsHandler()
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -125,10 +125,6 @@ func (c *configuration) IsValid() error {
 		return fmt.Errorf("UDPServerPort is not valid: %d is not in allowed range [1024, 49151]", *c.UDPServerPort)
 	}
 
-	if len(c.ICEServers) == 0 {
-		return fmt.Errorf("ICEServers cannot be empty")
-	}
-
 	return nil
 }
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -63,7 +63,7 @@ func getPublicIP(conn net.PacketConn, iceServers []string) (string, error) {
 		}
 	}
 	if stunURL == "" {
-		return "", fmt.Errorf("No STUN server URL was found")
+		return "", fmt.Errorf("no STUN server URL was found")
 	}
 	serverURL := stunURL[strings.Index(stunURL, ":")+1:]
 	serverAddr, err := net.ResolveUDPAddr("udp", serverURL)


### PR DESCRIPTION
#### Summary

A few more beta customers are hitting this as server side STUN requires an additional outgoing UDP port to be open.
PR disables server side STUN requests if the ICE host override is set. It also allows to set empty `ICEServers` which means disabling it on client side as well.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42498
