### PR TITLE
[MM-43140] Fix call icon color in channel link label

### DIFF
--- a/webapp/src/components/channel_link_label/component.tsx
+++ b/webapp/src/components/channel_link_label/component.tsx
@@ -11,6 +11,7 @@ import {getUserDisplayName} from '../../utils';
 import ActiveCallIcon from '../../components/icons/active_call_icon';
 
 interface Props {
+    theme: any,
     hasCall: boolean,
     profiles: UserProfile[],
 }
@@ -43,7 +44,7 @@ const ChannelLinkLabel = (props: Props) => {
             >
 
                 <ActiveCallIcon
-                    fill='#FFFFFF'
+                    fill={props.theme.centerChannelColor}
                     style={{marginLeft: 'auto', height: 'auto'}}
                 />
 


### PR DESCRIPTION
#### Summary

We were still using an hard-coded white value instead of following the theme.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43140
