### PR TITLE
[MM-44056] Make plugin start in Cloud opt-in

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -12,8 +12,8 @@ import (
 )
 
 func (p *Plugin) OnActivate() error {
-	if os.Getenv("MM_CALLS_DISABLE") == "true" {
-		p.LogInfo("disable flag is set, exiting")
+	if p.IsCloud() && os.Getenv("MM_CALLS_DISABLE") != "false" {
+		p.LogInfo("disable flag not set to false, exiting")
 		return fmt.Errorf("disabled by environment flag")
 	}
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -233,3 +233,11 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	return p.setConfiguration(cfg)
 }
+
+func (p *Plugin) IsCloud() bool {
+	license := p.API.GetLicense()
+	if license == nil || license.Features == nil || license.Features.Cloud == nil {
+		return false
+	}
+	return *license.Features.Cloud
+}


### PR DESCRIPTION
#### Summary

This will allow us to pre-enable the plugin in Cloud but still avoid it to run until it's time.

One thing to note is that once pre-packaged (and enabled) all cloud installations will experience an error on startup given the plugin will refuse to start. This shouldn't have any side effect other than the log but still something to keep in mind.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44056