### PR TITLE
[MM-43959] Implement env flag to disable plugin

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -12,6 +12,11 @@ import (
 )
 
 func (p *Plugin) OnActivate() error {
+	if os.Getenv("MM_CALLS_DISABLE") == "true" {
+		p.LogInfo("disable flag is set, exiting")
+		return fmt.Errorf("disabled by environment flag")
+	}
+
 	p.LogDebug("activating")
 
 	pluginAPIClient := pluginapi.NewClient(p.API, p.Driver)


### PR DESCRIPTION
#### Summary

PR adds the ability to "disable" the plugin through the `MM_CALLS_DISABLE=true` environment override.

This is the most stupidly simple approach, returning an error on activation if the flag is set. Semantically this isn't the same as disabling a plugin through config but more like preventing it from activating. This way allows the plugin to automatically startup  on subsequent server restarts if the flag is gone.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43959
