### PR TITLE
[MM-43590] Simplify client state re-initialization

### DIFF
--- a/build/pluginctl/main.go
+++ b/build/pluginctl/main.go
@@ -119,6 +119,10 @@ func deploy(client *model.Client4, pluginID, bundlePath string) error {
 	}
 	defer pluginBundle.Close()
 
+	// disabling in case the plugin is enabled. This helps to keep client state
+	// consistent as the plugin gets properly re-initialized.
+	_, _ = client.DisablePlugin(pluginID)
+
 	log.Print("Uploading plugin via API.")
 	_, _, err = client.UploadPluginForced(pluginBundle)
 	if err != nil {

--- a/server/activate.go
+++ b/server/activate.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mattermost/rtcd/service/rtc"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
-	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 func (p *Plugin) OnActivate() error {
@@ -119,7 +118,6 @@ func (p *Plugin) OnActivate() error {
 
 func (p *Plugin) OnDeactivate() error {
 	p.LogDebug("deactivate")
-	p.API.PublishWebSocketEvent(wsEventDeactivate, nil, &model.WebsocketBroadcast{ReliableClusterSend: true})
 	close(p.stopCh)
 
 	if p.rtcdClient != nil {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -24,7 +24,6 @@ const (
 	wsEventUserScreenOn     = "user_screen_on"
 	wsEventUserScreenOff    = "user_screen_off"
 	wsEventCallStart        = "call_start"
-	wsEventDeactivate       = "deactivate"
 	wsEventUserRaiseHand    = "user_raise_hand"
 	wsEventUserUnraiseHand  = "user_unraise_hand"
 	wsEventJoin             = "join"

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -16,6 +16,7 @@ import VoiceActivityDetector from './vad';
 import {parseRTCStats} from './rtc_stats';
 
 export default class CallsClient extends EventEmitter {
+    public channelID: string;
     private peer: SimplePeer.Instance | null;
     private ws: WebSocketClient | null;
     private localScreenTrack: any;
@@ -42,6 +43,7 @@ export default class CallsClient extends EventEmitter {
         this.stream = null;
         this.audioDevices = {inputs: [], outputs: []};
         this.isHandRaised = false;
+        this.channelID = '';
     }
 
     private initVAD(inputStream: MediaStream) {
@@ -71,6 +73,7 @@ export default class CallsClient extends EventEmitter {
     }
 
     public async init(channelID: string, title?: string) {
+        this.channelID = channelID;
         await this.updateDevices();
         navigator.mediaDevices.ondevicechange = this.updateDevices;
 

--- a/webapp/src/components/channel_header_button/component.tsx
+++ b/webapp/src/components/channel_header_button/component.tsx
@@ -17,7 +17,7 @@ const ChannelHeaderButton = (props: Props) => {
         <button
             id='calls-join-button'
             className={'style--none call-button ' + (props.inCall ? 'disabled' : '')}
-            disabled={Boolean(props.inCall)}
+            disabled={props.inCall}
         >
             <CompassIcon icon='phone-outline'/>
             <span

--- a/webapp/src/components/channel_header_button/index.ts
+++ b/webapp/src/components/channel_header_button/index.ts
@@ -9,7 +9,7 @@ import ChannelHeaderButton from './component';
 
 const mapStateToProps = (state: GlobalState) => ({
     hasCall: voiceConnectedUsers(state).length > 0,
-    inCall: connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state),
+    inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
     show: isVoiceEnabled(state),
 });
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -74,11 +74,15 @@ export default class Plugin {
 
     constructor() {
         this.unsubscribers = [];
-        this.unsubscribers.push(() => {
-            if (window.callsClient) {
-                window.callsClient.disconnect();
-            }
-        });
+    }
+
+    private registerReconnectHandler(registry: PluginRegistry, store: Store, onActivate: () => void, onDeactivate: () => void) {
+        const handler = () => {
+            onDeactivate();
+            onActivate();
+        };
+        registry.registerReconnectHandler(handler);
+        this.unsubscribers.push(() => registry.unregisterReconnectHandler(handler));
     }
 
     private registerWebSocketEvents(registry: PluginRegistry, store: Store) {
@@ -209,10 +213,6 @@ export default class Plugin {
                     channelID: ev.broadcast.channel_id,
                 },
             });
-        });
-
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_deactivate`, (ev) => {
-            this.uninitialize();
         });
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_user_raise_hand`, (ev) => {
@@ -532,27 +532,43 @@ export default class Plugin {
             }
         };
 
+        const onActivate = async () => {
+            const currChannelId = getCurrentChannelId(store.getState());
+            if (currChannelId) {
+                fetchChannelData(currChannelId);
+            } else {
+                const expandedID = getExpandedChannelID();
+                if (expandedID.length > 0) {
+                    await store.dispatch({
+                        type: VOICE_CHANNEL_USER_CONNECTED,
+                        data: {
+                            channelID: expandedID,
+                            userID: getCurrentUserId(store.getState()),
+                            currentUserID: getCurrentUserId(store.getState()),
+                        },
+                    });
+                    fetchChannelData(expandedID);
+                }
+            }
+        };
+
+        const onDeactivate = () => {
+            if (window.callsClient) {
+                window.callsClient.disconnect();
+            }
+            store.dispatch({
+                type: VOICE_CHANNEL_UNINIT,
+            });
+        };
+
+        this.unsubscribers.push(onDeactivate);
+
         this.registerWebSocketEvents(registry, store);
-        fetchChannels();
+        this.registerReconnectHandler(registry, store, onActivate, onDeactivate);
+
+        onActivate();
 
         let currChannelId = getCurrentChannelId(store.getState());
-        if (currChannelId) {
-            fetchChannelData(currChannelId);
-        } else {
-            const expandedID = getExpandedChannelID();
-            if (expandedID.length > 0) {
-                await store.dispatch({
-                    type: VOICE_CHANNEL_USER_CONNECTED,
-                    data: {
-                        channelID: expandedID,
-                        userID: getCurrentUserId(store.getState()),
-                        currentUserID: getCurrentUserId(store.getState()),
-                    },
-                });
-                fetchChannelData(expandedID);
-            }
-        }
-
         let joinCallParam = new URLSearchParams(window.location.search).get('join_call');
         this.unsubscribers.push(store.subscribe(() => {
             const currentChannelId = getCurrentChannelId(store.getState());
@@ -565,12 +581,6 @@ export default class Plugin {
                 joinCallParam = '';
             }
         }));
-
-        this.unsubscribers.push(() => {
-            store.dispatch({
-                type: VOICE_CHANNEL_UNINIT,
-            });
-        });
     }
 
     uninitialize() {

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -18,6 +18,8 @@ export interface PluginRegistry {
     registerCallButtonAction(button: React.ElementType, dropdownButton: React.ElementType, fn: (channel: Channel) => void)
     unregisterComponent(componentID: string)
     unregisterPostTypeComponent(componentID: string)
+    registerReconnectHandler(handler: () => void)
+    unregisterReconnectHandler(handler: () => void)
 }
 
 /**


### PR DESCRIPTION
#### Summary

PR fixes a couple of issues with client state upon plugin re-initialization due to either:

- plugin disable/enable
- server restart 

This should fix the need for people to refresh every time pods rotate in Community. I tested various scenarios and everything seems okay now.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43590