### PR TITLE
Use consistent prefix for environment overrides

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -70,7 +70,7 @@ func (p *Plugin) OnActivate() error {
 		return nil
 	}
 
-	if os.Getenv("CALLS_IS_HANDLER") != "" {
+	if os.Getenv("MM_CALLS_IS_HANDLER") != "" {
 		go func() {
 			p.LogInfo("calls handler, setting state", "clusterID", status.ClusterId)
 			if err := p.setHandlerID(status.ClusterId); err != nil {

--- a/server/rtcd.go
+++ b/server/rtcd.go
@@ -389,11 +389,11 @@ func (m *rtcdClientManager) getRTCDClientConfig(rtcdURL string, dialFn rtcd.Dial
 	// Give precedence to environment to override everything else.
 	cfg.ClientID = os.Getenv("MM_CLOUD_INSTALLATION_ID")
 	if cfg.ClientID == "" {
-		cfg.ClientID = os.Getenv("CALLS_RTCD_CLIENT_ID")
+		cfg.ClientID = os.Getenv("MM_CALLS_RTCD_CLIENT_ID")
 	}
-	cfg.AuthKey = os.Getenv("CALLS_RTCD_AUTH_KEY")
+	cfg.AuthKey = os.Getenv("MM_CALLS_RTCD_AUTH_KEY")
 	cfg.URL = rtcdURL
-	if rtcdURL = os.Getenv("CALLS_RTCD_URL"); rtcdURL != "" {
+	if rtcdURL = os.Getenv("MM_CALLS_RTCD_URL"); rtcdURL != "" {
 		cfg.URL = rtcdURL
 	}
 


### PR DESCRIPTION
#### Summary

Just being consistent with the prefix and break it now before it becomes more expensive to do.