### PR TITLE
[MM-43140] Use correct color for channel link label

### DIFF
--- a/webapp/src/components/channel_link_label/component.tsx
+++ b/webapp/src/components/channel_link_label/component.tsx
@@ -44,7 +44,7 @@ const ChannelLinkLabel = (props: Props) => {
             >
 
                 <ActiveCallIcon
-                    fill={props.theme.centerChannelColor}
+                    fill={props.theme.sidebarText}
                     style={{marginLeft: 'auto', height: 'auto'}}
                 />
 


### PR DESCRIPTION
#### Summary

This is why we badly need automated e2e tests :man_facepalming: 

In https://github.com/mattermost/mattermost-plugin-calls/pull/65 I used the wrong color. Now using `sidebarText` instead which makes more sense.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43140
