### PR TITLE
[MM-44952] Handle errors from callsClient.init()

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -474,7 +474,10 @@ export default class Plugin {
                     }
                 });
 
-                window.callsClient.init(channelID, title);
+                window.callsClient.init(channelID, title).catch((err: Error) => {
+                    delete window.callsClient;
+                    logErr(err);
+                });
             } catch (err) {
                 delete window.callsClient;
                 logErr(err);


### PR DESCRIPTION
#### Summary

An error in `init()` could cause the state to be stuck, forcing the user to refresh/reopen the app since we weren't cleaning up.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44952
