### PR TITLE
Call fetchChannels on plugin init

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -529,6 +529,7 @@ export default class Plugin {
         };
 
         const onActivate = async () => {
+            fetchChannels();
             const currChannelId = getCurrentChannelId(store.getState());
             if (currChannelId) {
                 fetchChannelData(currChannelId);
@@ -559,6 +560,7 @@ export default class Plugin {
 
         this.registerWebSocketEvents(registry, store);
         this.registerReconnectHandler(registry, store, () => {
+            console.log('calls: websocket reconnect handler');
             store.dispatch({
                 type: VOICE_CHANNEL_UNINIT,
             });
@@ -593,6 +595,7 @@ export default class Plugin {
     }
 
     uninitialize() {
+        console.log('calls: uninitialize');
         this.unsubscribers.forEach((unsubscribe) => {
             unsubscribe();
         });


### PR DESCRIPTION
#### Summary

Somehow the call to `fetchChannels` got lost as part of https://github.com/mattermost/mattermost-plugin-calls/pull/72.
This PR should fix the call duration issue.

I am yet unsure whether or not this relates to other issues we've been seeing today (e.g. [MM-44370](https://mattermost.atlassian.net/browse/MM-44370)). Adding a couple of log statements to help debugging those.


