### PR TITLE
[MM-44370] Fix state reset during ws reconnect

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -583,6 +583,7 @@ export default class Plugin {
             if (window.callsClient) {
                 window.callsClient.disconnect();
             }
+            console.log('calls: resetting state');
             store.dispatch({
                 type: VOICE_CHANNEL_UNINIT,
             });
@@ -591,20 +592,13 @@ export default class Plugin {
         this.registerWebSocketEvents(registry, store);
         this.registerReconnectHandler(registry, store, () => {
             console.log('calls: websocket reconnect handler');
-            store.dispatch({
-                type: VOICE_CHANNEL_UNINIT,
-            });
-            onActivate();
-            if (window.callsClient) {
+            if (!window.callsClient) {
+                console.log('calls: resetting state');
                 store.dispatch({
-                    type: VOICE_CHANNEL_USER_CONNECTED,
-                    data: {
-                        channelID: window.callsClient.channelID,
-                        userID: getCurrentUserId(store.getState()),
-                        currentUserID: getCurrentUserId(store.getState()),
-                    },
+                    type: VOICE_CHANNEL_UNINIT,
                 });
             }
+            onActivate();
         });
 
         onActivate();


### PR DESCRIPTION
#### Summary

Resetting state in https://github.com/mattermost/mattermost-plugin-calls/pull/72 turned out to be a bit too aggressive with various side effects like the attached issue. Now resetting the whole state only if the user has disconnected from the call, otherwise simply updating it. 

At some point we'll want to send the whole current state through the websocket channel, mainly to avoid possible race conditions that could still cause inconsistencies at this point.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44370
