### PR TITLE
[MM-44155] Implement `/call end` slash command

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -31,9 +31,11 @@ func (p *Plugin) OnActivate() error {
 	pluginAPIClient := pluginapi.NewClient(p.API, p.Driver)
 	p.pluginAPI = pluginAPIClient
 
-	if err := p.cleanUpState(); err != nil {
-		p.LogError(err.Error())
-		return err
+	if !p.isHAEnabled() {
+		if err := p.cleanUpState(); err != nil {
+			p.LogError(err.Error())
+			return err
+		}
 	}
 
 	if err := p.registerCommands(); err != nil {
@@ -137,8 +139,10 @@ func (p *Plugin) OnDeactivate() error {
 		}
 	}
 
-	if err := p.cleanUpState(); err != nil {
-		p.LogError(err.Error())
+	if !p.isHAEnabled() {
+		if err := p.cleanUpState(); err != nil {
+			p.LogError(err.Error())
+		}
 	}
 
 	if err := p.unregisterCommands(); err != nil {

--- a/server/api.go
+++ b/server/api.go
@@ -8,12 +8,14 @@ import (
 	"net/http/pprof"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
 )
 
 var chRE = regexp.MustCompile(`^\/([a-z0-9]+)$`)
+var callEndRE = regexp.MustCompile(`^\/calls\/([a-z0-9]+)\/end$`)
 
 type Call struct {
 	ID              string      `json:"id"`
@@ -180,59 +182,141 @@ func (p *Plugin) handleGetAllChannels(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (p *Plugin) handleEndCall(w http.ResponseWriter, r *http.Request, channelID string) {
+	var res httpResponse
+	defer p.httpAudit("handleEndCall", &res, w, r)
+
+	userID := r.Header.Get("Mattermost-User-Id")
+
+	isAdmin := p.API.HasPermissionTo(userID, model.PermissionManageSystem)
+
+	state, err := p.kvGetChannelState(channelID)
+	if err != nil {
+		res.Err = err.Error()
+		res.Code = http.StatusInternalServerError
+		return
+	}
+
+	if state == nil || state.Call == nil {
+		res.Err = "no call ongoing"
+		res.Code = http.StatusBadRequest
+		return
+	}
+
+	if !isAdmin && state.Call.CreatorID != userID {
+		res.Err = "no permissions to end the call"
+		res.Code = http.StatusForbidden
+		return
+	}
+
+	callID := state.Call.ID
+
+	if err := p.kvSetAtomicChannelState(channelID, func(state *channelState) (*channelState, error) {
+		if state == nil || state.Call == nil {
+			return nil, nil
+		}
+
+		if state.Call.ID != callID {
+			return nil, fmt.Errorf("previous call has ended and new one has started")
+		}
+
+		if state.Call.EndAt == 0 {
+			state.Call.EndAt = time.Now().UnixMilli()
+		}
+
+		return state, nil
+	}); err != nil {
+		res.Err = err.Error()
+		res.Code = http.StatusForbidden
+		return
+	}
+
+	p.API.PublishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
+
+	go func() {
+		// We wait a few seconds for the call to end cleanly. If this doesn't
+		// happen we force end it.
+		time.Sleep(5 * time.Second)
+
+		state, err := p.kvGetChannelState(channelID)
+		if err != nil {
+			p.LogError(err.Error())
+			return
+		}
+		if state == nil || state.Call == nil || state.Call.ID != callID {
+			return
+		}
+
+		p.LogInfo("call state is still in store, force ending it")
+
+		for connID := range state.Call.Sessions {
+			if err := p.closeRTCSession(userID, connID, channelID, state.NodeID); err != nil {
+				p.LogError(err.Error())
+			}
+		}
+
+		if err := p.cleanCallState(channelID); err != nil {
+			p.LogError(err.Error())
+		}
+	}()
+
+	res.Code = http.StatusOK
+	res.Msg = "success"
+}
+
 func (p *Plugin) handlePostChannel(w http.ResponseWriter, r *http.Request, channelID string) {
 	var res httpResponse
-	defer p.httpAudit("handlePostChannel", res, w, r)
+	defer p.httpAudit("handlePostChannel", &res, w, r)
 
 	userID := r.Header.Get("Mattermost-User-Id")
 
 	cfg := p.getConfiguration()
 	if !*cfg.AllowEnableCalls && !p.API.HasPermissionTo(userID, model.PermissionManageSystem) {
-		res.err = "Forbidden"
-		res.code = http.StatusForbidden
+		res.Err = "Forbidden"
+		res.Code = http.StatusForbidden
 		return
 	}
 
 	channel, appErr := p.API.GetChannel(channelID)
 	if appErr != nil {
-		res.err = appErr.Error()
-		res.code = http.StatusInternalServerError
+		res.Err = appErr.Error()
+		res.Code = http.StatusInternalServerError
 		return
 	}
 
 	cm, appErr := p.API.GetChannelMember(channelID, userID)
 	if appErr != nil {
-		res.err = appErr.Error()
-		res.code = http.StatusInternalServerError
+		res.Err = appErr.Error()
+		res.Code = http.StatusInternalServerError
 		return
 	}
 
 	switch channel.Type {
 	case model.ChannelTypeOpen, model.ChannelTypePrivate:
 		if !cm.SchemeAdmin && !p.API.HasPermissionTo(userID, model.PermissionManageSystem) {
-			res.err = "Forbidden"
-			res.code = http.StatusForbidden
+			res.Err = "Forbidden"
+			res.Code = http.StatusForbidden
 			return
 		}
 	case model.ChannelTypeDirect, model.ChannelTypeGroup:
 		if !p.API.HasPermissionToChannel(userID, channelID, model.PermissionCreatePost) {
-			res.err = "Forbidden"
-			res.code = http.StatusForbidden
+			res.Err = "Forbidden"
+			res.Code = http.StatusForbidden
 			return
 		}
 	}
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		res.err = err.Error()
-		res.code = http.StatusInternalServerError
+		res.Err = err.Error()
+		res.Code = http.StatusInternalServerError
 		return
 	}
 
 	var info ChannelState
 	if err := json.Unmarshal(data, &info); err != nil {
-		res.err = err.Error()
-		res.code = http.StatusBadRequest
+		res.Err = err.Error()
+		res.Code = http.StatusBadRequest
 		return
 	}
 
@@ -244,8 +328,8 @@ func (p *Plugin) handlePostChannel(w http.ResponseWriter, r *http.Request, chann
 		return state, nil
 	}); err != nil {
 		// handle creation case
-		res.err = err.Error()
-		res.code = http.StatusInternalServerError
+		res.Err = err.Error()
+		res.Code = http.StatusInternalServerError
 		return
 	}
 
@@ -265,12 +349,12 @@ func (p *Plugin) handlePostChannel(w http.ResponseWriter, r *http.Request, chann
 
 func (p *Plugin) handleDebug(w http.ResponseWriter, r *http.Request) {
 	var res httpResponse
-	defer p.httpAudit("handleDebug", res, w, r)
+	defer p.httpAudit("handleDebug", &res, w, r)
 
 	userID := r.Header.Get("Mattermost-User-Id")
 	if !p.API.HasPermissionTo(userID, model.PermissionManageSystem) {
-		res.err = "Forbidden"
-		res.code = http.StatusForbidden
+		res.Err = "Forbidden"
+		res.Code = http.StatusForbidden
 		return
 	}
 	if strings.HasPrefix(r.URL.Path, "/debug/pprof/profile") {
@@ -283,8 +367,8 @@ func (p *Plugin) handleDebug(w http.ResponseWriter, r *http.Request) {
 		pprof.Index(w, r)
 		return
 	}
-	res.err = "Not found"
-	res.code = http.StatusNotFound
+	res.Err = "Not found"
+	res.Code = http.StatusNotFound
 }
 
 // handleConfig returns the client configuration, and cloud license information
@@ -366,6 +450,11 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 
 		if matches := chRE.FindStringSubmatch(r.URL.Path); len(matches) == 2 {
 			p.handlePostChannel(w, r, matches[1])
+			return
+		}
+
+		if matches := callEndRE.FindStringSubmatch(r.URL.Path); len(matches) == 2 {
+			p.handleEndCall(w, r, matches[1])
 			return
 		}
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -24,6 +24,7 @@ type Call struct {
 	States          []userState `json:"states,omitempty"`
 	ThreadID        string      `json:"thread_id"`
 	ScreenSharingID string      `json:"screen_sharing_id"`
+	CreatorID       string      `json:"creator_id"`
 }
 
 type ChannelState struct {
@@ -77,6 +78,7 @@ func (p *Plugin) handleGetChannel(w http.ResponseWriter, r *http.Request, channe
 				States:          states,
 				ThreadID:        state.Call.ThreadID,
 				ScreenSharingID: state.Call.ScreenSharingID,
+				CreatorID:       state.Call.CreatorID,
 			}
 		}
 	}
@@ -164,6 +166,7 @@ func (p *Plugin) handleGetAllChannels(w http.ResponseWriter, r *http.Request) {
 					States:          states,
 					ThreadID:        state.Call.ThreadID,
 					ScreenSharingID: state.Call.ScreenSharingID,
+					CreatorID:       state.Call.CreatorID,
 				}
 			}
 			channels = append(channels, info)

--- a/server/api.go
+++ b/server/api.go
@@ -24,7 +24,7 @@ type Call struct {
 	States          []userState `json:"states,omitempty"`
 	ThreadID        string      `json:"thread_id"`
 	ScreenSharingID string      `json:"screen_sharing_id"`
-	CreatorID       string      `json:"creator_id"`
+	OwnerID         string      `json:"owner_id"`
 }
 
 type ChannelState struct {
@@ -78,7 +78,7 @@ func (p *Plugin) handleGetChannel(w http.ResponseWriter, r *http.Request, channe
 				States:          states,
 				ThreadID:        state.Call.ThreadID,
 				ScreenSharingID: state.Call.ScreenSharingID,
-				CreatorID:       state.Call.CreatorID,
+				OwnerID:         state.Call.OwnerID,
 			}
 		}
 	}
@@ -166,7 +166,7 @@ func (p *Plugin) handleGetAllChannels(w http.ResponseWriter, r *http.Request) {
 					States:          states,
 					ThreadID:        state.Call.ThreadID,
 					ScreenSharingID: state.Call.ScreenSharingID,
-					CreatorID:       state.Call.CreatorID,
+					OwnerID:         state.Call.OwnerID,
 				}
 			}
 			channels = append(channels, info)
@@ -206,7 +206,7 @@ func (p *Plugin) handleEndCall(w http.ResponseWriter, r *http.Request, channelID
 		return
 	}
 
-	if !isAdmin && state.Call.CreatorID != userID {
+	if !isAdmin && state.Call.OwnerID != userID {
 		res.Err = "no permissions to end the call"
 		res.Code = http.StatusForbidden
 		return

--- a/server/audit.go
+++ b/server/audit.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 )
 
+// httpResponse holds data returned to API clients.
+// JSON fields are overridden to be compliant with what MM server would return.
 type httpResponse struct {
-	Msg  string `json:"msg,omitempty"`
-	Err  string `json:"err,omitempty"`
-	Code int    `json:"code"`
+	Msg  string `json:"message,omitempty"`
+	Err  string `json:"detailed_error,omitempty"`
+	Code int    `json:"status_code"`
 }
 
 func (p *Plugin) httpAudit(handler string, res *httpResponse, w http.ResponseWriter, r *http.Request) {
@@ -18,6 +20,11 @@ func (p *Plugin) httpAudit(handler string, res *httpResponse, w http.ResponseWri
 		logFields = append(logFields, "error", res.Err, "code", res.Code, "status", "fail")
 	} else {
 		logFields = append(logFields, "status", "success")
+	}
+
+	if res.Err != "" && res.Msg == "" {
+		res.Msg = res.Err
+		res.Err = ""
 	}
 
 	w.Header().Add("Content-Type", "application/json")

--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -20,7 +20,7 @@ type callState struct {
 	EndAt           int64                 `json:"end_at"`
 	Users           map[string]*userState `json:"users,omitempty"`
 	Sessions        map[string]struct{}   `json:"sessions,omitempty"`
-	CreatorID       string                `json:"creator_id"`
+	OwnerID         string                `json:"owner_id"`
 	ThreadID        string                `json:"thread_id"`
 	ScreenSharingID string                `json:"screen_sharing_id"`
 	ScreenStreamID  string                `json:"screen_stream_id"`

--- a/server/cluster_message.go
+++ b/server/cluster_message.go
@@ -22,7 +22,6 @@ const (
 	clusterMessageTypeDisconnect clusterMessageType = "disconnect"
 	clusterMessageTypeSignaling  clusterMessageType = "signaling"
 	clusterMessageTypeUserState  clusterMessageType = "user_state"
-	clusterMessageTypeCallEnded  clusterMessageType = "call_ended"
 )
 
 func (m *clusterMessage) ToJSON() ([]byte, error) {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -233,3 +233,8 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	return p.setConfiguration(cfg)
 }
+
+func (p *Plugin) isHAEnabled() bool {
+	cfg := p.API.GetConfig()
+	return cfg != nil && cfg.ClusterSettings.Enable != nil && *cfg.ClusterSettings.Enable
+}

--- a/server/session.go
+++ b/server/session.go
@@ -46,7 +46,7 @@ func newUserSession(userID, channelID, connID string) *session {
 	}
 }
 
-func (p *Plugin) addUserSession(userID string, channel *model.Channel) (channelState, error) {
+func (p *Plugin) addUserSession(userID, connID string, channel *model.Channel) (channelState, error) {
 	var st channelState
 
 	cfg := p.getConfiguration()
@@ -68,9 +68,11 @@ func (p *Plugin) addUserSession(userID string, channel *model.Channel) (channelS
 
 		if state.Call == nil {
 			state.Call = &callState{
-				ID:      model.NewId(),
-				StartAt: time.Now().UnixMilli(),
-				Users:   make(map[string]*userState),
+				ID:        model.NewId(),
+				StartAt:   time.Now().UnixMilli(),
+				Users:     make(map[string]*userState),
+				Sessions:  make(map[string]struct{}),
+				CreatorID: userID,
 			}
 			state.NodeID = p.nodeID
 
@@ -82,6 +84,10 @@ func (p *Plugin) addUserSession(userID string, channel *model.Channel) (channelS
 				p.LogDebug("rtcd host has been assigned to call", "host", host)
 				state.Call.RTCDHost = host
 			}
+		}
+
+		if state.Call.EndAt > 0 {
+			return nil, fmt.Errorf("call has ended")
 		}
 
 		if _, ok := state.Call.Users[userID]; ok {
@@ -97,6 +103,7 @@ func (p *Plugin) addUserSession(userID string, channel *model.Channel) (channelS
 		}
 
 		state.Call.Users[userID] = &userState{}
+		state.Call.Sessions[connID] = struct{}{}
 		if len(state.Call.Users) > state.Call.Stats.Participants {
 			state.Call.Stats.Participants = len(state.Call.Users)
 		}
@@ -108,7 +115,7 @@ func (p *Plugin) addUserSession(userID string, channel *model.Channel) (channelS
 	return st, err
 }
 
-func (p *Plugin) removeUserSession(userID, channelID string) (channelState, channelState, error) {
+func (p *Plugin) removeUserSession(userID, connID, channelID string) (channelState, channelState, error) {
 	var currState channelState
 	var prevState channelState
 	errNotFound := errors.New("not found")
@@ -133,6 +140,7 @@ func (p *Plugin) removeUserSession(userID, channelID string) (channelState, chan
 		}
 
 		delete(state.Call.Users, userID)
+		delete(state.Call.Sessions, connID)
 
 		if len(state.Call.Users) == 0 {
 			state.Call = nil

--- a/server/session.go
+++ b/server/session.go
@@ -68,11 +68,11 @@ func (p *Plugin) addUserSession(userID, connID string, channel *model.Channel) (
 
 		if state.Call == nil {
 			state.Call = &callState{
-				ID:        model.NewId(),
-				StartAt:   time.Now().UnixMilli(),
-				Users:     make(map[string]*userState),
-				Sessions:  make(map[string]struct{}),
-				CreatorID: userID,
+				ID:       model.NewId(),
+				StartAt:  time.Now().UnixMilli(),
+				Users:    make(map[string]*userState),
+				Sessions: make(map[string]struct{}),
+				OwnerID:  userID,
 			}
 			state.NodeID = p.nodeID
 

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -33,7 +33,7 @@ func getAutocompleteData() *model.AutocompleteData {
 	data.AddCommand(model.NewAutocompleteData(leaveCommandTrigger, "", "Leave a call in the current channel."))
 	data.AddCommand(model.NewAutocompleteData(linkCommandTrigger, "", "Generate a link to join a call in the current channel."))
 	data.AddCommand(model.NewAutocompleteData(statsCommandTrigger, "", "Show client-generated statistics about the call."))
-	data.AddCommand(model.NewAutocompleteData(endCommandTrigger, "", "End the call for everyone. All the participants will drop immediately"))
+	data.AddCommand(model.NewAutocompleteData(endCommandTrigger, "", "End the call for everyone. All the participants will drop immediately."))
 
 	experimentalCmdData := model.NewAutocompleteData(experimentalCommandTrigger, "", "Turns on/off experimental features")
 	experimentalCmdData.AddTextArgument("Available options: on, off", "", "on|off")

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -30,7 +30,7 @@ func getAutocompleteData() *model.AutocompleteData {
 	startCmdData.AddTextArgument("[message]", "Root message for the call", "")
 	data.AddCommand(startCmdData)
 	data.AddCommand(model.NewAutocompleteData(joinCommandTrigger, "", "Joins a call in the current channel"))
-	data.AddCommand(model.NewAutocompleteData(leaveCommandTrigger, "", "Leaves a call in the current channel"))
+	data.AddCommand(model.NewAutocompleteData(leaveCommandTrigger, "", "Leave a call in the current channel."))
 	data.AddCommand(model.NewAutocompleteData(linkCommandTrigger, "", "Generates a link to join a call in the current channel"))
 	data.AddCommand(model.NewAutocompleteData(statsCommandTrigger, "", "Shows some client-generated statistics about the call"))
 	data.AddCommand(model.NewAutocompleteData(endCommandTrigger, "", "End the call for everyone. All the participants will drop immediately"))

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -32,7 +32,7 @@ func getAutocompleteData() *model.AutocompleteData {
 	data.AddCommand(model.NewAutocompleteData(joinCommandTrigger, "", "Joins a call in the current channel"))
 	data.AddCommand(model.NewAutocompleteData(leaveCommandTrigger, "", "Leave a call in the current channel."))
 	data.AddCommand(model.NewAutocompleteData(linkCommandTrigger, "", "Generate a link to join a call in the current channel."))
-	data.AddCommand(model.NewAutocompleteData(statsCommandTrigger, "", "Shows some client-generated statistics about the call"))
+	data.AddCommand(model.NewAutocompleteData(statsCommandTrigger, "", "Show client-generated statistics about the call."))
 	data.AddCommand(model.NewAutocompleteData(endCommandTrigger, "", "End the call for everyone. All the participants will drop immediately"))
 
 	experimentalCmdData := model.NewAutocompleteData(experimentalCommandTrigger, "", "Turns on/off experimental features")

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -31,7 +31,7 @@ func getAutocompleteData() *model.AutocompleteData {
 	data.AddCommand(startCmdData)
 	data.AddCommand(model.NewAutocompleteData(joinCommandTrigger, "", "Joins a call in the current channel"))
 	data.AddCommand(model.NewAutocompleteData(leaveCommandTrigger, "", "Leave a call in the current channel."))
-	data.AddCommand(model.NewAutocompleteData(linkCommandTrigger, "", "Generates a link to join a call in the current channel"))
+	data.AddCommand(model.NewAutocompleteData(linkCommandTrigger, "", "Generate a link to join a call in the current channel."))
 	data.AddCommand(model.NewAutocompleteData(statsCommandTrigger, "", "Shows some client-generated statistics about the call"))
 	data.AddCommand(model.NewAutocompleteData(endCommandTrigger, "", "End the call for everyone. All the participants will drop immediately"))
 

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -35,7 +35,7 @@ func getAutocompleteData() *model.AutocompleteData {
 	data.AddCommand(model.NewAutocompleteData(statsCommandTrigger, "", "Show client-generated statistics about the call."))
 	data.AddCommand(model.NewAutocompleteData(endCommandTrigger, "", "End the call for everyone. All the participants will drop immediately."))
 
-	experimentalCmdData := model.NewAutocompleteData(experimentalCommandTrigger, "", "Turns on/off experimental features")
+	experimentalCmdData := model.NewAutocompleteData(experimentalCommandTrigger, "", "Turn experimental features on or off.")
 	experimentalCmdData.AddTextArgument("Available options: on, off", "", "on|off")
 	data.AddCommand(experimentalCmdData)
 	return data

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -493,15 +493,6 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 				"Duration":     dur,
 				"Participants": prevState.Call.Stats.Participants,
 			})
-
-			if handlerID != p.nodeID && p.rtcdManager == nil {
-				if err := p.sendClusterMessage(clusterMessage{
-					ChannelID: channelID,
-					SenderID:  p.nodeID,
-				}, clusterMessageTypeCallEnded, handlerID); err != nil {
-					p.LogError(err.Error())
-				}
-			}
 		}
 	}
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -372,9 +372,10 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 
 		// TODO: send all the info attached to a call.
 		p.API.PublishWebSocketEvent(wsEventCallStart, map[string]interface{}{
-			"channelID": channelID,
-			"start_at":  state.Call.StartAt,
-			"thread_id": threadID,
+			"channelID":  channelID,
+			"start_at":   state.Call.StartAt,
+			"thread_id":  threadID,
+			"creator_id": state.Call.CreatorID,
 		}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
 	}
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -372,10 +372,10 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 
 		// TODO: send all the info attached to a call.
 		p.API.PublishWebSocketEvent(wsEventCallStart, map[string]interface{}{
-			"channelID":  channelID,
-			"start_at":   state.Call.StartAt,
-			"thread_id":  threadID,
-			"creator_id": state.Call.CreatorID,
+			"channelID": channelID,
+			"start_at":  state.Call.StartAt,
+			"thread_id": threadID,
+			"owner_id":  state.Call.OwnerID,
 		}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
 	}
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -24,6 +24,7 @@ const (
 	wsEventUserScreenOn     = "user_screen_on"
 	wsEventUserScreenOff    = "user_screen_off"
 	wsEventCallStart        = "call_start"
+	wsEventCallEnd          = "call_end"
 	wsEventUserRaiseHand    = "user_raise_hand"
 	wsEventUserUnraiseHand  = "user_unraise_hand"
 	wsEventJoin             = "join"
@@ -350,7 +351,7 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 		close(us.doneCh)
 	}()
 
-	state, err := p.addUserSession(userID, channel)
+	state, err := p.addUserSession(userID, connID, channel)
 	if err != nil {
 		return fmt.Errorf("failed to add user session: %w", err)
 	} else if state.Call == nil {
@@ -459,40 +460,16 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 
 	if state, err := p.kvGetChannelState(channelID); err != nil {
 		p.LogError(err.Error())
-	} else if state.Call != nil && state.Call.ScreenSharingID == userID {
+	} else if state != nil && state.Call != nil && state.Call.ScreenSharingID == userID {
 		p.API.PublishWebSocketEvent(wsEventUserScreenOff, map[string]interface{}{}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
 	}
 
-	if p.rtcServer != nil {
-		if handlerID == p.nodeID {
-			if err := p.rtcServer.CloseSession(us.connID); err != nil {
-				p.LogError(err.Error())
-			}
-		} else {
-			if err := p.sendClusterMessage(clusterMessage{
-				ConnID:    connID,
-				UserID:    userID,
-				ChannelID: channelID,
-				SenderID:  p.nodeID,
-			}, clusterMessageTypeDisconnect, handlerID); err != nil {
-				p.LogError(err.Error())
-			}
-		}
+	if err := p.closeRTCSession(userID, connID, channelID, handlerID); err != nil {
+		p.LogError(err.Error())
 	}
 
 	wg.Wait()
 
-	if p.rtcdManager != nil {
-		msg := rtcd.ClientMessage{
-			Type: rtcd.ClientMessageLeave,
-			Data: map[string]string{
-				"sessionID": connID,
-			},
-		}
-		if err := p.rtcdManager.Send(msg, channelID); err != nil {
-			p.LogError(fmt.Errorf("failed to send client message: %w", err).Error())
-		}
-	}
 	p.API.PublishWebSocketEvent(wsEventUserDisconnected, map[string]interface{}{
 		"userID": userID,
 	}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
@@ -503,7 +480,7 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 	})
 
 	p.LogDebug("removing session from state", "userID", userID)
-	if currState, prevState, err := p.removeUserSession(userID, channelID); err != nil {
+	if currState, prevState, err := p.removeUserSession(userID, connID, channelID); err != nil {
 		p.LogError(err.Error())
 	} else if currState.Call == nil && prevState.Call != nil {
 		// call has ended
@@ -596,4 +573,35 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 		p.LogError("chan is full, dropping ws msg", "type", msg.Type)
 		return
 	}
+}
+
+func (p *Plugin) closeRTCSession(userID, connID, channelID, handlerID string) error {
+	if p.rtcServer != nil {
+		if handlerID == p.nodeID {
+			if err := p.rtcServer.CloseSession(connID); err != nil {
+				return err
+			}
+		} else {
+			if err := p.sendClusterMessage(clusterMessage{
+				ConnID:    connID,
+				UserID:    userID,
+				ChannelID: channelID,
+				SenderID:  p.nodeID,
+			}, clusterMessageTypeDisconnect, handlerID); err != nil {
+				return err
+			}
+		}
+	} else if p.rtcdManager != nil {
+		msg := rtcd.ClientMessage{
+			Type: rtcd.ClientMessageLeave,
+			Data: map[string]string{
+				"sessionID": connID,
+			},
+		}
+		if err := p.rtcdManager.Send(msg, channelID); err != nil {
+			return fmt.Errorf("failed to send client message: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -27,6 +27,8 @@ export const SHOW_SWITCH_CALL_MODAL = pluginId + '_show_switch_call_modal';
 export const HIDE_SWITCH_CALL_MODAL = pluginId + '_hide_switch_call_modal';
 export const SHOW_SCREEN_SOURCE_MODAL = pluginId + '_show_screen_source_modal';
 export const HIDE_SCREEN_SOURCE_MODAL = pluginId + '_hide_screen_source_modal';
+export const SHOW_END_CALL_MODAL = pluginId + '_show_end_call_modal';
+export const HIDE_END_CALL_MODAL = pluginId + '_hide_end_call_modal';
 
 export const RECEIVED_CALLS_CONFIG = pluginId + '_received_calls_config';
 

--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -13,6 +13,7 @@ export const VOICE_CHANNEL_USERS_CONNECTED_STATES = pluginId + '_voice_channel_u
 export const VOICE_CHANNEL_PROFILES_CONNECTED = pluginId + '_voice_channel_profiles_connected';
 export const VOICE_CHANNEL_PROFILE_CONNECTED = pluginId + '_voice_channel_profile_connected';
 export const VOICE_CHANNEL_CALL_START = pluginId + '_voice_channel_call_start';
+export const VOICE_CHANNEL_CALL_END = pluginId + '_voice_channel_call_end';
 export const VOICE_CHANNEL_USER_SCREEN_ON = pluginId + '_voice_channel_screen_on';
 export const VOICE_CHANNEL_USER_SCREEN_OFF = pluginId + '_voice_channel_screen_off';
 export const VOICE_CHANNEL_UNINIT = pluginId + '_voice_channel_uninit';

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -1,4 +1,6 @@
 import {Dispatch} from 'redux';
+import axios from 'axios';
+
 import {ActionFunc, DispatchFunc, GenericAction, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {bindClientFunc} from 'mattermost-redux/actions/helpers';
@@ -30,6 +32,7 @@ import {
     HIDE_SWITCH_CALL_MODAL,
     SHOW_SCREEN_SOURCE_MODAL,
     HIDE_SCREEN_SOURCE_MODAL,
+    HIDE_END_CALL_MODAL,
     RECEIVED_CALLS_CONFIG,
 } from './action_types';
 
@@ -57,6 +60,12 @@ export const showSwitchCallModal = (targetID?: string) => (dispatch: Dispatch<Ge
 export const hideSwitchCallModal = () => (dispatch: Dispatch<GenericAction>) => {
     dispatch({
         type: HIDE_SWITCH_CALL_MODAL,
+    });
+};
+
+export const hideEndCallModal = () => (dispatch: Dispatch<GenericAction>) => {
+    dispatch({
+        type: HIDE_END_CALL_MODAL,
     });
 };
 
@@ -154,4 +163,9 @@ export const requestTrial = () => {
         }
         return {};
     };
+};
+
+export const endCall = (channelID: string) => {
+    return axios.post(`${getPluginPath()}/calls/${channelID}/end`, null,
+        {headers: {'X-Requested-With': 'XMLHttpRequest'}});
 };

--- a/webapp/src/components/end_call_modal/component.scss
+++ b/webapp/src/components/end_call_modal/component.scss
@@ -1,0 +1,42 @@
+%button-end-call-modal {
+  border-radius: 4px;
+  margin: 0 4px;
+  font-weight: 600;
+  padding: 12px 20px;
+
+  color: rgba(var(--center-channel-color-rgb), 0.64);
+}
+
+button.end-call-modal-close {
+  position: absolute;
+  font-size: 24px;
+  color: rgba(var(--center-channel-color-rgb), 0.56);
+  right: 18px;
+  top: 18px;
+  width: 40px;
+  height: 40px;
+
+  &:hover {
+    background: rgba(var(--center-channel-color-rgb), 0.08);
+  }
+}
+
+button.end-call-modal-cancel {
+  @extend %button-end-call-modal;
+  background: rgba(var(--button-bg-rgb), 0.08);
+  color: rgb(var(--button-bg-rgb));
+
+  &:hover {
+    background: rgba(var(--button-bg-rgb), 0.12);
+  }
+}
+
+button.end-call-modal-confirm {
+  @extend %button-end-call-modal;
+  background: rgb(var(--button-bg-rgb));
+  color: rgb(var(--center-channel-bg-rgb));
+
+  &:hover {
+    background: rgba(var(--button-bg-rgb), 0.90);
+  }
+}

--- a/webapp/src/components/end_call_modal/component.tsx
+++ b/webapp/src/components/end_call_modal/component.tsx
@@ -1,0 +1,205 @@
+import React, {CSSProperties} from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+import {Channel} from 'mattermost-redux/types/channels';
+import {UserProfile} from 'mattermost-redux/types/users';
+
+import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
+
+import {isDMChannel, isGMChannel, getUserDisplayName} from '../../utils';
+
+import {endCall} from '../../actions';
+
+import CompassIcon from '../../components/icons/compassIcon';
+
+import './component.scss';
+
+interface Props {
+    theme: any,
+    show: boolean,
+    channel: Channel,
+    connectedDMUser: UserProfile | undefined,
+    connectedUsers: string[],
+    hideEndCallModal: () => void,
+}
+
+interface State {
+    errorMsg: string,
+}
+
+export default class EndCallModal extends React.PureComponent<Props, State> {
+    private node: React.RefObject<HTMLDivElement>;
+    private style = {
+        main: {
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            zIndex: 10000,
+            background: changeOpacity(this.props.theme.centerChannelColor, 0.64),
+        },
+        modal: {
+            position: 'relative',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexDirection: 'column',
+            background: this.props.theme.centerChannelBg,
+            color: this.props.theme.centerChannelColor,
+            borderRadius: '8px',
+            border: `1px solid ${changeOpacity(this.props.theme.centerChannelColor, 0.16)}`,
+            boxShadow: `0px 20px 32px ${changeOpacity(this.props.theme.centerChannelColor, 0.12)}`,
+            width: '512px',
+            padding: '48px 32px',
+        },
+        header: {
+            position: 'relative',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            paddingBottom: '8px',
+        },
+        title: {
+            fontWeight: 600,
+            fontFamily: 'Metropolis',
+            fontSize: '22px',
+            lineHeight: '28px',
+        },
+        body: {
+            textAlign: 'center',
+        },
+        footer: {
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            paddingTop: '32px',
+        },
+        error: {
+            marginTop: '8px',
+            color: this.props.theme.errorTextColor,
+        },
+    };
+
+    constructor(props: Props) {
+        super(props);
+        this.node = React.createRef();
+        this.state = {
+            errorMsg: '',
+        };
+    }
+
+    private keyboardClose = (e: KeyboardEvent) => {
+        if (this.props.show && e.key === 'Escape') {
+            this.hideModal();
+        }
+    }
+
+    private closeOnBlur = (e: Event) => {
+        if (!this.props.show) {
+            return;
+        }
+        if (this.node?.current && e.target && this.node.current.contains(e.target as Node)) {
+            return;
+        }
+        this.hideModal();
+    }
+
+    private endCall = () => {
+        endCall(this.props.channel.id).then(() => {
+            this.hideModal();
+        }).catch((err) => {
+            this.setState({
+                errorMsg: err.response && err.response.data ? err.response.data.err : err.toString(),
+            });
+        });
+    }
+
+    private hideModal = () => {
+        this.setState({errorMsg: ''});
+        this.props.hideEndCallModal();
+    }
+
+    componentDidMount() {
+        document.addEventListener('keyup', this.keyboardClose, true);
+        document.addEventListener('click', this.closeOnBlur, true);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keyup', this.keyboardClose, true);
+        document.removeEventListener('click', this.closeOnBlur, true);
+    }
+
+    render() {
+        if (!this.props.show) {
+            return null;
+        }
+
+        let msg;
+        if (isDMChannel(this.props.channel)) {
+            msg = (<React.Fragment>
+                {'Are you sure you want to end a call with '}
+                <span style={{fontWeight: 600}}>{getUserDisplayName(this.props.connectedDMUser)}</span>
+                {'?'}
+            </React.Fragment>);
+        } else if (isGMChannel(this.props.channel)) {
+            msg = (<React.Fragment>
+                {'Are you sure you want to end a call with '}
+                <span style={{fontWeight: 600}}>{this.props.channel.display_name}</span>
+                {'?'}
+            </React.Fragment>);
+        } else {
+            msg = (<React.Fragment>
+                {`Are you sure you want to end a call with ${this.props.connectedUsers.length} participants in `}
+                <span style={{fontWeight: 600}}>{this.props.channel.display_name}</span>
+                {'?'}
+            </React.Fragment>);
+        }
+
+        return (
+            <div style={this.style.main as CSSProperties}>
+                <div
+                    id='calls-end-call-modal'
+                    style={this.style.modal as CSSProperties}
+                    ref={this.node}
+                >
+                    <button
+                        className='style--none end-call-modal-close'
+                        onClick={this.hideModal}
+                    >
+                        <CompassIcon icon='close'/>
+                    </button>
+                    <div style={this.style.header as CSSProperties}>
+                        <span style={this.style.title}>
+                            {'End call'}
+                        </span>
+                    </div>
+                    <div style={this.style.body as CSSProperties}>
+                        { msg }
+                    </div>
+
+                    { this.state.errorMsg &&
+                    <div style={this.style.error as CSSProperties}>
+                        { `An error has occurred: ${this.state.errorMsg}` }
+                    </div>
+                    }
+
+                    <div style={this.style.footer}>
+                        <button
+                            className='style--none end-call-modal-cancel'
+                            onClick={this.hideModal}
+                        >{'Cancel'}</button>
+                        <button
+                            className='style--none end-call-modal-confirm'
+                            onClick={this.endCall}
+                        >{'End call'}</button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/webapp/src/components/end_call_modal/index.ts
+++ b/webapp/src/components/end_call_modal/index.ts
@@ -1,0 +1,38 @@
+import {bindActionCreators, Dispatch} from 'redux';
+import {connect} from 'react-redux';
+import {GlobalState} from 'mattermost-redux/types/store';
+
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
+
+import {hideEndCallModal} from '../../actions';
+import {voiceConnectedUsersInChannel, endCallModal} from '../../selectors';
+import {isDMChannel, getUserIdFromDM} from '../../utils';
+
+import EndCallModal from './component';
+
+const mapStateToProps = (state: GlobalState) => {
+    const endCallState = endCallModal(state);
+    const connectedUsers = voiceConnectedUsersInChannel(state, endCallState.targetID);
+
+    const channel = getChannel(state, endCallState.targetID);
+
+    let connectedDMUser;
+    if (channel && isDMChannel(channel)) {
+        const otherID = getUserIdFromDM(channel.name, getCurrentUserId(state));
+        connectedDMUser = getUser(state, otherID);
+    }
+
+    return {
+        show: endCallModal(state).show,
+        connectedUsers,
+        connectedDMUser,
+        channel,
+    };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => bindActionCreators({
+    hideEndCallModal,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(EndCallModal);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -71,6 +71,7 @@ import {
     VOICE_CHANNEL_USER_VOICE_OFF,
     VOICE_CHANNEL_USER_VOICE_ON,
     VOICE_CHANNEL_CALL_START,
+    VOICE_CHANNEL_CALL_END,
     VOICE_CHANNEL_USER_SCREEN_ON,
     VOICE_CHANNEL_USER_SCREEN_OFF,
     VOICE_CHANNEL_USER_RAISE_HAND,
@@ -213,6 +214,18 @@ export default class Plugin {
             });
         });
 
+        registry.registerWebSocketEventHandler(`custom_${pluginId}_call_end`, (ev) => {
+            if (connectedChannelID(store.getState()) === ev.broadcast.channel_id && window.callsClient) {
+                window.callsClient.disconnect();
+            }
+            store.dispatch({
+                type: VOICE_CHANNEL_CALL_END,
+                data: {
+                    channelID: ev.broadcast.channel_id,
+                },
+            });
+        });
+
         registry.registerWebSocketEventHandler(`custom_${pluginId}_user_screen_on`, (ev) => {
             store.dispatch({
                 type: VOICE_CHANNEL_USER_SCREEN_ON,
@@ -306,6 +319,10 @@ export default class Plugin {
                     return {};
                 }
                 return {error: {message: 'You are not connected to a call in the current channel.'}};
+
+            case 'end':
+                // TODO: add confirmation dialog or other action to prevent user mistakes.
+                break;
             case 'link':
                 break;
             case 'experimental':

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -40,6 +40,7 @@ import PostType from './components/custom_post_types/post_type';
 import ExpandedView from './components/expanded_view';
 import SwitchCallModal from './components/switch_call_modal';
 import ScreenSourceModal from './components/screen_source_modal';
+import EndCallModal from './components/end_call_modal';
 
 import JoinUserSound from './sounds/join_user.mp3';
 import JoinSelfSound from './sounds/join_self.mp3';
@@ -79,6 +80,7 @@ import {
     VOICE_CHANNEL_UNINIT,
     VOICE_CHANNEL_ROOT_POST,
     SHOW_SWITCH_CALL_MODAL,
+    SHOW_END_CALL_MODAL,
 } from './action_types';
 
 // eslint-disable-next-line import/no-unresolved
@@ -278,6 +280,7 @@ export default class Plugin {
         registry.registerNeedsTeamRoute('/expanded', ExpandedView);
         registry.registerGlobalComponent(SwitchCallModal);
         registry.registerGlobalComponent(ScreenSourceModal);
+        registry.registerGlobalComponent(EndCallModal);
 
         registry.registerSlashCommandWillBePostedHook(async (message, args) => {
             const fullCmd = message.trim();
@@ -319,10 +322,18 @@ export default class Plugin {
                     return {};
                 }
                 return {error: {message: 'You are not connected to a call in the current channel.'}};
-
             case 'end':
-                // TODO: add confirmation dialog or other action to prevent user mistakes.
-                break;
+                if (voiceConnectedUsersInChannel(store.getState(), args.channel_id)?.length === 0) {
+                    return {error: {message: 'No ongoing call in the channel.'}};
+                }
+
+                store.dispatch({
+                    type: SHOW_END_CALL_MODAL,
+                    data: {
+                        targetID: args.channel_id,
+                    },
+                });
+                return {};
             case 'link':
                 break;
             case 'experimental':

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -317,13 +317,13 @@ export default class Plugin {
                     followThread(args.channel_id, args.team_id);
                     return {};
                 }
-                return {error: {message: `You're already connected to a call in the current channel.`}};
+                return {error: {message: 'You\'re already connected to a call in the current channel.'}};
             case 'leave':
                 if (connectedID && args.channel_id === connectedID && window.callsClient) {
                     window.callsClient.disconnect();
                     return {};
                 }
-                return {error: {message: `You're not connected to a call in the current channel.`}};
+                return {error: {message: 'You\'re not connected to a call in the current channel.'}};
             case 'end':
                 if (voiceConnectedUsersInChannel(store.getState(), args.channel_id)?.length === 0) {
                     return {error: {message: 'No ongoing call in the channel.'}};
@@ -331,7 +331,7 @@ export default class Plugin {
 
                 if (!isCurrentUserSystemAdmin(store.getState()) &&
                     getCurrentUserId(store.getState()) !== voiceChannelCallOwnerID(store.getState(), args.channel_id)) {
-                    return {error: {message: `You don't have permission to end the call. Please ask the call owner to end call.`}};
+                    return {error: {message: 'You don\'t have permission to end the call. Please ask the call owner to end call.'}};
                 }
 
                 store.dispatch({
@@ -357,7 +357,7 @@ export default class Plugin {
                 break;
             case 'stats':
                 if (!window.callsClient) {
-                    return {error: {message: `You're not connected to any call`}};
+                    return {error: {message: 'You\'re not connected to any call'}};
                 }
                 try {
                     const stats = await window.callsClient.getStats();

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -323,7 +323,7 @@ export default class Plugin {
                     window.callsClient.disconnect();
                     return {};
                 }
-                return {error: {message: 'You are not connected to a call in the current channel.'}};
+                return {error: {message: 'You're not connected to a call in the current channel.'}};
             case 'end':
                 if (voiceConnectedUsersInChannel(store.getState(), args.channel_id)?.length === 0) {
                     return {error: {message: 'No ongoing call in the channel.'}};

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -19,7 +19,7 @@ import {
     voiceConnectedUsers,
     voiceConnectedUsersInChannel,
     voiceChannelCallStartAt,
-    voiceChannelCallCreatorID,
+    voiceChannelCallOwnerID,
     isCloudFeatureRestricted,
     isCloudLimitRestricted,
     voiceChannelRootPost,
@@ -206,7 +206,7 @@ export default class Plugin {
                 data: {
                     channelID: ev.broadcast.channel_id,
                     startAt: ev.data.start_at,
-                    creatorID: ev.data.creator_id,
+                    ownerID: ev.data.owner_id,
                 },
             });
             store.dispatch({
@@ -317,21 +317,21 @@ export default class Plugin {
                     followThread(args.channel_id, args.team_id);
                     return {};
                 }
-                return {error: {message: 'You are already connected to a call in the current channel.'}};
+                return {error: {message: `You're already connected to a call in the current channel.`}};
             case 'leave':
                 if (connectedID && args.channel_id === connectedID && window.callsClient) {
                     window.callsClient.disconnect();
                     return {};
                 }
-                return {error: {message: 'You're not connected to a call in the current channel.'}};
+                return {error: {message: `You're not connected to a call in the current channel.`}};
             case 'end':
                 if (voiceConnectedUsersInChannel(store.getState(), args.channel_id)?.length === 0) {
                     return {error: {message: 'No ongoing call in the channel.'}};
                 }
 
                 if (!isCurrentUserSystemAdmin(store.getState()) &&
-                    getCurrentUserId(store.getState()) !== voiceChannelCallCreatorID(store.getState(), args.channel_id)) {
-                    return {error: {message: 'You do not have permission to end the call. Please ask the call creator to end call.'}};
+                    getCurrentUserId(store.getState()) !== voiceChannelCallOwnerID(store.getState(), args.channel_id)) {
+                    return {error: {message: `You don't have permission to end the call. Please ask the call owner to end call.`}};
                 }
 
                 store.dispatch({
@@ -357,7 +357,7 @@ export default class Plugin {
                 break;
             case 'stats':
                 if (!window.callsClient) {
-                    return {error: {message: 'You are not connected to any call'}};
+                    return {error: {message: `You're not connected to any call`}};
                 }
                 try {
                     const stats = await window.callsClient.getStats();
@@ -514,7 +514,7 @@ export default class Plugin {
                             data: {
                                 channelID: resp.data[i].channel_id,
                                 startAt: resp.data[i].call?.start_at,
-                                creatorID: resp.data[i].call?.creator_id,
+                                ownerID: resp.data[i].call?.owner_id,
                             },
                         });
                     }

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -371,7 +371,7 @@ const voiceUsersStatuses = (state: usersStatusesState = {}, action: usersStatuse
 interface callState {
     channelID: string,
     startAt: number,
-    creatorID: string,
+    ownerID: string,
 }
 
 interface callStartAction {
@@ -389,7 +389,7 @@ const voiceChannelCalls = (state: {[channelID: string]: callState} = {}, action:
             [action.data.channelID]: {
                 channelID: action.data.channelID,
                 startAt: action.data.startAt,
-                creatorID: action.data.creatorID,
+                ownerID: action.data.ownerID,
             },
         };
     default:

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -18,6 +18,7 @@ import {
     VOICE_CHANNEL_USER_VOICE_ON,
     VOICE_CHANNEL_USER_VOICE_OFF,
     VOICE_CHANNEL_CALL_START,
+    VOICE_CHANNEL_CALL_END,
     VOICE_CHANNEL_USER_SCREEN_ON,
     VOICE_CHANNEL_USER_SCREEN_OFF,
     VOICE_CHANNEL_USER_RAISE_HAND,
@@ -88,6 +89,11 @@ const voiceConnectedProfiles = (state: connectedProfilesState = {}, action: conn
             ...state,
             [action.data.channelID]: state[action.data.channelID]?.filter((val) => val.id !== action.data.userID),
         };
+    case VOICE_CHANNEL_CALL_END:
+        return {
+            ...state,
+            [action.data.channelID]: [],
+        };
     default:
         return state;
     }
@@ -134,6 +140,11 @@ const voiceConnectedChannels = (state: connectedChannelsState = {}, action: conn
             ...state,
             [action.data.channelID]: action.data.users,
         };
+    case VOICE_CHANNEL_CALL_END:
+        return {
+            ...state,
+            [action.data.channelID]: [],
+        };
     default:
         return state;
     }
@@ -150,6 +161,11 @@ const connectedChannelID = (state: string | null = null, action: { type: string,
         return state;
     case VOICE_CHANNEL_USER_DISCONNECTED:
         if (action.data.currentUserID === action.data.userID) {
+            return null;
+        }
+        return state;
+    case VOICE_CHANNEL_CALL_END:
+        if (state === action.data.channelID) {
             return null;
         }
         return state;
@@ -385,6 +401,7 @@ const voiceChannelScreenSharingID = (state: { [channelID: string]: string } = {}
             ...state,
             [action.data.channelID]: action.data.userID,
         };
+    case VOICE_CHANNEL_CALL_END:
     case VOICE_CHANNEL_USER_SCREEN_OFF:
         return {
             ...state,

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -32,6 +32,8 @@ import {
     SHOW_SCREEN_SOURCE_MODAL,
     HIDE_SCREEN_SOURCE_MODAL,
     RECEIVED_CALLS_CONFIG,
+    SHOW_END_CALL_MODAL,
+    HIDE_END_CALL_MODAL,
 } from './action_types';
 
 const isVoiceEnabled = (state = false, action: { type: string }) => {
@@ -441,6 +443,20 @@ const switchCallModal = (state = {
     }
 };
 
+const endCallModal = (state = {
+    show: false,
+    targetID: '',
+}, action: { type: string, data?: { targetID: string } }) => {
+    switch (action.type) {
+    case SHOW_END_CALL_MODAL:
+        return {show: true, targetID: action.data?.targetID};
+    case HIDE_END_CALL_MODAL:
+        return {show: false, targetID: ''};
+    default:
+        return state;
+    }
+};
+
 const screenSourceModal = (state = false, action: { type: string }) => {
     switch (action.type) {
     case VOICE_CHANNEL_UNINIT:
@@ -473,6 +489,7 @@ export default combineReducers({
     voiceChannelScreenSharingID,
     expandedView,
     switchCallModal,
+    endCallModal,
     screenSourceModal,
     voiceChannelRootPost,
     callsConfig,

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -368,14 +368,29 @@ const voiceUsersStatuses = (state: usersStatusesState = {}, action: usersStatuse
     }
 };
 
-const callStartAt = (state: { [channelID: string]: number } = {}, action: { type: string, data: { channelID: string, startAt: number } }) => {
+interface callState {
+    channelID: string,
+    startAt: number,
+    creatorID: string,
+}
+
+interface callStartAction {
+    type: string,
+    data: callState,
+}
+
+const voiceChannelCalls = (state: {[channelID: string]: callState} = {}, action: callStartAction) => {
     switch (action.type) {
     case VOICE_CHANNEL_UNINIT:
         return {};
     case VOICE_CHANNEL_CALL_START:
         return {
             ...state,
-            [action.data.channelID]: action.data.startAt,
+            [action.data.channelID]: {
+                channelID: action.data.channelID,
+                startAt: action.data.startAt,
+                creatorID: action.data.creatorID,
+            },
         };
     default:
         return state;
@@ -485,7 +500,7 @@ export default combineReducers({
     connectedChannelID,
     voiceConnectedProfiles,
     voiceUsersStatuses,
-    callStartAt,
+    voiceChannelCalls,
     voiceChannelScreenSharingID,
     expandedView,
     switchCallModal,

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -61,7 +61,11 @@ export const voiceUsersStatuses = (state: GlobalState) => {
 };
 
 export const voiceChannelCallStartAt = (state: GlobalState, channelID: string) => {
-    return getPluginState(state).callStartAt[channelID];
+    return getPluginState(state).voiceChannelCalls[channelID]?.startAt;
+};
+
+export const voiceChannelCallCreatorID = (state: GlobalState, channelID: string) => {
+    return getPluginState(state).voiceChannelCalls[channelID]?.creatorID;
 };
 
 export const voiceChannelScreenSharingID = (state: GlobalState, channelID: string) => {

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -64,8 +64,8 @@ export const voiceChannelCallStartAt = (state: GlobalState, channelID: string) =
     return getPluginState(state).voiceChannelCalls[channelID]?.startAt;
 };
 
-export const voiceChannelCallCreatorID = (state: GlobalState, channelID: string) => {
-    return getPluginState(state).voiceChannelCalls[channelID]?.creatorID;
+export const voiceChannelCallOwnerID = (state: GlobalState, channelID: string) => {
+    return getPluginState(state).voiceChannelCalls[channelID]?.ownerID;
 };
 
 export const voiceChannelScreenSharingID = (state: GlobalState, channelID: string) => {

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -100,6 +100,10 @@ export const allowEnableCalls: (state: GlobalState) => boolean = createSelector(
     (config) => config.AllowEnableCalls,
 );
 
+export const endCallModal = (state: GlobalState) => {
+    return getPluginState(state).endCallModal;
+};
+
 //
 // Selectors for Cloud and beta limits:
 //


### PR DESCRIPTION
#### Summary

PR introduces a new `/call end` slash command to end a call for all participants. This was made necessary as a way to fix some state issues we've been seeing lately. Originally a `cleanupState` functionality would run during plugin initialization to fix any potentially inconsistent state left by a sudden crash but this created an issue in HA deployments where one plugin instance would overwrite a perfectly healthy state on start up. Now removing the state cleanup call in case of HA deployment and relying on the end call command to fix potentially stuck calls.
 
Permissions wise the command is available to any system admin and to the call creator, meaning the user starting the call (aka the first participant to join).

@abhijit-singh Asking for your review since the PR introduces some minor UI but this shouldn't be considered a proper feature just yet, more like a fail-safe mechanism in case calls get stuck due to server crash or worse.

/cc @tao for visibility

#### Screenshots
![image](https://user-images.githubusercontent.com/1832946/170545657-1af17edd-897e-4e99-a3a9-b69d0ce0b612.png)

#### Private/Public channels

![image](https://user-images.githubusercontent.com/1832946/170542518-0d8746d9-8a19-4918-8214-247caee2b3b2.png)

#### DMs / GMs

![image](https://user-images.githubusercontent.com/1832946/170542632-0af7929c-9a47-49fd-b4a1-eef172dc35b1.png)

#### Error case

![error_end_call](https://user-images.githubusercontent.com/1832946/170542947-43ed3838-be92-41c0-8f83-87bfe80a3b40.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44155
