### PR TITLE
[MM-42712] Implement basic rate limiting for incoming WebSocket messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mattermost/rtcd v0.3.1-0.20220427165117-035048fda047
 	github.com/pion/stun v0.3.5
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
+	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1918,6 +1918,7 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 h1:Hir2P/De0WpUhtrKGGjvSb2YxUgyZ7EFOSLIcSSpiwE=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/server/session.go
+++ b/server/session.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
@@ -25,6 +27,8 @@ type session struct {
 
 	doneCh  chan struct{}
 	closeCh chan struct{}
+
+	limiter *rate.Limiter
 }
 
 func newUserSession(userID, channelID, connID string) *session {
@@ -38,6 +42,7 @@ func newUserSession(userID, channelID, connID string) *session {
 		wsCloseCh:   make(chan struct{}),
 		closeCh:     make(chan struct{}),
 		doneCh:      make(chan struct{}),
+		limiter:     rate.NewLimiter(2, 20),
 	}
 }
 


### PR DESCRIPTION
#### Summary

I've tested this locally and while this is surely better than nothing, it feels like a proper solution should be either implemented on the server side or we should find a way to allow a plugin to disconnect a malicious connection. As things stand a high rate of messages will still produce some noticeable load given the events are routed to the plugin with RPC calls happening and all that's involved into that process.

Please let me know your thoughts.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42712
