### PR TITLE
[MM-42737] Fix screen-sharing on Firefox

### DIFF
--- a/server/sfu.go
+++ b/server/sfu.go
@@ -355,6 +355,7 @@ func (p *Plugin) initRTCConn(userID string) {
 		p.LogDebug(fmt.Sprintf("Track has started, of type %d: %s", remoteTrack.PayloadType(), remoteTrack.Codec().MimeType))
 
 		trackID := remoteTrack.ID()
+		streamID := remoteTrack.StreamID()
 		state, err := p.kvGetChannelState(userSession.channelID)
 		if err != nil {
 			p.LogError(err.Error())
@@ -432,12 +433,12 @@ func (p *Plugin) initRTCConn(userID string) {
 
 			}
 		} else if remoteTrack.Codec().MimeType == rtpVideoCodecVP8.MimeType {
-			if trackID == "" || trackID != state.Call.ScreenTrackID {
-				p.LogError("received unexpected video track", "trackID", trackID)
+			if trackID != state.Call.ScreenTrackID && streamID != state.Call.ScreenTrackID {
+				p.LogError("received unexpected video track", "trackID", trackID, "streamID", streamID)
 				return
 			}
 
-			p.LogDebug("received screen sharing track")
+			p.LogDebug("received screen sharing track", "trackID", trackID, "streamID", streamID)
 			call := p.getCall(userSession.channelID)
 			if call == nil {
 				p.LogError("call should not be nil")

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -7,7 +7,7 @@ import {deflate} from 'pako/lib/deflate.js';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {getPluginWSConnectionURL, getScreenStream, getPluginPath, setSDPMaxVideoBW} from './utils';
+import {getPluginWSConnectionURL, getScreenStream, getPluginPath, setSDPMaxVideoBW, isFirefox} from './utils';
 
 import WebSocketClient from './websocket';
 import VoiceActivityDetector from './vad';
@@ -416,10 +416,9 @@ export default class CallsClient extends EventEmitter {
         };
 
         this.peer.addStream(screenStream);
-
         this.ws.send('screen_on', {
             data: JSON.stringify({
-                screenTrackID: screenTrack.id,
+                screenTrackID: isFirefox() ? screenStream.id : screenTrack.id,
                 screenAudioTrackID: screenAudioTrack?.id,
             }),
         });

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -288,3 +288,7 @@ export function setSDPMaxVideoBW(sdp: string, bandwidth: number) {
 export function hasExperimentalFlag() {
     return window.localStorage.getItem('calls_experimental_features') === 'on';
 }
+
+export function isFirefox() {
+    return navigator.userAgent.indexOf('Firefox') >= 0;
+}


### PR DESCRIPTION
#### Summary

Unfortunately https://github.com/mattermost/mattermost-plugin-calls/pull/32 introduced a regression that prevented screen-sharing from working on Firefox as the original track id is not sent over WebRTC but the stream id is sent instead (don't ask me why). Adding a browser specific check for now and compare on both ids server side until we find a better way, assuming there's one.

@cpoile I'll go ahead an include this in community build to restore functionality but feel free to review this at your convenience. We should cut a new plugin release as soon as this is merged.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42737
