### PR TITLE
[MM-44651] Implement `MaxCallParticipants` config setting

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -47,7 +47,7 @@
           "key": "MaxCallParticipants",
           "display_name": "Max Call Participants",
           "type": "number",
-          "help_text": "The maximum number of participants that can join a call. If left empty it means unlimited.",
+          "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
           "default": 0
         },
         {

--- a/plugin.json
+++ b/plugin.json
@@ -44,6 +44,13 @@
           "default": false
         },
         {
+          "key": "MaxCallParticipants",
+          "display_name": "Max Call Participants",
+          "type": "number",
+          "help_text": "The maximum number of participants that can join a call. If left empty it means unlimited.",
+          "default": 0
+        },
+        {
           "key": "ICEHostOverride",
           "display_name": "ICE Host Override",
           "type": "text",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "com.mattermost.calls",
-    "name": "Calls",
+    "name": "Calls (Beta)",
     "description": "Integrates real-time voice communication in Mattermost",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
@@ -18,15 +18,9 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "",
+        "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
         "footer": "",
-        "settings": [{
-          "key": "ICEHostOverride",
-          "display_name": "ICE Host Override",
-          "type": "text",
-          "help_text": "The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
-          "default": ""
-        },
+        "settings": [
         {
           "key": "UDPServerPort",
           "display_name": "RTC Server Port",
@@ -36,33 +30,40 @@
           "placeholder": "8443"
         },
         {
-          "key": "RTCDServiceURL",
-          "display_name": "RTCD Service URL",
-          "type": "text",
-          "help_text": "The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
-          "placeholder": "https://rtcd.example.com"
-        },
-        {
-          "key": "ICEServers",
-          "display_name": "ICE Servers",
-          "type": "text",
-          "help_text": "A comma separated list of ICE servers URLs (STUN/TURN) to use.",
-          "default": "stun:stun.global.calls.mattermost.com:3478",
-          "placeholder": "stun:example.com:3478"
-        },
-        {
           "key": "AllowEnableCalls",
-          "display_name": "Allow Enable Calls",
+          "display_name": "Enable on Specific Channels",
           "type": "bool",
           "help_text": "When set to true, it allows channel admins to enable or disable calls in their channels. It also allows participants of DMs/GMs to enable or disable calls.",
           "default": false
         },
         {
           "key": "DefaultEnabled",
-          "display_name": "Default Enabled Calls",
+          "display_name": "Enable on All Channels",
           "type": "bool",
           "help_text": "When set to true, calls will be possible in all channels where they are not explicitly disabled.",
-          "default": true
+          "default": false
+        },
+        {
+          "key": "ICEHostOverride",
+          "display_name": "ICE Host Override",
+          "type": "text",
+          "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+          "default": ""
+        },
+        {
+          "key": "ICEServers",
+          "display_name": "ICE Servers",
+          "type": "text",
+          "help_text": "(Optional) A comma separated list of ICE servers URLs (STUN/TURN) to use.",
+          "default": "stun:stun.global.calls.mattermost.com:3478",
+          "placeholder": "stun:example.com:3478"
+        },
+        {
+          "key": "RTCDServiceURL",
+          "display_name": "RTCD Service URL",
+          "type": "text",
+          "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+          "placeholder": "https://rtcd.example.com"
         }
         ]
     }

--- a/server/activate.go
+++ b/server/activate.go
@@ -53,6 +53,18 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
+	// On Cloud installations we want calls enabled in all channels so we
+	// override it since the plugin's default is now false.
+	if isCloud(p.pluginAPI.System.GetLicense()) {
+		cfg.DefaultEnabled = new(bool)
+		*cfg.DefaultEnabled = true
+		if err := p.setConfiguration(cfg); err != nil {
+			err = fmt.Errorf("failed to set configuration: %w", err)
+			p.LogError(err.Error())
+			return err
+		}
+	}
+
 	if cfg.RTCDServiceURL != "" {
 		rtcdManager, err := p.newRTCDClientManager(cfg.RTCDServiceURL)
 		if err != nil {

--- a/server/activate.go
+++ b/server/activate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/mattermost/rtcd/service/rtc"
@@ -40,29 +39,6 @@ func (p *Plugin) OnActivate() error {
 
 	cfg := p.getConfiguration()
 	if err := cfg.IsValid(); err != nil {
-		p.LogError(err.Error())
-		return err
-	}
-
-	if isCloud(p.pluginAPI.System.GetLicense()) {
-		cfg.MaxCallParticipants = new(int)
-		*cfg.MaxCallParticipants = cloudMaxParticipantsDefault
-		// On Cloud installations we want calls enabled in all channels so we
-		// override it since the plugin's default is now false.
-		cfg.DefaultEnabled = new(bool)
-		*cfg.DefaultEnabled = true
-	}
-
-	if maxPart := os.Getenv("MM_CALLS_MAX_PARTICIPANTS"); maxPart != "" {
-		if max, err := strconv.Atoi(maxPart); err == nil {
-			*cfg.MaxCallParticipants = max
-		} else {
-			p.LogError("activate", "failed to parse MM_CALLS_MAX_PARTICIPANTS", err.Error())
-		}
-	}
-
-	if err := p.setConfiguration(cfg); err != nil {
-		err = fmt.Errorf("failed to set configuration: %w", err)
 		p.LogError(err.Error())
 		return err
 	}

--- a/server/activate.go
+++ b/server/activate.go
@@ -44,26 +44,27 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
-	// On Cloud installations we want calls enabled in all channels so we
-	// override it since the plugin's default is now false.
 	if isCloud(p.pluginAPI.System.GetLicense()) {
 		cfg.MaxCallParticipants = new(int)
 		*cfg.MaxCallParticipants = cloudMaxParticipantsDefault
-		if maxPart := os.Getenv("MM_CALLS_MAX_PARTICIPANTS"); maxPart != "" {
-			if max, err := strconv.Atoi(maxPart); err == nil {
-				*cfg.MaxCallParticipants = max
-			} else {
-				p.LogError("activate", "failed to parse MM_CALLS_MAX_PARTICIPANTS", err.Error())
-			}
-		}
-
+		// On Cloud installations we want calls enabled in all channels so we
+		// override it since the plugin's default is now false.
 		cfg.DefaultEnabled = new(bool)
 		*cfg.DefaultEnabled = true
-		if err := p.setConfiguration(cfg); err != nil {
-			err = fmt.Errorf("failed to set configuration: %w", err)
-			p.LogError(err.Error())
-			return err
+	}
+
+	if maxPart := os.Getenv("MM_CALLS_MAX_PARTICIPANTS"); maxPart != "" {
+		if max, err := strconv.Atoi(maxPart); err == nil {
+			*cfg.MaxCallParticipants = max
+		} else {
+			p.LogError("activate", "failed to parse MM_CALLS_MAX_PARTICIPANTS", err.Error())
 		}
+	}
+
+	if err := p.setConfiguration(cfg); err != nil {
+		err = fmt.Errorf("failed to set configuration: %w", err)
+		p.LogError(err.Error())
+		return err
 	}
 
 	if cfg.RTCDServiceURL != "" {

--- a/server/api.go
+++ b/server/api.go
@@ -298,13 +298,11 @@ func (p *Plugin) handleConfig(w http.ResponseWriter) error {
 
 	type config struct {
 		clientConfig
-		SkuShortName         string `json:"sku_short_name"`
-		CloudMaxParticipants int    `json:"cloud_max_participants"`
+		SkuShortName string `json:"sku_short_name"`
 	}
 	ret := config{
-		clientConfig:         p.getConfiguration().getClientConfig(),
-		SkuShortName:         skuShortName,
-		CloudMaxParticipants: cloudMaxParticipants,
+		clientConfig: p.getConfiguration().getClientConfig(),
+		SkuShortName: skuShortName,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/cloud_limits.go
+++ b/server/cloud_limits.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 )
 
-// cloudMaxParticipantsDefault is set to 8, can be overridden by setting the env variable
-// MM_CALLS_CLOUD_MAX_PARTICIPANTS
+// cloudMaxParticipantsDefault is set to 8.
+// The value used can be overridden by setting the MM_CLOUD_MAX_PARTICIPANTS env variable.
+
 const (
 	cloudMaxParticipantsDefault     = 8
 	maxAdminsToQueryForNotification = 25

--- a/server/cloud_limits.go
+++ b/server/cloud_limits.go
@@ -8,7 +8,7 @@ import (
 )
 
 // cloudMaxParticipantsDefault is set to 8.
-// The value used can be overridden by setting the MM_CLOUD_MAX_PARTICIPANTS env variable.
+// The value used can be overridden by setting the MM_CALLS_MAX_PARTICIPANTS env variable.
 
 const (
 	cloudMaxParticipantsDefault     = 8

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -257,7 +257,7 @@ func (p *Plugin) OnConfigurationChange() error {
 		} else {
 			p.LogError("setOverrides", "failed to parse MM_CALLS_MAX_PARTICIPANTS", err.Error())
 		}
-	} else if clusterID := os.Getenv("MM_INSTALLATION_ID"); clusterID != "" {
+	} else if license := p.pluginAPI.System.GetLicense(); license != nil && isCloud(license) {
 		// otherwise, if this is a cloud installation, set it at the default
 		*cfg.MaxCallParticipants = cloudMaxParticipantsDefault
 	}
@@ -266,8 +266,7 @@ func (p *Plugin) OnConfigurationChange() error {
 }
 
 func (p *Plugin) setOverrides(cfg *configuration) {
-	// if MM_INSTALLATION_ID is set, this is cloud
-	if clusterID := os.Getenv("MM_INSTALLATION_ID"); clusterID != "" {
+	if license := p.API.GetLicense(); license != nil && isCloud(license) {
 		*cfg.MaxCallParticipants = cloudMaxParticipantsDefault
 		// On Cloud installations we want calls enabled in all channels so we
 		// override it since the plugin's default is now false.

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -119,7 +119,7 @@ func (c *configuration) SetDefaults() {
 	}
 	if c.DefaultEnabled == nil {
 		c.DefaultEnabled = new(bool)
-		*c.DefaultEnabled = true
+		*c.DefaultEnabled = false
 	}
 }
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -41,6 +41,9 @@ type clientConfig struct {
 	AllowEnableCalls *bool
 	// When set to true, calls will be possible in all channels where they are not explicitly disabled.
 	DefaultEnabled *bool
+	// The maximum number of participants that can join a call. The zero value
+	// means unlimited.
+	MaxCallParticipants *int
 }
 
 type ICEServers []string
@@ -104,9 +107,10 @@ func (pr PortsRange) IsValid() error {
 
 func (c *configuration) getClientConfig() clientConfig {
 	return clientConfig{
-		AllowEnableCalls: c.AllowEnableCalls,
-		DefaultEnabled:   c.DefaultEnabled,
-		ICEServers:       c.ICEServers,
+		AllowEnableCalls:    c.AllowEnableCalls,
+		DefaultEnabled:      c.DefaultEnabled,
+		ICEServers:          c.ICEServers,
+		MaxCallParticipants: c.MaxCallParticipants,
 	}
 }
 
@@ -119,7 +123,9 @@ func (c *configuration) SetDefaults() {
 	}
 	if c.DefaultEnabled == nil {
 		c.DefaultEnabled = new(bool)
-		*c.DefaultEnabled = false
+	}
+	if c.MaxCallParticipants == nil {
+		c.MaxCallParticipants = new(int)
 	}
 }
 
@@ -130,6 +136,10 @@ func (c *configuration) IsValid() error {
 
 	if *c.UDPServerPort < 1024 || *c.UDPServerPort > 49151 {
 		return fmt.Errorf("UDPServerPort is not valid: %d is not in allowed range [1024, 49151]", *c.UDPServerPort)
+	}
+
+	if c.MaxCallParticipants == nil || *c.MaxCallParticipants < 0 {
+		return fmt.Errorf("MaxCallParticipants is not valid")
 	}
 
 	return nil
@@ -160,6 +170,10 @@ func (c *configuration) Clone() *configuration {
 		for i, u := range c.ICEServers {
 			cfg.ICEServers[i] = u
 		}
+	}
+
+	if c.MaxCallParticipants != nil {
+		cfg.MaxCallParticipants = model.NewInt(*c.MaxCallParticipants)
 	}
 
 	return &cfg

--- a/server/session.go
+++ b/server/session.go
@@ -91,9 +91,9 @@ func (p *Plugin) addUserSession(userID string, channel *model.Channel) (channelS
 		// Check for cloud limits -- needs to be done here to prevent a race condition
 		if allowed, err := p.joinAllowed(channel, state); !allowed {
 			if err != nil {
-				p.LogError("error checking for cloud limits", "error", err.Error())
+				p.LogError("joinAllowed failed", "error", err.Error())
 			}
-			return nil, fmt.Errorf("user cannot join because of cloud limits")
+			return nil, fmt.Errorf("user cannot join because of limits")
 		}
 
 		state.Call.Users[userID] = &userState{}
@@ -157,4 +157,29 @@ func (p *Plugin) removeUserSession(userID, channelID string) (channelState, chan
 	}
 
 	return currState, prevState, err
+}
+
+// JoinAllowed returns true if the user is allowed to join the call, taking into
+// account cloud and configuration limits
+func (p *Plugin) joinAllowed(channel *model.Channel, state *channelState) (bool, error) {
+	// Rules are:
+	// On-prem, Cloud Professional & Cloud Enterprise: DMs 1-1, GMs and Channel calls
+	// limited to cfg.MaxCallParticipants people.
+	// Cloud Starter: DMs 1-1 only
+
+	if cfg := p.getConfiguration(); cfg != nil && cfg.MaxCallParticipants != nil &&
+		*cfg.MaxCallParticipants != 0 && len(state.Call.Users) >= *cfg.MaxCallParticipants {
+		return false, nil
+	}
+
+	license := p.pluginAPI.System.GetLicense()
+	if !isCloud(license) {
+		return true, nil
+	}
+
+	if isCloudStarter(license) {
+		return channel.Type == model.ChannelTypeDirect, nil
+	}
+
+	return true, nil
 }

--- a/webapp/src/components/channel_call_toast/component.tsx
+++ b/webapp/src/components/channel_call_toast/component.tsx
@@ -13,7 +13,7 @@ interface Props {
     startAt?: number,
     pictures: string[],
     profiles: UserProfile[],
-    isCloudLimitRestricted: boolean,
+    isLimitRestricted: boolean,
 }
 
 interface State {
@@ -58,7 +58,7 @@ export default class ChannelCallToast extends React.PureComponent<Props, State> 
     }
 
     render() {
-        if (!this.props.hasCall || this.state.hidden || this.props.isCloudLimitRestricted) {
+        if (!this.props.hasCall || this.state.hidden || this.props.isLimitRestricted) {
             return null;
         }
 

--- a/webapp/src/components/channel_call_toast/index.js
+++ b/webapp/src/components/channel_call_toast/index.js
@@ -9,7 +9,7 @@ import {
     voiceConnectedProfilesInChannel,
     connectedChannelID,
     voiceChannelCallStartAt,
-    isCloudLimitRestricted,
+    isLimitRestricted,
 } from 'selectors';
 
 import ChannelCallToast from './component';
@@ -39,7 +39,7 @@ const mapStateToProps = (state) => {
         startAt: voiceChannelCallStartAt(state, currentID),
         pictures,
         profiles,
-        isCloudLimitRestricted: isCloudLimitRestricted(state),
+        isLimitRestricted: isLimitRestricted(state),
     };
 };
 

--- a/webapp/src/components/channel_header_button/component.tsx
+++ b/webapp/src/components/channel_header_button/component.tsx
@@ -12,8 +12,9 @@ interface Props {
     inCall: boolean,
     hasCall: boolean,
     isCloudFeatureRestricted: boolean,
-    isCloudLimitRestricted: boolean,
-    cloudMaxParticipants: number,
+    isCloudPaid: boolean,
+    isLimitRestricted: boolean,
+    maxParticipants: number,
 }
 
 const ChannelHeaderButton = ({
@@ -21,19 +22,22 @@ const ChannelHeaderButton = ({
     inCall,
     hasCall,
     isCloudFeatureRestricted,
-    isCloudLimitRestricted,
-    cloudMaxParticipants,
+    isCloudPaid,
+    isLimitRestricted,
+    maxParticipants,
 }: Props) => {
     if (!show) {
         return null;
     }
-    const restricted = isCloudFeatureRestricted || isCloudLimitRestricted;
+
+    const restricted = isLimitRestricted || isCloudFeatureRestricted;
 
     const button = (
         <CallButton
             id='calls-join-button'
             className={'style--none call-button ' + (inCall || restricted ? 'disabled' : '')}
             restricted={restricted}
+            isCloudPaid={isCloudPaid}
         >
             <CompassIcon icon='phone-outline'/>
             <span className='call-button-label'>
@@ -65,18 +69,21 @@ const ChannelHeaderButton = ({
         );
     }
 
-    if (isCloudLimitRestricted && !inCall) {
+    if (isLimitRestricted && !inCall) {
         return (
             <OverlayTrigger
                 placement='bottom'
                 overlay={
                     <Tooltip id='tooltip-limit-header'>
                         <Header>
-                            {`There's a limit of ${cloudMaxParticipants} participants per call.`}
+                            {`There's a limit of ${maxParticipants} participants per call.`}
                         </Header>
+
+                        {isCloudPaid &&
                         <SubHeader>
                             {'This is because calls is currently in beta. We’re working to remove this limit soon.'}
                         </SubHeader>
+                        }
                     </Tooltip>
                 }
             >
@@ -88,7 +95,7 @@ const ChannelHeaderButton = ({
     return button;
 };
 
-const CallButton = styled.button<{ restricted: boolean }>`
+const CallButton = styled.button<{ restricted: boolean, isCloudPaid: boolean }>`
     // &&& is to override the call-button styles
     &&& {
         ${(props) => props.restricted && css`
@@ -96,6 +103,9 @@ const CallButton = styled.button<{ restricted: boolean }>`
             border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
             cursor: pointer;
             margin-right: 4px;
+        `}
+        ${(props) => props.isCloudPaid && css`
+            cursor: not-allowed;
         `}
     }
 `;

--- a/webapp/src/components/channel_header_button/component.tsx
+++ b/webapp/src/components/channel_header_button/component.tsx
@@ -101,12 +101,9 @@ const CallButton = styled.button<{ restricted: boolean, isCloudPaid: boolean }>`
         ${(props) => props.restricted && css`
             color: rgba(var(--center-channel-color-rgb), 0.48);
             border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
-            cursor: pointer;
             margin-right: 4px;
         `}
-        ${(props) => props.isCloudPaid && css`
-            cursor: not-allowed;
-        `}
+        cursor: ${(props) => (props.restricted && props.isCloudPaid ? 'not-allowed' : 'pointer')};
     }
 `;
 

--- a/webapp/src/components/channel_header_button/index.ts
+++ b/webapp/src/components/channel_header_button/index.ts
@@ -8,8 +8,9 @@ import {
     connectedChannelID,
     isVoiceEnabled,
     isCloudFeatureRestricted,
-    isCloudLimitRestricted,
-    cloudMaxParticipants,
+    isCloudProfessionalOrEnterprise,
+    isLimitRestricted,
+    maxParticipants,
 } from 'src/selectors';
 
 import ChannelHeaderButton from './component';
@@ -19,8 +20,9 @@ const mapStateToProps = (state: GlobalState) => ({
     inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
     hasCall: voiceConnectedUsers(state).length > 0,
     isCloudFeatureRestricted: isCloudFeatureRestricted(state),
-    isCloudLimitRestricted: isCloudLimitRestricted(state),
-    cloudMaxParticipants: cloudMaxParticipants(state),
+    isCloudPaid: isCloudProfessionalOrEnterprise(state),
+    isLimitRestricted: isLimitRestricted(state),
+    maxParticipants: maxParticipants(state),
 });
 
 export default connect(mapStateToProps)(ChannelHeaderButton);

--- a/webapp/src/components/channel_header_dropdown_button/component.tsx
+++ b/webapp/src/components/channel_header_dropdown_button/component.tsx
@@ -12,8 +12,9 @@ interface Props {
     inCall: boolean,
     hasCall: boolean,
     isCloudFeatureRestricted: boolean,
-    isCloudLimitRestricted: boolean,
-    cloudMaxParticipants: number,
+    isCloudPaid: boolean,
+    isLimitRestricted: boolean,
+    maxParticipants: number,
 }
 
 const ChannelHeaderDropdownButton = ({
@@ -21,13 +22,15 @@ const ChannelHeaderDropdownButton = ({
     inCall,
     hasCall,
     isCloudFeatureRestricted,
-    isCloudLimitRestricted,
-    cloudMaxParticipants,
+    isCloudPaid,
+    isLimitRestricted,
+    maxParticipants,
 }: Props) => {
     if (!show) {
         return null;
     }
-    const restricted = isCloudFeatureRestricted || isCloudLimitRestricted;
+    const restricted = isLimitRestricted || isCloudFeatureRestricted;
+    const isCloudLimitRestricted = isCloudPaid && isLimitRestricted;
     const withUpsellIcon = isCloudFeatureRestricted || (isCloudLimitRestricted && !inCall);
 
     const button = (
@@ -71,18 +74,21 @@ const ChannelHeaderDropdownButton = ({
         );
     }
 
-    if (isCloudLimitRestricted && !inCall) {
+    if (isLimitRestricted && !inCall) {
         return (
             <OverlayTrigger
                 placement='bottom'
                 overlay={
                     <Tooltip id='tooltip-limit-header'>
                         <Header>
-                            {`There's a limit of ${cloudMaxParticipants} participants per call.`}
+                            {`There's a limit of ${maxParticipants} participants per call.`}
                         </Header>
+
+                        {isCloudPaid &&
                         <SubHeader>
                             {'This is because calls is currently in beta. We’re working to remove this limit soon.'}
                         </SubHeader>
+                        }
                     </Tooltip>
                 }
             >

--- a/webapp/src/components/channel_header_dropdown_button/index.ts
+++ b/webapp/src/components/channel_header_dropdown_button/index.ts
@@ -8,8 +8,9 @@ import {
     connectedChannelID,
     isVoiceEnabled,
     isCloudFeatureRestricted,
-    isCloudLimitRestricted,
-    cloudMaxParticipants,
+    isCloudProfessionalOrEnterprise,
+    isLimitRestricted,
+    maxParticipants,
 } from 'src/selectors';
 
 import ChannelHeaderDropdownButton from './component';
@@ -19,8 +20,9 @@ const mapStateToProps = (state: GlobalState) => ({
     inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
     hasCall: voiceConnectedUsers(state).length > 0,
     isCloudFeatureRestricted: isCloudFeatureRestricted(state),
-    isCloudLimitRestricted: isCloudLimitRestricted(state),
-    cloudMaxParticipants: cloudMaxParticipants(state),
+    isCloudPaid: isCloudProfessionalOrEnterprise(state),
+    isLimitRestricted: isLimitRestricted(state),
+    maxParticipants: maxParticipants(state),
 });
 
 export default connect(mapStateToProps)(ChannelHeaderDropdownButton);

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -20,7 +20,7 @@ interface Props {
     profiles: UserProfile[],
     showSwitchCallModal: (targetID: string) => void,
     isCloudPaid: boolean,
-    cloudMaxParticipants: number,
+    maxParticipants: number,
 }
 
 const PostType = ({
@@ -30,7 +30,7 @@ const PostType = ({
     profiles,
     showSwitchCallModal,
     isCloudPaid,
-    cloudMaxParticipants,
+    maxParticipants,
 }: Props) => {
     const onJoinCallClick = () => {
         if (connectedID) {
@@ -67,19 +67,21 @@ const PostType = ({
         </JoinButton>
     );
 
-    // Note: don't use isCloudLimitRestricted because that uses current channel, and this post could be in RHS
-    if (isCloudPaid && profiles.length >= cloudMaxParticipants) {
+    // Note: don't use isLimitRestricted because that uses current channel, and this post could be in RHS
+    if (maxParticipants > 0 && profiles.length >= maxParticipants) {
         joinButton = (
             <OverlayTrigger
                 placement='top'
                 overlay={
                     <Tooltip id='tooltip-limit'>
                         <Header>
-                            {`Sorry, participants per call are currently limited to ${cloudMaxParticipants}.`}
+                            {`Sorry, participants per call are currently limited to ${maxParticipants}.`}
                         </Header>
+                        { isCloudPaid &&
                         <SubHeader>
                             {'This is because Calls is in the Beta phase. We’re working to remove this limit soon.'}
                         </SubHeader>
+                        }
                     </Tooltip>
                 }
             >

--- a/webapp/src/components/custom_post_types/post_type/index.ts
+++ b/webapp/src/components/custom_post_types/post_type/index.ts
@@ -10,7 +10,7 @@ import {
     voiceConnectedProfilesInChannel,
     connectedChannelID,
     isCloudProfessionalOrEnterprise,
-    cloudMaxParticipants,
+    maxParticipants,
 } from 'src/selectors';
 import {showSwitchCallModal} from 'src/actions';
 
@@ -40,7 +40,7 @@ const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
         pictures,
         profiles,
         isCloudPaid: isCloudProfessionalOrEnterprise(state),
-        cloudMaxParticipants: cloudMaxParticipants(state),
+        maxParticipants: maxParticipants(state),
     };
 };
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -21,7 +21,7 @@ import {
     voiceConnectedUsersInChannel,
     voiceChannelCallStartAt,
     isCloudFeatureRestricted,
-    isCloudLimitRestricted,
+    isLimitRestricted,
     voiceChannelRootPost,
     allowEnableCalls,
     iceServers,
@@ -361,7 +361,7 @@ export default class Plugin {
                         return;
                     }
 
-                    if (isCloudLimitRestricted(store.getState())) {
+                    if (isLimitRestricted(store.getState())) {
                         return;
                     }
 

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -100,6 +100,19 @@ export const allowEnableCalls: (state: GlobalState) => boolean = createSelector(
     (config) => config.AllowEnableCalls,
 );
 
+export const maxParticipants: (state: GlobalState) => number = createSelector(
+    'maxParticipants',
+    callsConfig,
+    (config) => config.MaxCallParticipants,
+);
+
+export const isLimitRestricted: (state: GlobalState) => boolean = createSelector(
+    'isLimitRestricted',
+    numCurrentVoiceConnectedUsers,
+    maxParticipants,
+    (numCurrentUsers, max) => max > 0 && numCurrentUsers >= max,
+);
+
 //
 // Selectors for Cloud and beta limits:
 //
@@ -107,12 +120,6 @@ const cloudSku: (state: GlobalState) => string = createSelector(
     'cloudSku',
     callsConfig,
     (config) => config.sku_short_name,
-);
-
-export const cloudMaxParticipants: (state: GlobalState) => number = createSelector(
-    'cloudMaxParticipants',
-    callsConfig,
-    (config) => config.cloud_max_participants,
 );
 
 export const isCloud: (state: GlobalState) => boolean = createSelector(
@@ -155,15 +162,6 @@ export const isCloudFeatureRestricted: (state: GlobalState) => boolean = createS
     isCloudStarter,
     getCurrentChannel,
     (isStarter, channel) => isStarter && !isDMChannel(channel),
-);
-
-// isCloudLimitRestricted means: are you restricted from joining a call because of our beta limits?
-export const isCloudLimitRestricted: (state: GlobalState) => boolean = createSelector(
-    'isCloudLimitRestricted',
-    isCloudProfessionalOrEnterprise,
-    numCurrentVoiceConnectedUsers,
-    cloudMaxParticipants,
-    (isCloudPaid, numCurrentUsers, maxParticipants) => isCloudPaid && numCurrentUsers >= maxParticipants,
 );
 
 const getSubscription = (state: GlobalState) => {

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -58,16 +58,16 @@ export type CallsConfig = {
     ICEServers: string[],
     AllowEnableCalls: boolean,
     DefaultEnabled: boolean,
+    MaxCallParticipants: number,
     sku_short_name: string,
-    cloud_max_participants: number,
 }
 
 export const CallsConfigDefault = {
     ICEServers: [],
     AllowEnableCalls: false,
     DefaultEnabled: false,
+    MaxCallParticipants: 0,
     sku_short_name: '',
-    cloud_max_participants: 0,
 } as CallsConfig;
 
 export type CallsClientConfig = {


### PR DESCRIPTION
#### Summary

PR implements a new `MaxCallParticipants` config setting to optionally limit the maximum number of participants in calls.

- For on-prem the default is 0 meaning unlimited. 
- For Cloud the default is 8. 

Config value can be also be overridden through the `MM_CALLS_MAX_PARTICIPANTS` environment variable if needed.

@cpoile I made various changes to the logic to avoid having two values for essentially the same thing. It would be great if you could do some QA on this to make sure I haven't missed anything.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44651