### PR TITLE
MM-44919: Fix: Calls: Error checking channel type in global threads view

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -544,6 +544,11 @@ export default class Plugin {
         };
 
         const fetchChannelData = async (channelID: string) => {
+            if (!channelID) {
+                // Must be Global threads view, or another view that isn't a channel.
+                return;
+            }
+
             let channel = getChannel(store.getState(), channelID);
             if (!channel) {
                 await getChannelAction(channelID)(store.dispatch as any, store.getState);


### PR DESCRIPTION
#### Summary
- Don't fetch channel data if we're not in a channel.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-44919

