### PR TITLE
[MM-42420] Implement new "Start Call" channel header button

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "description": "Integrates real-time voice communication in Mattermost",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
-    "min_server_version": "6.3.0",
+    "min_server_version": "6.6.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/webapp/src/components/channel_header_button/component.tsx
+++ b/webapp/src/components/channel_header_button/component.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import CallIcon from '../../components/icons/call_icon';
+import CompassIcon from '../../components/icons/compassIcon';
 
 interface Props {
     show: boolean,
+    inCall: boolean,
     hasCall: boolean,
 }
 
@@ -13,18 +14,18 @@ const ChannelHeaderButton = (props: Props) => {
         return null;
     }
     return (
-        <div
+        <button
             id='calls-join-button'
-            style={{display: 'flex', justifyContent: 'center', alignItems: 'center'}}
+            className={'style--none call-button ' + (props.inCall ? 'disabled' : '')}
+            disabled={Boolean(props.inCall)}
         >
-            <CallIcon style={{margin: '0 4px'}}/>
+            <CompassIcon icon='phone-outline'/>
             <span
-                className='icon__text'
-                style={{margin: '0 4px'}}
+                className='call-button-label'
             >
                 {props.hasCall ? 'Join Call' : 'Start Call'}
             </span>
-        </div>
+        </button>
     );
 };
 

--- a/webapp/src/components/channel_header_dropdown_button/component.tsx
+++ b/webapp/src/components/channel_header_dropdown_button/component.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import CompassIcon from '../../components/icons/compassIcon';
+
+interface Props {
+    show: boolean,
+    inCall: boolean,
+    hasCall: boolean,
+}
+
+const ChannelHeaderDropdownButton = (props: Props) => {
+    if (!props.show) {
+        return null;
+    }
+    return (
+        <button
+            id='calls-join-button'
+            className={'style--none call-button-dropdown ' + (props.inCall ? 'disabled' : '')}
+            disabled={Boolean(props.inCall)}
+        >
+            <CompassIcon icon='phone-outline'/>
+            <div>
+                <span >
+                    {props.hasCall ? 'Join Call' : 'Start Call'}
+                </span>
+                <span
+                    className='call-button-dropdown-sublabel'
+                >
+                    {'In this channel'}
+                </span>
+            </div>
+        </button>
+    );
+};
+
+export default ChannelHeaderDropdownButton;

--- a/webapp/src/components/channel_header_dropdown_button/index.ts
+++ b/webapp/src/components/channel_header_dropdown_button/index.ts
@@ -5,7 +5,7 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 
 import {voiceConnectedUsers, connectedChannelID, isVoiceEnabled} from '../../selectors';
 
-import ChannelHeaderButton from './component';
+import ChannelHeaderDropdownButton from './component';
 
 const mapStateToProps = (state: GlobalState) => ({
     hasCall: voiceConnectedUsers(state).length > 0,
@@ -13,4 +13,4 @@ const mapStateToProps = (state: GlobalState) => ({
     show: isVoiceEnabled(state),
 });
 
-export default connect(mapStateToProps)(ChannelHeaderButton);
+export default connect(mapStateToProps)(ChannelHeaderDropdownButton);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -18,6 +18,7 @@ import {pluginId} from './manifest';
 import CallsClient from './client';
 
 import ChannelHeaderButton from './components/channel_header_button';
+import ChannelHeaderDropdownButton from './components/channel_header_dropdown_button';
 import ChannelHeaderMenuButton from './components/channel_header_menu_button';
 import CallWidget from './components/call_widget';
 import ChannelLinkLabel from './components/channel_link_label';
@@ -323,9 +324,9 @@ export default class Plugin {
             if (channelHeaderMenuButtonID) {
                 return;
             }
-            channelHeaderMenuButtonID = registry.registerChannelHeaderButtonAction(
-                ChannelHeaderButton
-                ,
+            channelHeaderMenuButtonID = registry.registerCallButtonAction(
+                ChannelHeaderButton,
+                ChannelHeaderDropdownButton,
                 async (channel) => {
                     try {
                         const users = voiceConnectedUsers(store.getState());
@@ -367,7 +368,6 @@ export default class Plugin {
                 window.callsClient.on('close', () => {
                     registry.unregisterComponent(globalComponentID);
                     registry.unregisterComponent(rootComponentID);
-                    this.registerChannelHeaderMenuButton();
                     if (window.callsClient) {
                         window.callsClient.destroy();
                         delete window.callsClient;
@@ -378,8 +378,6 @@ export default class Plugin {
                 });
 
                 window.callsClient.init(channelID);
-
-                this.unregisterChannelHeaderMenuButton();
             } catch (err) {
                 delete window.callsClient;
                 console.log(err);
@@ -471,8 +469,6 @@ export default class Plugin {
                 registry.unregisterComponent(channelHeaderMenuID);
                 console.log(err);
             }
-
-            this.unregisterChannelHeaderMenuButton();
 
             try {
                 const resp = await axios.get(`${getPluginPath()}/${channelID}`);

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -15,6 +15,7 @@ export interface PluginRegistry {
     registerCustomRoute(route: string, component: React.ElementType)
     registerNeedsTeamRoute(route: string, component: React.ElementType)
     registerSlashCommandWillBePostedHook(hook: (message: string, args: CommandArgs) => any)
+    registerCallButtonAction(button: React.ElementType, dropdownButton: React.ElementType, fn: (channel: Channel) => void)
     unregisterComponent(componentID: string)
     unregisterPostTypeComponent(componentID: string)
 }


### PR DESCRIPTION
#### Summary

PR moves the "Start/Join call button" from the soon to be deprecated `registerChannelHeaderButtonAction` to the newly added `registerCallButtonAction`. This has a positive side effect of simplifying registrations which should fix a couple of long lasting issues (see tickets below).

As a consequence to this change we are going to bump the minimum supported server version to 6.6.0.

You can refer to the [original webapp PR](https://github.com/mattermost/mattermost-webapp/pull/9809) for screenshots.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-41710
https://mattermost.atlassian.net/browse/MM-42420
https://mattermost.atlassian.net/browse/MM-42304
