### PR TITLE
[MM-44739] Remove border from avatars in expanded/popout participants list view

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -321,6 +321,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                     <Avatar
                         size={24}
                         fontSize={10}
+                        border={false}
                         url={this.props.pictures[profile.id]}
                         style={{
                             boxShadow: isSpeaking ? '0px 0px 4px 4px rgba(61, 184, 135, 0.8)' : '',


### PR DESCRIPTION
#### Summary

Removing the unexpected border from the avatar in expanded view's participants list.

#### Screenshots

Before:

![image](https://user-images.githubusercontent.com/1832946/171835661-69e36dad-29f3-4002-844c-635900c96ac6.png)

After:

![image](https://user-images.githubusercontent.com/1832946/171835588-df151f7e-f4d7-440f-8af5-d29984e23773.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44739
