### PR TITLE
[MM-43660] Expose some client-side metrics through `/call stats` command

### DIFF
--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -7,10 +7,13 @@ import {deflate} from 'pako/lib/deflate.js';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {getPluginWSConnectionURL, getScreenStream, getPluginPath, setSDPMaxVideoBW} from './utils';
+import {RTCStats} from 'src/types/types';
 
+import {getPluginWSConnectionURL, getScreenStream, getPluginPath, setSDPMaxVideoBW} from './utils';
 import WebSocketClient from './websocket';
 import VoiceActivityDetector from './vad';
+
+import {parseRTCStats} from './rtc_stats';
 
 export default class CallsClient extends EventEmitter {
     private peer: SimplePeer.Instance | null;
@@ -462,5 +465,19 @@ export default class CallsClient extends EventEmitter {
             this.ws.send('unraise_hand');
         }
         this.isHandRaised = false;
+    }
+
+    public async getStats(): Promise<RTCStats | null> {
+        // @ts-ignore
+        // eslint-disable-next-line no-underscore-dangle
+        if (!this.peer || !this.peer._pc) {
+            throw new Error('not connected');
+        }
+
+        // @ts-ignore
+        // eslint-disable-next-line no-underscore-dangle
+        const stats = await this.peer._pc.getStats(null);
+
+        return parseRTCStats(stats);
     }
 }

--- a/webapp/src/rtc_stats.ts
+++ b/webapp/src/rtc_stats.ts
@@ -1,0 +1,58 @@
+import {RTCStats} from 'src/types/types';
+
+export function parseRTCStats(reports: RTCStatsReport): RTCStats {
+    const stats: RTCStats = {};
+    reports.forEach((report) => {
+        if (!report.ssrc) {
+            return;
+        }
+
+        if (!stats[report.ssrc]) {
+            stats[report.ssrc] = {
+                local: {},
+                remote: {},
+            };
+        }
+
+        switch (report.type) {
+        case 'inbound-rtp':
+            stats[report.ssrc].local.in = {
+                kind: report.kind,
+                packetsReceived: report.packetsReceived,
+                bytesReceived: report.bytesReceived,
+                packetsLost: report.packetsLost,
+                packetsDiscarded: report.packetsDiscarded,
+                jitter: report.jitter,
+                jitterBufferDelay: report.jitterBufferDelay,
+            };
+            break;
+        case 'outbound-rtp':
+            stats[report.ssrc].local.out = {
+                kind: report.kind,
+                packetsSent: report.packetsSent,
+                bytesSent: report.bytesSent,
+                retransmittedPacketsSent: report.retransmittedPacketsSent,
+                retransmittedBytesSent: report.retransmittedBytesSent,
+                nackCount: report.nackCount,
+                targetBitrate: report.targetBitrate,
+            };
+            break;
+        case 'remote-inbound-rtp':
+            stats[report.ssrc].remote.in = {
+                kind: report.kind,
+                packetsLost: report.packetsLost,
+                fractionLost: report.fractionLost,
+                jitter: report.jitter,
+            };
+            break;
+        case 'remote-outbound-rtp':
+            stats[report.ssrc].remote.out = {
+                kind: report.kind,
+                packetsSent: report.packetsSent,
+                bytesSent: report.bytesSent,
+            };
+            break;
+        }
+    });
+    return stats;
+}

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -3,3 +3,54 @@ export type UserState = {
     unmuted: boolean;
     raised_hand: number;
 }
+
+export type RTCStats = {
+    [key: number]: {
+        local: RTCLocalStats,
+        remote: RTCRemoteStats,
+    }
+}
+
+export type RTCLocalStats = {
+    in?: RTCLocalInboundStats,
+    out?: RTCLocalOutboundStats,
+}
+
+export type RTCRemoteStats = {
+    in?: RTCRemoteInboundStats,
+    out?: RTCRemoteOutboundStats,
+}
+
+export type RTCLocalInboundStats = {
+    kind: string,
+    packetsReceived: number,
+    bytesReceived: number,
+    packetsLost: number,
+    packetsDiscarded: number,
+    jitter: number,
+    jitterBufferDelay: number,
+}
+
+export type RTCLocalOutboundStats = {
+    kind: string,
+    packetsSent: number,
+    bytesSent: number,
+    retransmittedPacketsSent: number,
+    retransmittedBytesSent: number,
+    nackCount: number,
+    targetBitrate: number,
+}
+
+export type RTCRemoteInboundStats = {
+    kind: string,
+    packetsLost: number,
+    fractionLost: number,
+    jitter: number,
+}
+
+export type RTCRemoteOutboundStats = {
+    kind: string,
+    packetsSent: number,
+    bytesSent: number,
+}
+


### PR DESCRIPTION
#### Summary

Adding a new utility command `/call stats` to expose some client-side metrics.
Command will generate an ephemeral message with the collected metrics in JSON, e.g.:

![image](https://user-images.githubusercontent.com/1832946/166302448-2aa6c37c-0524-4923-a99a-d1a1e247490a.png)

This will be useful to debug possible client-side conditions (e.g. networking) affecting calls quality.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43660