### PR TITLE
Implement using external `rtcd` service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,14 @@ require (
 )
 
 require (
-	github.com/mattermost/rtcd v0.1.1
+	github.com/mattermost/rtcd v0.2.0
 	github.com/pion/stun v0.3.5
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
 )
 
 require (
+	git.mills.io/prologic/bitcask v1.0.2 // indirect
+	github.com/abcum/lcp v0.0.0-20201209214815-7a3f3840be81 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.3 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
+	github.com/gofrs/flock v0.8.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/go-hclog v1.0.0 // indirect
@@ -69,6 +72,7 @@ require (
 	github.com/pion/turn/v2 v2.0.8 // indirect
 	github.com/pion/udp v0.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/plar/go-adaptive-radix-tree v1.0.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
@@ -87,6 +91,7 @@ require (
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	github.com/yuin/goldmark v1.4.4 // indirect
 	golang.org/x/crypto v0.0.0-20220314234724-5d542ad81a58 // indirect
+	golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+git.mills.io/prologic/bitcask v1.0.2 h1:Iy9x3mVVd1fB+SWY0LTmsSDPGbzMrd7zCZPKbsb/tDA=
 git.mills.io/prologic/bitcask v1.0.2/go.mod h1:ppXpR3haeYrijyJDleAkSGH3p90w6sIHxEA/7UHMxH4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
@@ -121,6 +122,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/RoaringBitmap/roaring v0.9.4/go.mod h1:icnadbWcNyfEHlYdr+tDlOTih1Bf/h+rzPpv4sbomAA=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/abcum/lcp v0.0.0-20201209214815-7a3f3840be81 h1:uHogIJ9bXH75ZYrXnVShHIyywFiUZ7OOabwd9Sfd8rw=
 github.com/abcum/lcp v0.0.0-20201209214815-7a3f3840be81/go.mod h1:6ZvnjTZX1LNo1oLpfaJK8h+MXqHxcBFBIwkgsv+xlv0=
 github.com/advancedlogic/GoOse v0.0.0-20191112112754-e742535969c1/go.mod h1:f3HCSN1fBWjcpGtXyM119MJgeQl838v6so/PQOqvE1w=
 github.com/advancedlogic/GoOse v0.0.0-20210820140952-9d5822d4a625/go.mod h1:f3HCSN1fBWjcpGtXyM119MJgeQl838v6so/PQOqvE1w=
@@ -542,6 +544,7 @@ github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblf
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.8.0 h1:MSdYClljsF3PbENUUEx85nkWfJSGfzYI9yEBZOJz6CY=
 github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -654,6 +657,7 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherjs v0.0.0-20211111143520-d0d5ecc1a356 h1:d3wWSjdOuGrMHa8+Tvw3z9EGPzATpzVq1BmGK3+IyeU=
 github.com/gopherjs/gopherjs v0.0.0-20211111143520-d0d5ecc1a356/go.mod h1:cz9oNYuRUWGdHmLF2IodMLkAhcPtXeULvcBNagUrxTI=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
@@ -811,6 +815,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -913,8 +918,8 @@ github.com/mattermost/logr/v2 v2.0.15/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXp
 github.com/mattermost/mattermost-server/v6 v6.4.0 h1:rN1/IFFzG/IosUbMUWk/czwoJJd1DH/l85nJg43sEbA=
 github.com/mattermost/mattermost-server/v6 v6.4.0/go.mod h1:fnig0sw6M1hOHvW6b9EMTbhjMSD0tU9FErQX+gz86rg=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/rtcd v0.1.1 h1:XRxvG47uJycfAkYu9fVBCiUnyTAP73sOUnI0KL4W6m0=
-github.com/mattermost/rtcd v0.1.1/go.mod h1:yNedG1IgFmRfPFBvCiShHC3DtvbRsO9Gv4Z68kvlNvg=
+github.com/mattermost/rtcd v0.2.0 h1:fReX0+eBgByeAgXee2q2RRZRxTcGhNeqYkG0HtekTG8=
+github.com/mattermost/rtcd v0.2.0/go.mod h1:yNedG1IgFmRfPFBvCiShHC3DtvbRsO9Gv4Z68kvlNvg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -1160,6 +1165,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
+github.com/plar/go-adaptive-radix-tree v1.0.4 h1:Ucd8R6RH2E7RW8ZtDKrsWyOD3paG2qqJO0I20WQ8oWQ=
 github.com/plar/go-adaptive-radix-tree v1.0.4/go.mod h1:Ot8d28EII3i7Lv4PSvBlF8ejiD/CtRYDuPsySJbSaK8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -1290,8 +1296,10 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/snowflakedb/gosnowflake v1.6.3/go.mod h1:6hLajn6yxuJ4xUHZegMekpq9rnQbGJ7TMwXjgTmA6lg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -1331,6 +1339,7 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
 github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -1517,6 +1526,7 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200228211341-fcea875c7e85/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925 h1:5XVKs2rlCg8EFyRcvO8/XFwYxh1oKJO1Q3X5vttIf9c=
 golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925/go.mod h1:1phAWC201xIgDyaFpmDeZkgf70Q4Pd/CNqfRtVPtxNw=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/plugin.json
+++ b/plugin.json
@@ -35,6 +35,13 @@
           "placeholder": "8443"
         },
         {
+          "key": "RTCDServiceURL",
+          "display_name": "RTCD Service URL",
+          "type": "text",
+          "help_text": "The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+          "placeholder": "https://clientID:authKey@rtcd.example.com"
+        },
+        {
           "key": "ICEServers",
           "display_name": "ICE Servers",
           "type": "text",

--- a/server/activate.go
+++ b/server/activate.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
+	"net/url"
 	"os"
 	"time"
 
 	"github.com/mattermost/rtcd/logger"
+	rtcd "github.com/mattermost/rtcd/service"
 	"github.com/mattermost/rtcd/service/rtc"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -27,78 +30,113 @@ func (p *Plugin) OnActivate() error {
 		return appErr
 	}
 
-	if os.Getenv("CALLS_IS_HANDLER") != "" {
-		go func() {
-			p.LogInfo("calls handler, setting state", "clusterID", status.ClusterId)
-			if err := p.setHandlerID(status.ClusterId); err != nil {
-				p.LogError(err.Error())
-				return
-			}
-			ticker := time.NewTicker(handlerKeyCheckInterval)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					if err := p.setHandlerID(status.ClusterId); err != nil {
-						p.LogError(err.Error())
-						return
-					}
-				case <-p.stopCh:
-					return
-				}
-			}
-		}()
-	}
-
 	cfg := p.getConfiguration()
 	if err := cfg.IsValid(); err != nil {
 		p.LogError(err.Error())
 		return err
 	}
 
-	var err error
-	publicHost := cfg.ICEHostOverride
-	if publicHost == "" {
-		publicHost, err = getPublicIP(*cfg.UDPServerPort, cfg.ICEServers)
+	if cfg.RTCDServiceURL != "" {
+		u, err := url.Parse(cfg.RTCDServiceURL)
 		if err != nil {
 			p.LogError(err.Error())
 			return err
 		}
+
+		clientID := u.User.Username()
+		authKey, _ := u.User.Password()
+		u.User = nil
+
+		client, err := rtcd.NewClient(rtcd.ClientConfig{
+			URL:      u.String(),
+			ClientID: clientID,
+			AuthKey:  authKey,
+		})
+		if err != nil {
+			err = fmt.Errorf("failed to create rtcd client: %w", err)
+			p.LogError(err.Error())
+			return err
+		}
+		if err := client.Connect(); err != nil {
+			err = fmt.Errorf("failed to connect rtcd client: %w", err)
+			p.LogError(err.Error())
+			return err
+		}
+		p.rtcdClient = client
+		go func() {
+			for err := range p.rtcdClient.ErrorCh() {
+				p.LogError(err.Error())
+			}
+		}()
+	} else {
+		if os.Getenv("CALLS_IS_HANDLER") != "" {
+			go func() {
+				p.LogInfo("calls handler, setting state", "clusterID", status.ClusterId)
+				if err := p.setHandlerID(status.ClusterId); err != nil {
+					p.LogError(err.Error())
+					return
+				}
+				ticker := time.NewTicker(handlerKeyCheckInterval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ticker.C:
+						if err := p.setHandlerID(status.ClusterId); err != nil {
+							p.LogError(err.Error())
+							return
+						}
+					case <-p.stopCh:
+						return
+					}
+				}
+			}()
+		}
+
+		var err error
+		publicHost := cfg.ICEHostOverride
+		if publicHost == "" {
+			publicHost, err = getPublicIP(*cfg.UDPServerPort, cfg.ICEServers)
+			if err != nil {
+				p.LogError(err.Error())
+				return err
+			}
+		}
+
+		log, err := logger.New(logger.Config{
+			EnableConsole: true,
+			ConsoleLevel:  "DEBUG",
+		})
+		if err != nil {
+			p.LogError(err.Error())
+			return err
+		}
+
+		rtcServer, err := rtc.NewServer(rtc.ServerConfig{
+			ICEPortUDP:      *cfg.UDPServerPort,
+			ICEHostOverride: publicHost,
+		}, log, p.metrics.RTCMetrics())
+		if err != nil {
+			p.LogError(err.Error())
+			return err
+		}
+
+		if err := rtcServer.Start(); err != nil {
+			p.LogError(err.Error())
+			return err
+		}
+
+		p.mut.Lock()
+		p.nodeID = status.ClusterId
+		p.rtcServer = rtcServer
+		p.hostIP = publicHost
+		p.log = log
+		p.mut.Unlock()
+
+		go p.clusterEventsHandler()
+
+		p.LogDebug("activate", "ClusterID", status.ClusterId, "publicHost", publicHost)
 	}
 
-	log, err := logger.New(logger.Config{
-		EnableConsole: true,
-		ConsoleLevel:  "DEBUG",
-	})
-	if err != nil {
-		p.LogError(err.Error())
-		return err
-	}
-
-	rtcServer, err := rtc.NewServer(rtc.ServerConfig{
-		ICEPortUDP:      *cfg.UDPServerPort,
-		ICEHostOverride: publicHost,
-	}, log, p.metrics.RTCMetrics())
-	if err != nil {
-		p.LogError(err.Error())
-		return err
-	}
-
-	if err := rtcServer.Start(); err != nil {
-		p.LogError(err.Error())
-		return err
-	}
-
-	p.mut.Lock()
-	p.nodeID = status.ClusterId
-	p.rtcServer = rtcServer
-	p.hostIP = publicHost
-	p.log = log
-	p.mut.Unlock()
-
-	p.LogDebug("activate", "ClusterID", status.ClusterId, "publicHost", publicHost)
-
-	go p.clusterEventsHandler()
 	go p.wsWriter()
 
 	return nil
@@ -108,6 +146,12 @@ func (p *Plugin) OnDeactivate() error {
 	p.LogDebug("deactivate")
 	p.API.PublishWebSocketEvent(wsEventDeactivate, nil, &model.WebsocketBroadcast{})
 	close(p.stopCh)
+
+	if p.rtcdClient != nil {
+		if err := p.rtcdClient.Close(); err != nil {
+			p.LogError(err.Error())
+		}
+	}
 
 	if p.rtcServer != nil {
 		if err := p.rtcServer.Stop(); err != nil {

--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -107,6 +107,10 @@ func (p *Plugin) cleanUpState() error {
 				continue
 			}
 
+			if len(k) < 26 {
+				continue
+			}
+
 			if err := p.kvSetAtomicChannelState(k, func(state *channelState) (*channelState, error) {
 				if state == nil {
 					return nil, nil

--- a/server/session.go
+++ b/server/session.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mattermost/rtcd/service/rtc"
-
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
@@ -17,7 +15,6 @@ type session struct {
 	userID    string
 	channelID string
 	connID    string
-	cfg       rtc.SessionConfig
 
 	// WebSocket
 	signalInCh  chan []byte
@@ -31,15 +28,9 @@ type session struct {
 
 func newUserSession(userID, channelID, connID string) *session {
 	return &session{
-		userID:    userID,
-		channelID: channelID,
-		connID:    connID,
-		cfg: rtc.SessionConfig{
-			GroupID:   "default",
-			UserID:    userID,
-			CallID:    channelID,
-			SessionID: connID,
-		},
+		userID:      userID,
+		channelID:   channelID,
+		connID:      connID,
 		signalInCh:  make(chan []byte, msgChSize),
 		signalOutCh: make(chan []byte, msgChSize),
 		wsMsgCh:     make(chan clientMessage, msgChSize*2),


### PR DESCRIPTION
#### Summary

PR adds the necessary logic to enable running calls through a provided `rtcd` service.
A new `RTCDServiceURL` configuration field is available of the form:

```
https://clientID:authKey@rtcd.example.com
```

When set, the plugin will offload all calls to the external service.

Note that the authentication/authorization flow is still in under review by security so it's very likely subject to breaking changes.
