### PR TITLE
[MM-44486] Support advanced ICE server configs through ICEServersConfigs

### DIFF
--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -181,11 +181,13 @@ func applyManifest(manifest *model.Manifest) error {
 			return err
 		}
 		manifestStr := string(manifestBytes)
+		// escaping necessary to make JS string evaluation happy with embedding JSON.
+		manifestStr = strings.ReplaceAll(fmt.Sprintf(pluginIDJSFileTemplate, manifestStr), `\`, `\\`)
 
 		// write generated code to file by using JS file template.
 		if err := ioutil.WriteFile(
 			"webapp/src/manifest.ts",
-			[]byte(fmt.Sprintf(pluginIDJSFileTemplate, manifestStr)),
+			[]byte(manifestStr),
 			0600,
 		); err != nil {
 			return errors.Wrap(err, "failed to open webapp/src/manifest.ts")

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.0.27
-	github.com/mattermost/rtcd v0.5.1
+	github.com/mattermost/rtcd v0.6.5-0.20220609185544-df3153ebd103
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.0.27
-	github.com/mattermost/rtcd v0.6.5-0.20220609185544-df3153ebd103
+	github.com/mattermost/rtcd v0.6.8
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/mattermost/mattermost-server/v6 v6.6.0 h1:47XbXSJu9fdbhZWG5bQ5dj3ySrI
 github.com/mattermost/mattermost-server/v6 v6.6.0/go.mod h1:oR6UCRo+SEvnfN2FEOdzHs1UljrskyCKU8tWeKlxgMo=
 github.com/mattermost/morph v0.0.0-20220401091636-39f834798da8/go.mod h1:jxM3g1bx+k2Thz7jofcHguBS8TZn5Pc+o5MGmORObhw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/rtcd v0.5.1 h1:c9viF2L2XIQnUh4PGNE+ofFAQoxQ3lcsTa2AYGs51S4=
-github.com/mattermost/rtcd v0.5.1/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
+github.com/mattermost/rtcd v0.6.5-0.20220609185544-df3153ebd103 h1:l6gC3iL+6L0i/MMrXgzQ3ycBXUTsYyHYhUMRk9rJVP8=
+github.com/mattermost/rtcd v0.6.5-0.20220609185544-df3153ebd103/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/mattermost/mattermost-server/v6 v6.6.0 h1:47XbXSJu9fdbhZWG5bQ5dj3ySrI
 github.com/mattermost/mattermost-server/v6 v6.6.0/go.mod h1:oR6UCRo+SEvnfN2FEOdzHs1UljrskyCKU8tWeKlxgMo=
 github.com/mattermost/morph v0.0.0-20220401091636-39f834798da8/go.mod h1:jxM3g1bx+k2Thz7jofcHguBS8TZn5Pc+o5MGmORObhw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/rtcd v0.6.5-0.20220609185544-df3153ebd103 h1:l6gC3iL+6L0i/MMrXgzQ3ycBXUTsYyHYhUMRk9rJVP8=
-github.com/mattermost/rtcd v0.6.5-0.20220609185544-df3153ebd103/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
+github.com/mattermost/rtcd v0.6.8 h1:SHRsqty7wZuAG92iX7omq1ASaB5AxhakVQlkYekeHNo=
+github.com/mattermost/rtcd v0.6.8/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/plugin.json
+++ b/plugin.json
@@ -60,11 +60,19 @@
         },
         {
           "key": "ICEServers",
-          "display_name": "ICE Servers",
+          "display_name": "STUN Servers",
           "type": "text",
           "help_text": "(Optional) A comma-separated list of ICE servers' URLs (STUN/TURN) to use.",
           "default": "stun:stun.global.calls.mattermost.com:3478",
           "placeholder": "stun:example.com:3478"
+        },
+        {
+          "key": "ICEServersConfigs",
+          "display_name": "ICE servers configurations",
+          "type": "longtext",
+          "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
+          "default": "",
+          "placeholder": "[{\n \"urls\": \"[\"turn:turnserver.example.org\"]\",\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]"
         },
         {
           "key": "RTCDServiceURL",

--- a/plugin.json
+++ b/plugin.json
@@ -59,16 +59,8 @@
           "default": ""
         },
         {
-          "key": "ICEServers",
-          "display_name": "STUN Servers",
-          "type": "text",
-          "help_text": "(Optional) A comma-separated list of ICE servers' URLs (STUN/TURN) to use.",
-          "default": "stun:stun.global.calls.mattermost.com:3478",
-          "placeholder": "stun:example.com:3478"
-        },
-        {
           "key": "ICEServersConfigs",
-          "display_name": "ICE servers configurations",
+          "display_name": "ICE Servers Configurations",
           "type": "longtext",
           "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
           "default": "",

--- a/plugin.json
+++ b/plugin.json
@@ -63,8 +63,8 @@
           "display_name": "ICE Servers Configurations",
           "type": "longtext",
           "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
-          "default": "",
-          "placeholder": "[{\n \"urls\": \"[\"turn:turnserver.example.org\"]\",\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]"
+          "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]",
+          "placeholder": "[{\n \"urls\": \"[\"turn:turnserver.example.org:3478\"]\",\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]"
         },
         {
           "key": "RTCDServiceURL",

--- a/server/activate.go
+++ b/server/activate.go
@@ -106,7 +106,7 @@ func (p *Plugin) OnActivate() error {
 	rtcServer, err := rtc.NewServer(rtc.ServerConfig{
 		ICEPortUDP:      *cfg.UDPServerPort,
 		ICEHostOverride: cfg.ICEHostOverride,
-		ICEServers:      cfg.ICEServers,
+		ICEServers:      rtc.ICEServers(cfg.getICEServers()),
 	}, newLogger(p), p.metrics.RTCMetrics())
 	if err != nil {
 		p.LogError(err.Error())

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -41,8 +41,9 @@ type configuration struct {
 }
 
 type clientConfig struct {
-	// A comma separated list of ICE servers URLs (STUN/TURN) to use.
+	// **DEPRECATED use ICEServersConfigs** A comma separated list of ICE servers URLs (STUN/TURN) to use.
 	ICEServers ICEServers
+
 	// A list of ICE server configurations to use.
 	ICEServersConfigs ICEServersConfigs
 	// When set to true, it allows channel admins to enable or disable calls in their channels.

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -199,16 +199,12 @@ func (c *configuration) Clone() *configuration {
 
 	if c.ICEServers != nil {
 		cfg.ICEServers = make(ICEServers, len(c.ICEServers))
-		for i, u := range c.ICEServers {
-			cfg.ICEServers[i] = u
-		}
+		copy(cfg.ICEServers, c.ICEServers)
 	}
 
 	if c.ICEServersConfigs != nil {
 		cfg.ICEServersConfigs = make([]rtc.ICEServerConfig, len(c.ICEServersConfigs))
-		for i, u := range c.ICEServersConfigs {
-			cfg.ICEServersConfigs[i] = u
-		}
+		copy(cfg.ICEServersConfigs, c.ICEServersConfigs)
 	}
 
 	if c.MaxCallParticipants != nil {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -4,12 +4,15 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/mattermost/rtcd/service/rtc"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 )
@@ -40,6 +43,8 @@ type configuration struct {
 type clientConfig struct {
 	// A comma separated list of ICE servers URLs (STUN/TURN) to use.
 	ICEServers ICEServers
+	// A list of ICE server configurations to use.
+	ICEServersConfigs ICEServersConfigs
 	// When set to true, it allows channel admins to enable or disable calls in their channels.
 	// It also allows participants of DMs/GMs to enable or disable calls.
 	AllowEnableCalls *bool
@@ -51,6 +56,26 @@ type clientConfig struct {
 }
 
 type ICEServers []string
+type ICEServersConfigs rtc.ICEServers
+
+func (cfgs *ICEServersConfigs) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	unquoted, err := strconv.Unquote(string(data))
+	if err != nil {
+		return err
+	}
+	if unquoted == "" {
+		return nil
+	}
+
+	var dst []rtc.ICEServerConfig
+	err = json.Unmarshal([]byte(unquoted), &dst)
+	*cfgs = dst
+
+	return err
+}
 
 func (is *ICEServers) UnmarshalJSON(data []byte) error {
 	*is = []string{}
@@ -114,6 +139,7 @@ func (c *configuration) getClientConfig() clientConfig {
 		AllowEnableCalls:    c.AllowEnableCalls,
 		DefaultEnabled:      c.DefaultEnabled,
 		ICEServers:          c.ICEServers,
+		ICEServersConfigs:   c.getICEServers(),
 		MaxCallParticipants: c.MaxCallParticipants,
 	}
 }
@@ -174,6 +200,13 @@ func (c *configuration) Clone() *configuration {
 		cfg.ICEServers = make(ICEServers, len(c.ICEServers))
 		for i, u := range c.ICEServers {
 			cfg.ICEServers[i] = u
+		}
+	}
+
+	if c.ICEServersConfigs != nil {
+		cfg.ICEServersConfigs = make([]rtc.ICEServerConfig, len(c.ICEServersConfigs))
+		for i, u := range c.ICEServersConfigs {
+			cfg.ICEServersConfigs[i] = u
 		}
 	}
 
@@ -290,4 +323,15 @@ func (p *Plugin) setOverrides(cfg *configuration) {
 func (p *Plugin) isHAEnabled() bool {
 	cfg := p.API.GetConfig()
 	return cfg != nil && cfg.ClusterSettings.Enable != nil && *cfg.ClusterSettings.Enable
+}
+
+func (c *configuration) getICEServers() ICEServersConfigs {
+	iceServers := c.ICEServersConfigs
+	if len(c.ICEServers) > 0 {
+		iceServers = append(iceServers, rtc.ICEServerConfig{
+			URLs: c.ICEServers,
+		})
+	}
+
+	return iceServers
 }

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -160,11 +160,13 @@ export default class CallsClient extends EventEmitter {
 
         ws.on('join', async () => {
             logDebug('join ack received, initializing connection');
-            const iceServers = this.config.iceServers?.length > 0 ? [{urls: this.config.iceServers}] : [];
+
             const peer = new SimplePeer({
                 initiator: true,
                 trickle: true,
-                config: {iceServers},
+                config: {
+                    iceServers: this.config.iceServers || [],
+                },
             }) as SimplePeer.Instance;
 
             this.peer = peer;

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -92,10 +92,10 @@ const callsConfig = (state: GlobalState): CallsConfig => {
     return getPluginState(state).callsConfig;
 };
 
-export const iceServers: (state: GlobalState) => string[] = createSelector(
+export const iceServers: (state: GlobalState) => RTCIceServer[] = createSelector(
     'iceServers',
     callsConfig,
-    (config) => config.ICEServers,
+    (config) => config.ICEServersConfigs,
 );
 
 export const allowEnableCalls: (state: GlobalState) => boolean = createSelector(

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -56,6 +56,7 @@ export type RTCRemoteOutboundStats = {
 
 export type CallsConfig = {
     ICEServers: string[],
+    ICEServersConfigs: RTCIceServer[],
     AllowEnableCalls: boolean,
     DefaultEnabled: boolean,
     MaxCallParticipants: number,
@@ -64,6 +65,7 @@ export type CallsConfig = {
 
 export const CallsConfigDefault = {
     ICEServers: [],
+    ICEServersConfigs: [],
     AllowEnableCalls: false,
     DefaultEnabled: false,
     MaxCallParticipants: 0,
@@ -72,5 +74,5 @@ export const CallsConfigDefault = {
 
 export type CallsClientConfig = {
     wsURL: string,
-    iceServers: string[],
+    iceServers: RTCIceServer[],
 }


### PR DESCRIPTION
#### Summary

Adding a new `ICEServersConfigs` config setting to support passing to clients both STUN and TURN server configs (with credentials). This is a superset of the existing `ICEServers` which we are deprecating but not removing to maintain backwards compatibility.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44486