### PR TITLE
[MM-42574] Single handler mode

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -140,7 +140,7 @@ func (p *Plugin) handleGetAllChannels(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, channelID := range channelIDs {
-			if !p.hasPermissionToChannel(channelMembers[channelID], model.PermissionReadChannel) {
+			if len(channelID) != 26 || !p.hasPermissionToChannel(channelMembers[channelID], model.PermissionReadChannel) {
 				continue
 			}
 

--- a/server/call.go
+++ b/server/call.go
@@ -23,6 +23,15 @@ func (c *call) getScreenSession() *session {
 	return c.screenSession
 }
 
+func (c *call) getScreenSessionID() string {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	if c.screenSession == nil {
+		return ""
+	}
+	return c.screenSession.userID
+}
+
 func (c *call) setScreenSession(s *session) {
 	c.mut.Lock()
 	defer c.mut.Unlock()

--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -93,6 +93,21 @@ func (p *Plugin) cleanUpState() error {
 			break
 		}
 		for _, k := range keys {
+			if k == handlerKey {
+				handlerID, err := p.getHandlerID()
+				if err != nil {
+					p.LogError(err.Error())
+					continue
+				}
+
+				if p.nodeID == handlerID {
+					if appErr = p.API.KVDelete(k); appErr != nil {
+						p.LogError(err.Error())
+					}
+				}
+				continue
+			}
+
 			if err := p.kvSetAtomicChannelState(k, func(state *channelState) (*channelState, error) {
 				if state == nil {
 					return nil, nil

--- a/server/cluster_message.go
+++ b/server/cluster_message.go
@@ -23,6 +23,7 @@ const (
 	clusterMessageTypeDisconnect clusterMessageType = "disconnect"
 	clusterMessageTypeSignaling  clusterMessageType = "signaling"
 	clusterMessageTypeUserState  clusterMessageType = "user_state"
+	clusterMessageTypeCallEnded  clusterMessageType = "call_ended"
 )
 
 func (m *clusterMessage) ToJSON() ([]byte, error) {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -50,6 +50,9 @@ func (is *ICEServers) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
+	if unquoted == "" {
+		return nil
+	}
 	*is = strings.Split(strings.TrimSpace(unquoted), ",")
 	return nil
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -14,6 +14,26 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	handlerKey              = "handler"
+	handlerKeyCheckInterval = 5 * time.Second
+)
+
+func (p *Plugin) getHandlerID() (string, error) {
+	data, appErr := p.API.KVGet(handlerKey)
+	if appErr != nil {
+		return "", fmt.Errorf("failed to get handler id: %w", appErr)
+	}
+	return string(data), nil
+}
+
+func (p *Plugin) setHandlerID(nodeID string) error {
+	if appErr := p.API.KVSetWithExpiry(handlerKey, []byte(nodeID), int64(handlerKeyCheckInterval.Seconds()*2)); appErr != nil {
+		return fmt.Errorf("failed to set handler id: %w", appErr)
+	}
+	return nil
+}
+
 func (p *Plugin) kvSetAtomic(key string, cb func(data []byte) ([]byte, error)) error {
 	for {
 		p.metrics.StoreOpCounters.With(prometheus.Labels{"type": "KVGet"}).Inc()

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -158,10 +158,11 @@ export default class CallsClient extends EventEmitter {
                 return;
             }
 
+            const iceServers = config.ICEServers?.length > 0 ? [{urls: config.ICEServers}] : [];
             const peer = new SimplePeer({
                 initiator: true,
                 trickle: true,
-                config: {iceServers: [{urls: config.ICEServers}]},
+                config: {iceServers},
             }) as SimplePeer.Instance;
 
             this.peer = peer;


### PR DESCRIPTION
#### Summary

PR implements a special single handler mode that allows calls to be hosted on a single instance in a HA cluster through the use of the `CALLS_IS_HANDLER=true` environment variable. This is how our community installation has been operating so far. The only relevant addition from the community branch is the extra expiry check which is needed to avoid potential issues with the state getting messed up due to the handler node crashing without cleaning up.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42574
