### PR TITLE
[MM-43789] Simplify client initialization

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -340,19 +340,14 @@ export default class Plugin {
             );
         };
 
-        let initializing = false;
         const connectCall = async (channelID: string) => {
-            if (initializing) {
-                console.log('client is already initializing');
-                return;
-            } else if (window.callsClient) {
-                console.log('client is already initialized');
-                return;
-            }
             try {
-                initializing = true;
-                window.callsClient = await new CallsClient().init(channelID);
-                initializing = false;
+                if (window.callsClient) {
+                    console.log('calls client is already initialized');
+                    return;
+                }
+
+                window.callsClient = new CallsClient();
                 const globalComponentID = registry.registerGlobalComponent(CallWidget);
                 const rootComponentID = registry.registerRootComponent(ExpandedView);
                 window.callsClient.on('close', () => {
@@ -367,9 +362,12 @@ export default class Plugin {
                         audio.play();
                     }
                 });
+
+                window.callsClient.init(channelID);
+
                 this.unregisterChannelHeaderMenuButton();
             } catch (err) {
-                initializing = false;
+                delete window.callsClient;
                 console.log(err);
             }
         };


### PR DESCRIPTION
#### Summary

PR simplifies client initialization by decoupling object creation and call to the `init()` method.
This change was done already in the [community branch](https://github.com/mattermost/mattermost-plugin-calls/blob/7a6b5645f44bd6c636857b1436e4258ff35e17fb/webapp/src/index.tsx#L356) but I forgot to add the early return check which I think allowed for this bug to happen.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43789
