### PR TITLE
Implement `/call recording` slash command

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -55,6 +55,14 @@
           "type": "bool",
           "help_text": "When set to true, calls will be possible in all channels where they are not explicitly disabled.",
           "default": true
+        },
+        {
+          "key": "AllowedRecordingUsers",
+          "display_name": "Allowed Recording Users",
+          "type": "longtext",
+          "help_text": "A comma separated list of user IDs that should be allowed to run the '/call recording' command",
+          "default": "",
+          "placeholder": ""
         }
         ]
     }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -26,6 +26,10 @@ type configuration struct {
 	ICEHostOverride string
 	// UDP port used by the RTC server to listen to.
 	UDPServerPort *int
+	// A comma separated list of user IDs that should be allowed to run the
+	// "/call recording" command.
+	AllowedRecordingUsers string
+
 	clientConfig
 }
 
@@ -156,6 +160,8 @@ func (c *configuration) Clone() *configuration {
 			cfg.ICEServers[i] = u
 		}
 	}
+
+	cfg.AllowedRecordingUsers = c.AllowedRecordingUsers
 
 	return &cfg
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -28,6 +28,8 @@ const (
 	wsEventUserUnraiseHand  = "user_unraise_hand"
 	wsEventJoin             = "join"
 	wsEventError            = "error"
+	wsEventRecordingStart   = "recording_start"
+	wsEventRecordingStop    = "recording_stop"
 )
 
 func (p *Plugin) handleClientMessageTypeScreen(msg clientMessage, channelID, userID, handlerID string) error {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -294,6 +294,15 @@ export default class Plugin {
                     console.log('experimental features disabled');
                     window.localStorage.removeItem('calls_experimental_features');
                 }
+                break;
+            case 'recording':
+                if (fields.length !== 3) {
+                    return {error: {message: 'Invalid number of arguments'}};
+                }
+
+                if (fields[2] !== 'start' && fields[2] !== 'stop') {
+                    return {error: {message: `${fields[2]} is not a valid sub-command`}};
+                }
             }
 
             return {message, args};


### PR DESCRIPTION
#### Summary

PR implements a new `/call recording` slash command that will let certain users (see `AllowedRecordingUsers`) on our Community server start/stop recordings on their own. As expected this PR is meant to go on top of `community` branch. 

These are the related changes on the recorder side: https://github.com/streamer45/calls-recorder/commit/6149291f34eba3f596cff1b9896eba741e7ece31