### PR TITLE
Send cloudMaxParticipants to the client

### DIFF
--- a/server/cloud_limits.go
+++ b/server/cloud_limits.go
@@ -50,7 +50,8 @@ func (p *Plugin) handleCloudInfo(w http.ResponseWriter) error {
 
 	w.Header().Set("Content-Type", "application/json")
 	info := map[string]interface{}{
-		"sku_short_name": license.SkuShortName,
+		"sku_short_name":         license.SkuShortName,
+		"cloud_max_participants": cloudMaxParticipants,
 	}
 	if err := json.NewEncoder(w).Encode(info); err != nil {
 		return errors.Wrap(err, "error encoding cloud info")

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -11,7 +11,6 @@ import ActiveCallIcon from 'src/components/icons/active_call_icon';
 import CallIcon from 'src/components/icons/call_icon';
 import LeaveCallIcon from 'src/components/icons/leave_call_icon';
 import ConnectedProfiles from 'src/components/connected_profiles';
-import {CLOUD_MAX_PARTICIPANTS} from 'src/constants';
 
 interface Props {
     post: Post,
@@ -20,6 +19,7 @@ interface Props {
     profiles: UserProfile[],
     showSwitchCallModal: (targetID: string) => void,
     isCloudPaid: boolean,
+    cloudMaxParticipants: number,
 }
 
 const PostType = ({
@@ -29,6 +29,7 @@ const PostType = ({
     profiles,
     showSwitchCallModal,
     isCloudPaid,
+    cloudMaxParticipants,
 }: Props) => {
     const onJoinCallClick = () => {
         if (connectedID) {
@@ -64,7 +65,9 @@ const PostType = ({
             <ButtonText>{'Join call'}</ButtonText>
         </JoinButton>
     );
-    if (isCloudPaid && profiles.length >= CLOUD_MAX_PARTICIPANTS) {
+
+    // Note: don't use isCloudLimitRestricted because that uses current channel, and this post could be in RHS
+    if (isCloudPaid && profiles.length >= cloudMaxParticipants) {
         joinButton = (
             <OverlayTrigger
                 placement='top'
@@ -155,11 +158,11 @@ const Main = styled.div`
     border-radius: 4px;
 `;
 
-const SubMain = styled.div<{ ended: Boolean }>`
+const SubMain = styled.div<{ ended: boolean }>`
     display: flex;
     align-items: center;
     width: 100%;
-    flex-wrap: ${props => props.ended ? 'nowrap' : 'wrap'};
+    flex-wrap: ${(props) => (props.ended ? 'nowrap' : 'wrap')};
     row-gap: 8px;
 `;
 
@@ -175,8 +178,8 @@ const Right = styled.div`
     flex-grow: 1;
 `;
 
-const CallIndicator = styled.div<{ ended: Boolean }>`
-    background: ${props => props.ended ? 'rgba(var(--center-channel-color-rgb), 0.16)' : 'var(--online-indicator)'};
+const CallIndicator = styled.div<{ ended: boolean }>`
+    background: ${(props) => (props.ended ? 'rgba(var(--center-channel-color-rgb), 0.16)' : 'var(--online-indicator)')};
     border-radius: 4px;
     padding: 10px;
     width: 40px;

--- a/webapp/src/components/custom_post_types/post_type/index.ts
+++ b/webapp/src/components/custom_post_types/post_type/index.ts
@@ -10,6 +10,7 @@ import {
     voiceConnectedProfilesInChannel,
     connectedChannelID,
     isCloudProfessionalOrEnterprise,
+    cloudMaxParticipants,
 } from 'src/selectors';
 import {showSwitchCallModal} from 'src/actions';
 
@@ -39,6 +40,7 @@ const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
         pictures,
         profiles,
         isCloudPaid: isCloudProfessionalOrEnterprise(state),
+        cloudMaxParticipants: cloudMaxParticipants(state),
     };
 };
 

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -1,1 +1,0 @@
-export const CLOUD_MAX_PARTICIPANTS_DEFAULT = 8;

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -1,1 +1,1 @@
-export const CLOUD_MAX_PARTICIPANTS = 8;
+export const CLOUD_MAX_PARTICIPANTS_DEFAULT = 8;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -22,7 +22,6 @@ import {
     isCloudFeatureRestricted,
     isCloudLimitRestricted,
     voiceChannelRootPost,
-    retrievedCloudSku,
 } from './selectors';
 
 import {pluginId} from './manifest';
@@ -488,11 +487,6 @@ export default class Plugin {
         };
 
         const fetchChannelData = async (channelID: string) => {
-            // Don't retrieve cloud info on every channel change.
-            if (!retrievedCloudSku(store.getState())) {
-                store.dispatch(getCloudInfo());
-            }
-
             let channel = getChannel(store.getState(), channelID);
             if (!channel) {
                 await getChannelAction(channelID)(store.dispatch as any, store.getState);
@@ -585,6 +579,7 @@ export default class Plugin {
         };
 
         const onActivate = async () => {
+            store.dispatch(getCloudInfo());
             fetchChannels();
             const currChannelId = getCurrentChannelId(store.getState());
             if (currChannelId) {

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -2,9 +2,7 @@ import {combineReducers} from 'redux';
 
 import {UserProfile} from 'mattermost-redux/types/users';
 
-import {GenericAction} from 'mattermost-redux/types/actions';
-
-import {UserState} from './types/types';
+import {CloudInfo, CloudInfoDefault, UserState} from './types/types';
 
 import {
     VOICE_CHANNEL_ENABLE,
@@ -438,13 +436,10 @@ const screenSourceModal = (state = false, action: { type: string }) => {
     }
 };
 
-const cloudInfo = (state = {sku_short_name: '', retrieved: false}, action: GenericAction) => {
+const cloudInfo = (state = CloudInfoDefault, action: { type: string, data: CloudInfo }) => {
     switch (action.type) {
     case RECEIVED_CLOUD_INFO:
-        return {
-            sku_short_name: action.data.sku_short_name,
-            retrieved: true,
-        };
+        return action.data;
     default:
         return state;
     }

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -6,7 +6,6 @@ import {createSelector} from 'reselect';
 
 import {LicenseSkus} from '@mattermost/types/general';
 
-import {CLOUD_MAX_PARTICIPANTS} from 'src/constants';
 import {isDMChannel} from 'src/utils';
 
 import {pluginId} from './manifest';
@@ -24,6 +23,12 @@ export const voiceConnectedUsers = (state: GlobalState) => {
     }
     return [];
 };
+
+const numCurrentVoiceConnectedUsers: (state: GlobalState) => number = createSelector(
+    'numCurrentVoiceConnectedUsers',
+    voiceConnectedUsers,
+    (connectedUsers) => connectedUsers.length,
+);
 
 export const voiceConnectedUsersInChannel = (state: GlobalState, channelID: string) => {
     const channels = voiceConnectedChannels(state);
@@ -84,8 +89,8 @@ const cloudSku = (state: GlobalState): string => {
     return getPluginState(state).cloudInfo.sku_short_name;
 };
 
-export const retrievedCloudSku = (state: GlobalState): boolean => {
-    return getPluginState(state).cloudInfo.retrieved;
+export const cloudMaxParticipants = (state: GlobalState) => {
+    return getPluginState(state).cloudInfo.cloud_max_participants;
 };
 
 export const isCloud: (state: GlobalState) => boolean = createSelector(
@@ -134,8 +139,9 @@ export const isCloudFeatureRestricted: (state: GlobalState) => boolean = createS
 export const isCloudLimitRestricted: (state: GlobalState) => boolean = createSelector(
     'isCloudLimitRestricted',
     isCloudProfessionalOrEnterprise,
-    voiceConnectedUsers,
-    (isCloudPaid, users) => isCloudPaid && users.length >= CLOUD_MAX_PARTICIPANTS,
+    numCurrentVoiceConnectedUsers,
+    cloudMaxParticipants,
+    (isCloudPaid, numCurrentUsers, maxParticipants) => isCloudPaid && numCurrentUsers >= maxParticipants,
 );
 
 const getSubscription = (state: GlobalState) => {
@@ -165,4 +171,3 @@ export const isCloudTrialNeverStarted: (state: GlobalState) => boolean = createS
         return subscription?.trial_end_at === 0;
     },
 );
-

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -1,3 +1,5 @@
+import {CLOUD_MAX_PARTICIPANTS_DEFAULT} from 'src/constants';
+
 export type UserState = {
     voice: boolean;
     unmuted: boolean;
@@ -56,4 +58,10 @@ export type RTCRemoteOutboundStats = {
 
 export type CloudInfo = {
     sku_short_name: string,
+    cloud_max_participants: number,
 }
+
+export const CloudInfoDefault = {
+    sku_short_name: '',
+    cloud_max_participants: CLOUD_MAX_PARTICIPANTS_DEFAULT,
+} as CloudInfo;

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -1,5 +1,3 @@
-import {CLOUD_MAX_PARTICIPANTS_DEFAULT} from 'src/constants';
-
 export type UserState = {
     voice: boolean;
     unmuted: boolean;
@@ -63,5 +61,5 @@ export type CloudInfo = {
 
 export const CloudInfoDefault = {
     sku_short_name: '',
-    cloud_max_participants: CLOUD_MAX_PARTICIPANTS_DEFAULT,
+    cloud_max_participants: 0,
 } as CloudInfo;


### PR DESCRIPTION
#### Summary
- Send cloudMaxParticipants to the client so that the UI limits reflect the actual limit (overridable with the env var)
- Retrieve the cloud limit on reconnect -- if the node's limits are changed with an env var, the client will know the new limit.

#### Ticket Link
- None
