### PR TITLE
Fix rate limit

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -42,7 +42,7 @@ func newUserSession(userID, channelID, connID string) *session {
 		wsCloseCh:   make(chan struct{}),
 		closeCh:     make(chan struct{}),
 		doneCh:      make(chan struct{}),
-		limiter:     rate.NewLimiter(2, 30),
+		limiter:     rate.NewLimiter(2, 50),
 	}
 }
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -545,6 +545,7 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 
 	if us != nil && !us.limiter.Allow() {
 		p.LogError("message was dropped by rate limiter", "msgType", msg.Type, "userID", us.userID, "connID", us.connID)
+		return
 	}
 
 	switch msg.Type {


### PR DESCRIPTION
#### Summary

I forgot a `return` there which was rather important. I was likely testing with and without and erroneously pushed the wrong version. Also bumping the burst size as there were some reports of ice candidates hitting the limit.


