### PR TITLE
[MM-43887] Attempt to re-register client if first connect attempt fails

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/mattermost/rtcd/logger"
-	rtcd "github.com/mattermost/rtcd/service"
 	"github.com/mattermost/rtcd/service/rtc"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
@@ -42,25 +41,15 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	if cfg.RTCDServiceURL != "" {
-		clientCfg, err := p.getRTCDClientConfig(cfg.RTCDServiceURL)
-		if err != nil {
-			err = fmt.Errorf("failed to get rtcd client config: %w", err)
-			p.LogError(err.Error())
-			return err
-		}
-
-		client, err := rtcd.NewClient(clientCfg)
+		client, err := p.newRTCDClient(cfg.RTCDServiceURL)
 		if err != nil {
 			err = fmt.Errorf("failed to create rtcd client: %w", err)
 			p.LogError(err.Error())
 			return err
 		}
 
-		if err := client.Connect(); err != nil {
-			err = fmt.Errorf("failed to connect rtcd client: %w", err)
-			p.LogError(err.Error())
-			return err
-		}
+		p.LogDebug("rtcd client connected successfully")
+
 		p.rtcdClient = client
 		go func() {
 			for err := range p.rtcdClient.ErrorCh() {


### PR DESCRIPTION
#### Summary

Turned out that persisting `rtcd`'s auth store in k8s is a bit more complex than anticipated so we are allowing (tolerating really) it to reset on each pod restart. This means we need to support re-registering the client (plugin) which is what this PR is about.

This isn't ideal but hopefully it won't be needed for long as we are looking into moving to a decoupled auth service at some point.

/cc @angeloskyratzakos 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43887
