### PR TITLE
Consolidate config, Reduce quantity of api calls

### DIFF
--- a/server/cloud_limits.go
+++ b/server/cloud_limits.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
@@ -37,27 +36,6 @@ func (p *Plugin) joinAllowed(channel *model.Channel, state *channelState) (bool,
 	}
 
 	return true, nil
-}
-
-// handleCloudInfo returns license information that isn't exposed to clients yet
-func (p *Plugin) handleCloudInfo(w http.ResponseWriter) error {
-	license := p.pluginAPI.System.GetLicense()
-	if license == nil {
-		p.handleErrorWithCode(w, http.StatusBadRequest, "no license",
-			errors.New("no license found"))
-		return nil
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	info := map[string]interface{}{
-		"sku_short_name":         license.SkuShortName,
-		"cloud_max_participants": cloudMaxParticipants,
-	}
-	if err := json.NewEncoder(w).Encode(info); err != nil {
-		return errors.Wrap(err, "error encoding cloud info")
-	}
-
-	return nil
 }
 
 // handleCloudNotifyAdmins notifies the user's admin about upgrading for calls

--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -27,5 +27,5 @@ export const HIDE_SWITCH_CALL_MODAL = pluginId + '_hide_switch_call_modal';
 export const SHOW_SCREEN_SOURCE_MODAL = pluginId + '_show_screen_source_modal';
 export const HIDE_SCREEN_SOURCE_MODAL = pluginId + '_hide_screen_source_modal';
 
-export const RECEIVED_CLOUD_INFO = pluginId + '_received_cloud_info';
+export const RECEIVED_CALLS_CONFIG = pluginId + '_received_calls_config';
 

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -9,7 +9,7 @@ import {CloudCustomer} from '@mattermost/types/cloud';
 
 import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 
-import {CloudInfo} from 'src/types/types';
+import {CallsConfig} from 'src/types/types';
 import {getPluginPath} from 'src/utils';
 
 import {modals, openPricingModal} from 'src/webapp_globals';
@@ -30,7 +30,7 @@ import {
     HIDE_SWITCH_CALL_MODAL,
     SHOW_SCREEN_SOURCE_MODAL,
     HIDE_SCREEN_SOURCE_MODAL,
-    RECEIVED_CLOUD_INFO,
+    RECEIVED_CALLS_CONFIG,
 } from './action_types';
 
 export const showExpandedView = () => (dispatch: Dispatch<GenericAction>) => {
@@ -72,13 +72,13 @@ export const hideScreenSourceModal = () => (dispatch: Dispatch<GenericAction>) =
     });
 };
 
-export const getCloudInfo = (): ActionFunc => {
+export const getCallsConfig = (): ActionFunc => {
     return bindClientFunc({
-        clientFunc: () => Client4.doFetch<CloudInfo>(
-            `${getPluginPath()}/cloud-info`,
+        clientFunc: () => Client4.doFetch<CallsConfig>(
+            `${getPluginPath()}/config`,
             {method: 'get'},
         ),
-        onSuccess: [RECEIVED_CLOUD_INFO],
+        onSuccess: [RECEIVED_CALLS_CONFIG],
     });
 };
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -10,7 +10,7 @@ import {getChannel as getChannelAction} from 'mattermost-redux/actions/channels'
 import {getProfilesByIds as getProfilesByIdsAction} from 'mattermost-redux/actions/users';
 import {setThreadFollow} from 'mattermost-redux/actions/threads';
 
-import {displayFreeTrial, getCloudInfo} from 'src/actions';
+import {displayFreeTrial, getCallsConfig} from 'src/actions';
 import {PostTypeCloudTrialRequest} from 'src/components/custom_post_types/post_type_cloud_trial_request';
 
 import {
@@ -21,7 +21,7 @@ import {
     voiceChannelCallStartAt,
     isCloudFeatureRestricted,
     isCloudLimitRestricted,
-    voiceChannelRootPost,
+    voiceChannelRootPost, allowEnableCalls,
 } from './selectors';
 
 import {pluginId} from './manifest';
@@ -406,7 +406,7 @@ export default class Plugin {
                     return;
                 }
 
-                window.callsClient = new CallsClient();
+                window.callsClient = new CallsClient(store.getState);
                 const globalComponentID = registry.registerGlobalComponent(CallWidget);
                 const rootComponentID = registry.registerRootComponent(ExpandedView);
                 window.callsClient.on('close', () => {
@@ -506,9 +506,9 @@ export default class Plugin {
             }
 
             try {
-                const resp = await axios.get(`${getPluginPath()}/config`);
+                const allowEnable = allowEnableCalls(store.getState());
                 registry.unregisterComponent(channelHeaderMenuID);
-                if (hasPermissionsToEnableCalls(channel, cms[channelID], systemRoles, channelRoles, resp.data.AllowEnableCalls)) {
+                if (hasPermissionsToEnableCalls(channel, cms[channelID], systemRoles, channelRoles, allowEnable)) {
                     registerChannelHeaderMenuAction();
                 }
             } catch (err) {
@@ -579,7 +579,7 @@ export default class Plugin {
         };
 
         const onActivate = async () => {
-            store.dispatch(getCloudInfo());
+            store.dispatch(getCallsConfig());
             fetchChannels();
             const currChannelId = getCurrentChannelId(store.getState());
             if (currChannelId) {

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -2,7 +2,7 @@ import {combineReducers} from 'redux';
 
 import {UserProfile} from 'mattermost-redux/types/users';
 
-import {CloudInfo, CloudInfoDefault, UserState} from './types/types';
+import {CallsConfigDefault, CallsConfig, UserState} from './types/types';
 
 import {
     VOICE_CHANNEL_ENABLE,
@@ -29,7 +29,8 @@ import {
     SHOW_SWITCH_CALL_MODAL,
     HIDE_SWITCH_CALL_MODAL,
     SHOW_SCREEN_SOURCE_MODAL,
-    HIDE_SCREEN_SOURCE_MODAL, RECEIVED_CLOUD_INFO,
+    HIDE_SCREEN_SOURCE_MODAL,
+    RECEIVED_CALLS_CONFIG,
 } from './action_types';
 
 const isVoiceEnabled = (state = false, action: { type: string }) => {
@@ -436,9 +437,9 @@ const screenSourceModal = (state = false, action: { type: string }) => {
     }
 };
 
-const cloudInfo = (state = CloudInfoDefault, action: { type: string, data: CloudInfo }) => {
+const callsConfig = (state = CallsConfigDefault, action: { type: string, data: CallsConfig }) => {
     switch (action.type) {
-    case RECEIVED_CLOUD_INFO:
+    case RECEIVED_CALLS_CONFIG:
         return action.data;
     default:
         return state;
@@ -457,5 +458,5 @@ export default combineReducers({
     switchCallModal,
     screenSourceModal,
     voiceChannelRootPost,
-    cloudInfo,
+    callsConfig,
 });

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -8,6 +8,8 @@ import {LicenseSkus} from '@mattermost/types/general';
 
 import {isDMChannel} from 'src/utils';
 
+import {CallsConfig} from 'src/types/types';
+
 import {pluginId} from './manifest';
 
 //@ts-ignore GlobalState is not complete
@@ -82,16 +84,36 @@ export const voiceChannelRootPost = (state: GlobalState, channelID: string) => {
     return getPluginState(state).voiceChannelRootPost[channelID];
 };
 
+const callsConfig = (state: GlobalState): CallsConfig => {
+    return getPluginState(state).callsConfig;
+};
+
+export const iceServers: (state: GlobalState) => string[] = createSelector(
+    'iceServers',
+    callsConfig,
+    (config) => config.ice_servers,
+);
+
+export const allowEnableCalls: (state: GlobalState) => boolean = createSelector(
+    'allowEnableCalls',
+    callsConfig,
+    (config) => config.allow_enable_calls,
+);
+
 //
 // Selectors for Cloud and beta limits:
 //
-const cloudSku = (state: GlobalState): string => {
-    return getPluginState(state).cloudInfo.sku_short_name;
-};
+const cloudSku: (state: GlobalState) => string = createSelector(
+    'cloudSku',
+    callsConfig,
+    (config) => config.sku_short_name,
+);
 
-export const cloudMaxParticipants = (state: GlobalState) => {
-    return getPluginState(state).cloudInfo.cloud_max_participants;
-};
+export const cloudMaxParticipants: (state: GlobalState) => number = createSelector(
+    'cloudMaxParticipants',
+    callsConfig,
+    (config) => config.cloud_max_participants,
+);
 
 export const isCloud: (state: GlobalState) => boolean = createSelector(
     'isCloud',

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -54,12 +54,18 @@ export type RTCRemoteOutboundStats = {
     bytesSent: number,
 }
 
-export type CloudInfo = {
+export type CallsConfig = {
+    ice_servers: string[],
+    allow_enable_calls: boolean,
+    default_enabled: boolean,
     sku_short_name: string,
     cloud_max_participants: number,
 }
 
-export const CloudInfoDefault = {
+export const CallsConfigDefault = {
+    ice_servers: [],
+    allow_enable_calls: false,
+    default_enabled: false,
     sku_short_name: '',
     cloud_max_participants: 0,
-} as CloudInfo;
+} as CallsConfig;


### PR DESCRIPTION
#### Summary
- While working on the beta limits for mobile, I anticipated that Elias would not like us adding another API call, even if it's only on connect/reconnect. Anyway, I think we should be sending over the `/cloud-info` data in the `/config` api call, since they're both "config" type of data.
- Then I thought we may as well put the config into the store -- it's been bugging me that we make an api call on every join, and 2 api calls on every channel switch. Now we only make one api call on a channel switch (and I'd like to get rid of that too, maybe later).

#### Ticket Link
- None

