### PR TITLE
[MM-42737] Use stream ids instead of track ids

### DIFF
--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -17,14 +17,13 @@ type callStats struct {
 }
 
 type callState struct {
-	ID                 string                `json:"id"`
-	StartAt            int64                 `json:"create_at"`
-	Users              map[string]*userState `json:"users,omitempty"`
-	ThreadID           string                `json:"thread_id"`
-	ScreenSharingID    string                `json:"screen_sharing_id"`
-	ScreenTrackID      string                `json:"screen_track_id"`
-	ScreenAudioTrackID string                `json:"screen_audio_track_id"`
-	Stats              callStats             `json:"stats"`
+	ID              string                `json:"id"`
+	StartAt         int64                 `json:"create_at"`
+	Users           map[string]*userState `json:"users,omitempty"`
+	ThreadID        string                `json:"thread_id"`
+	ScreenSharingID string                `json:"screen_sharing_id"`
+	ScreenStreamID  string                `json:"screen_stream_id"`
+	Stats           callStats             `json:"stats"`
 }
 
 type channelState struct {

--- a/server/session.go
+++ b/server/session.go
@@ -121,8 +121,7 @@ func (p *Plugin) removeUserSession(userID, channelID string) (channelState, chan
 
 		if state.Call.ScreenSharingID == userID {
 			state.Call.ScreenSharingID = ""
-			state.Call.ScreenTrackID = ""
-			state.Call.ScreenAudioTrackID = ""
+			state.Call.ScreenStreamID = ""
 			if call := p.getCall(channelID); call != nil {
 				call.setScreenSession(nil)
 			}

--- a/server/sfu.go
+++ b/server/sfu.go
@@ -354,7 +354,7 @@ func (p *Plugin) initRTCConn(userID string) {
 		p.LogDebug(fmt.Sprintf("%+v", remoteTrack.Codec().RTPCodecCapability))
 		p.LogDebug(fmt.Sprintf("Track has started, of type %d: %s", remoteTrack.PayloadType(), remoteTrack.Codec().MimeType))
 
-		trackID := remoteTrack.ID()
+		streamID := remoteTrack.StreamID()
 		state, err := p.kvGetChannelState(userSession.channelID)
 		if err != nil {
 			p.LogError(err.Error())
@@ -367,7 +367,7 @@ func (p *Plugin) initRTCConn(userID string) {
 
 		if remoteTrack.Codec().MimeType == rtpAudioCodec.MimeType {
 			trackType := "voice"
-			if trackID != "" && trackID == state.Call.ScreenAudioTrackID {
+			if streamID == state.Call.ScreenStreamID {
 				p.LogDebug("received screen sharing audio track")
 				trackType = "screen-audio"
 			}
@@ -432,8 +432,8 @@ func (p *Plugin) initRTCConn(userID string) {
 
 			}
 		} else if remoteTrack.Codec().MimeType == rtpVideoCodecVP8.MimeType {
-			if trackID == "" || trackID != state.Call.ScreenTrackID {
-				p.LogError("received unexpected video track", "trackID", trackID)
+			if streamID != state.Call.ScreenStreamID {
+				p.LogError("received unexpected video track", "streamID", streamID, "ScreenStreamID", state.Call.ScreenStreamID)
 				return
 			}
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -51,15 +51,13 @@ func (p *Plugin) handleClientMessageTypeScreen(msg clientMessage, channelID, use
 				return nil, fmt.Errorf("cannot start screen sharing, someone else is sharing already: %q", state.Call.ScreenSharingID)
 			}
 			state.Call.ScreenSharingID = userID
-			state.Call.ScreenTrackID = data["screenTrackID"]
-			state.Call.ScreenAudioTrackID = data["screenAudioTrackID"]
+			state.Call.ScreenStreamID = data["screenStreamID"]
 		} else {
 			if state.Call.ScreenSharingID != userID {
 				return nil, fmt.Errorf("cannot stop screen sharing, someone else is sharing already: %q", state.Call.ScreenSharingID)
 			}
 			state.Call.ScreenSharingID = ""
-			state.Call.ScreenTrackID = ""
-			state.Call.ScreenAudioTrackID = ""
+			state.Call.ScreenStreamID = ""
 			if call := p.getCall(channelID); call != nil {
 				call.setScreenSession(nil)
 			}

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -419,8 +419,7 @@ export default class CallsClient extends EventEmitter {
 
         this.ws.send('screen_on', {
             data: JSON.stringify({
-                screenTrackID: screenTrack.id,
-                screenAudioTrackID: screenAudioTrack?.id,
+                screenStreamID: screenStream.id,
             }),
         });
     }


### PR DESCRIPTION
#### Summary

 After some debugging (thanks @cpoile :raised_hands: ) and [knowledge gathering](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTrack) I figured out that relying on local track ids was a **dangerous** move as they are not passed consistently. Stream IDs instead seem to be the way to go, so going with those this time around. 

This solution does also remove the annoying browser specific check. The moral of the story is: I should have listened to Firefox when it told me something was clearly wrong with my intended logic. 

Oh, and this is mostly why R&D call failed so emphatically.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42737

