### PR TITLE
[MM-44682] Follow thread on start event to avoid missing the root id

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -98,7 +98,7 @@ export default class Plugin {
         this.unsubscribers.push(() => registry.unregisterReconnectHandler(handler));
     }
 
-    private registerWebSocketEvents(registry: PluginRegistry, store: Store) {
+    private registerWebSocketEvents(registry: PluginRegistry, store: Store, followThread: (channelID: string, teamID: string) => Promise<void>) {
         registry.registerWebSocketEventHandler(`custom_${pluginId}_channel_enable_voice`, (data) => {
             store.dispatch({
                 type: VOICE_CHANNEL_ENABLE,
@@ -214,6 +214,9 @@ export default class Plugin {
                     rootPost: ev.data.thread_id,
                 },
             });
+
+            const channel = getChannel(store.getState(), ev.broadcast.channel_id);
+            followThread(channel?.id, channel?.team_id);
         });
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_user_screen_on`, (ev) => {
@@ -383,7 +386,12 @@ export default class Plugin {
 
                     if (!connectedChannelID(store.getState())) {
                         connectCall(channel.id);
-                        followThread(channel.id, channel.team_id);
+
+                        // following the thread only on join. On call start
+                        // this is done in the call_start ws event handler.
+                        if (voiceConnectedUsersInChannel(store.getState(), channel.id).length > 0) {
+                            followThread(channel.id, channel.team_id);
+                        }
                     } else if (connectedChannelID(store.getState()) !== channel.id) {
                         store.dispatch({
                             type: SHOW_SWITCH_CALL_MODAL,
@@ -618,7 +626,7 @@ export default class Plugin {
             });
         });
 
-        this.registerWebSocketEvents(registry, store);
+        this.registerWebSocketEvents(registry, store, followThread);
         this.registerReconnectHandler(registry, store, () => {
             logDebug('websocket reconnect handler');
             if (!window.callsClient) {


### PR DESCRIPTION
#### Summary

`followThread` could fail with `Unable to follow call's thread, not registered in store` on call start due to the thread id not being set yet. Fixing this by calling it once we get the `call_start` event that has that information.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44682
