### PR TITLE
[MM-44560] Review plugin's configuration settings

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -38,7 +38,7 @@
         },
         {
           "key": "DefaultEnabled",
-          "display_name": "Enable on All Channels",
+          "display_name": "Enable on all channels",
           "type": "bool",
           "help_text": "When set to true, calls will be possible in all channels where they are not explicitly disabled.",
           "default": false

--- a/plugin.json
+++ b/plugin.json
@@ -31,7 +31,7 @@
         },
         {
           "key": "AllowEnableCalls",
-          "display_name": "Enable on Specific Channels",
+          "display_name": "Enable on specific channels",
           "type": "bool",
           "help_text": "When set to true, it allows channel admins to enable or disable calls in their channels. It also allows participants of DMs/GMs to enable or disable calls.",
           "default": false

--- a/plugin.json
+++ b/plugin.json
@@ -54,7 +54,7 @@
           "key": "ICEServers",
           "display_name": "ICE Servers",
           "type": "text",
-          "help_text": "(Optional) A comma separated list of ICE servers URLs (STUN/TURN) to use.",
+          "help_text": "(Optional) A comma-separated list of ICE servers' URLs (STUN/TURN) to use.",
           "default": "stun:stun.global.calls.mattermost.com:3478",
           "placeholder": "stun:example.com:3478"
         },

--- a/plugin.json
+++ b/plugin.json
@@ -40,7 +40,7 @@
           "key": "DefaultEnabled",
           "display_name": "Enable on all channels",
           "type": "bool",
-          "help_text": "When set to true, calls will be possible in all channels where they are not explicitly disabled.",
+          "help_text": "When set to true, calls can be started in all channels where they're not explicitly disabled.",
           "default": false
         },
         {

--- a/plugin.json
+++ b/plugin.json
@@ -33,7 +33,7 @@
           "key": "AllowEnableCalls",
           "display_name": "Enable on specific channels",
           "type": "bool",
-          "help_text": "When set to true, it allows channel admins to enable or disable calls in their channels. It also allows participants of DMs/GMs to enable or disable calls.",
+          "help_text": "When set to true, Channel Admins can enable or disable calls in their channels. It also allows participants in DMs/GMs to enable or disable calls.",
           "default": false
         },
         {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "com.mattermost.calls",
-    "name": "Calls",
+    "name": "Calls (Beta)",
     "description": "Integrates real-time voice communication in Mattermost",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
@@ -18,15 +18,9 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "",
+        "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
         "footer": "",
-        "settings": [{
-          "key": "ICEHostOverride",
-          "display_name": "ICE Host Override",
-          "type": "text",
-          "help_text": "The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
-          "default": ""
-        },
+        "settings": [
         {
           "key": "UDPServerPort",
           "display_name": "RTC Server Port",
@@ -36,33 +30,40 @@
           "placeholder": "8443"
         },
         {
-          "key": "RTCDServiceURL",
-          "display_name": "RTCD Service URL",
-          "type": "text",
-          "help_text": "The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
-          "placeholder": "https://rtcd.example.com"
-        },
-        {
-          "key": "ICEServers",
-          "display_name": "ICE Servers",
-          "type": "text",
-          "help_text": "A comma separated list of ICE servers URLs (STUN/TURN) to use.",
-          "default": "stun:stun.global.calls.mattermost.com:3478",
-          "placeholder": "stun:example.com:3478"
-        },
-        {
           "key": "AllowEnableCalls",
-          "display_name": "Allow Enable Calls",
+          "display_name": "Enable on Specific Channels",
           "type": "bool",
           "help_text": "When set to true, it allows channel admins to enable or disable calls in their channels. It also allows participants of DMs/GMs to enable or disable calls.",
           "default": false
         },
         {
           "key": "DefaultEnabled",
-          "display_name": "Default Enabled Calls",
+          "display_name": "Enable on All Channels",
           "type": "bool",
           "help_text": "When set to true, calls will be possible in all channels where they are not explicitly disabled.",
-          "default": true
+          "default": false
+        },
+        {
+          "key": "ICEHostOverride",
+          "display_name": "ICE Host Override",
+          "type": "text",
+          "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+          "default": ""
+        },
+        {
+          "key": "ICEServers",
+          "display_name": "ICE Servers",
+          "type": "text",
+          "help_text": "(Optional) A comma separated list of ICE servers URLs (STUN/TURN) to use.",
+          "default": "stun:stun.global.calls.mattermost.com:3478",
+          "placeholder": "stun:example.com:3478"
+        },
+        {
+          "key": "RTCDServiceURL",
+          "display_name": "RTCD Service URL",
+          "type": "text",
+          "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+          "placeholder": "https://rtcd.example.com"
         }
         ]
     }

--- a/plugin.json
+++ b/plugin.json
@@ -60,7 +60,7 @@
         },
         {
           "key": "RTCDServiceURL",
-          "display_name": "RTCD Service URL",
+          "display_name": "RTCD service URL",
           "type": "text",
           "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
           "placeholder": "https://rtcd.example.com"

--- a/server/activate.go
+++ b/server/activate.go
@@ -53,6 +53,18 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
+	// On Cloud installations we want calls enabled in all channels so we
+	// override it since the plugin's default is now false.
+	if isCloud(p.pluginAPI.System.GetLicense()) {
+		cfg.DefaultEnabled = new(bool)
+		*cfg.DefaultEnabled = true
+		if err := p.setConfiguration(cfg); err != nil {
+			err = fmt.Errorf("failed to set configuration: %w", err)
+			p.LogError(err.Error())
+			return err
+		}
+	}
+
 	if cfg.RTCDServiceURL != "" {
 		rtcdManager, err := p.newRTCDClientManager(cfg.RTCDServiceURL)
 		if err != nil {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -119,7 +119,7 @@ func (c *configuration) SetDefaults() {
 	}
 	if c.DefaultEnabled == nil {
 		c.DefaultEnabled = new(bool)
-		*c.DefaultEnabled = true
+		*c.DefaultEnabled = false
 	}
 }
 


### PR DESCRIPTION
#### Summary

PR reviews Calls plugin's configuration settings:

- Reworked the order and labeling of settings. 
- Prepending `(Optional)` to help text of non mandatory settings.
- Added a header with some description and link to documentation. Please let me know if we should also link on a per-setting basis. 
- Changed the plugin's display name to include the Beta word.
- Calls are now disabled by default unless MM is running on a Cloud license.

Please note that I've purposely deferred adding a setting to configure max participants per call to a follow-up ticket ([MM-44651](https://mattermost.atlassian.net/browse/MM-44651)) as it's a slightly more involved piece of work.

#### Screenshots

![image](https://user-images.githubusercontent.com/1832946/170702910-c8e8dba7-0a05-45fe-bb59-d4cf3a7c30be.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44560