### PR TITLE
[MM-42289] Implement tooltip with participants in connected profiles component

### DIFF
--- a/webapp/src/components/channel_link_label/component.tsx
+++ b/webapp/src/components/channel_link_label/component.tsx
@@ -6,7 +6,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {Channel} from 'mattermost-redux/types/channels';
 import {UserProfile} from 'mattermost-redux/types/users';
 
-import {getUserDisplayName} from '../../utils';
+import {getUserDisplayName, getUsersList} from '../../utils';
 
 import ActiveCallIcon from '../../components/icons/active_call_icon';
 
@@ -15,19 +15,6 @@ interface Props {
     hasCall: boolean,
     profiles: UserProfile[],
 }
-
-const getUsersList = (profiles: UserProfile[]) => {
-    if (profiles.length === 0) {
-        return '';
-    }
-    if (profiles.length === 1) {
-        return getUserDisplayName(profiles[0]);
-    }
-    const list = profiles.slice(0, -1).map((profile, idx) => {
-        return getUserDisplayName(profile);
-    }).join(', ');
-    return list + ' and ' + getUserDisplayName(profiles[profiles.length - 1]);
-};
 
 const ChannelLinkLabel = (props: Props) => {
     if (props.hasCall) {

--- a/webapp/src/components/connected_profiles.tsx
+++ b/webapp/src/components/connected_profiles.tsx
@@ -3,6 +3,8 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import {UserProfile} from 'mattermost-redux/types/users';
 
+import {getUserDisplayName, getUsersList} from '../utils';
+
 import Avatar from './avatar/avatar';
 
 interface Props {
@@ -17,9 +19,10 @@ interface Props {
 const ConnectedProfiles = ({pictures, profiles, maxShowedProfiles, size, fontSize, border}: Props) => {
     maxShowedProfiles = maxShowedProfiles || 2;
     const diff = profiles.length - maxShowedProfiles;
-    profiles = diff > 0 ? profiles.slice(0, maxShowedProfiles) : profiles;
 
-    const els = profiles.map((profile, idx) => {
+    const showedProfiles = diff > 0 ? profiles.slice(0, maxShowedProfiles) : profiles;
+
+    const els = showedProfiles.map((profile, idx) => {
         return (
             <OverlayTrigger
                 placement='bottom'
@@ -41,13 +44,26 @@ const ConnectedProfiles = ({pictures, profiles, maxShowedProfiles, size, fontSiz
     });
 
     if (diff > 0) {
+        profiles = profiles.slice(showedProfiles.length);
         els.push(
-            <Avatar
-                size={size}
-                text={`+${diff}`}
-                border={Boolean(border)}
+            <OverlayTrigger
+                placement='bottom'
                 key='call_thread_more_profiles'
-            />,
+                overlay={
+                    <Tooltip
+                        id='call-profiles'
+                    >
+                        {getUsersList(profiles)}
+                    </Tooltip>
+                }
+            >
+                <Avatar
+                    size={size}
+                    text={`+${diff}`}
+                    border={Boolean(border)}
+                    key='call_thread_more_profiles'
+                />
+            </OverlayTrigger>,
         );
     }
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -288,3 +288,16 @@ export function setSDPMaxVideoBW(sdp: string, bandwidth: number) {
 export function hasExperimentalFlag() {
     return window.localStorage.getItem('calls_experimental_features') === 'on';
 }
+
+export function getUsersList(profiles: UserProfile[]) {
+    if (profiles.length === 0) {
+        return '';
+    }
+    if (profiles.length === 1) {
+        return getUserDisplayName(profiles[0]);
+    }
+    const list = profiles.slice(0, -1).map((profile, idx) => {
+        return getUserDisplayName(profile);
+    }).join(', ');
+    return list + ' and ' + getUserDisplayName(profiles[profiles.length - 1]);
+}


### PR DESCRIPTION
#### Summary

PR implements a tooltip on the +x circle to show the remaining participants in the call.

#### Screenshots

![tooltip_1](https://user-images.githubusercontent.com/1832946/168561452-bbac375f-1c7f-4653-86bb-a087bef129dc.png)

![tooltip_2](https://user-images.githubusercontent.com/1832946/168561447-3650c9de-a334-4dbb-a6de-ba01e022b2af.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42289
