### PR TITLE
[MM-44894] Check rtcd URL override prior to activation

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -73,8 +73,8 @@ func (p *Plugin) OnActivate() error {
 		}
 	}
 
-	if cfg.RTCDServiceURL != "" && p.licenseChecker.RTCDAllowed() {
-		rtcdManager, err := p.newRTCDClientManager(cfg.RTCDServiceURL)
+	if rtcdURL := cfg.getRTCDURL(); rtcdURL != "" && p.licenseChecker.RTCDAllowed() {
+		rtcdManager, err := p.newRTCDClientManager(rtcdURL)
 		if err != nil {
 			err = fmt.Errorf("failed to create rtcd manager: %w", err)
 			p.LogError(err.Error())

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -166,6 +167,13 @@ func (c *configuration) Clone() *configuration {
 	}
 
 	return &cfg
+}
+
+func (c *configuration) getRTCDURL() string {
+	if url := os.Getenv("MM_CALLS_RTCD_URL"); url != "" {
+		return url
+	}
+	return c.RTCDServiceURL
 }
 
 // getConfiguration retrieves the active configuration under lock, making it safe to use

--- a/server/rtcd.go
+++ b/server/rtcd.go
@@ -401,9 +401,6 @@ func (m *rtcdClientManager) getRTCDClientConfig(rtcdURL string, dialFn rtcd.Dial
 	}
 	cfg.AuthKey = os.Getenv("MM_CALLS_RTCD_AUTH_KEY")
 	cfg.URL = rtcdURL
-	if rtcdURL = os.Getenv("MM_CALLS_RTCD_URL"); rtcdURL != "" {
-		cfg.URL = rtcdURL
-	}
 
 	// Parsing the URL in case it's already containing credentials.
 	u, clientID, authKey, err := parseURL(cfg.URL)


### PR DESCRIPTION
#### Summary

This somehow slipped through our tests. In Cloud the config setting will be empty since we set it through env but the client was not being created unless the config value was set. Now checking for both config and env through a useful configuration getter.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44894