### PR TITLE
Switch to using the @mattermost/types npm package

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@mattermost/types": "6.7.0-0",
         "@msgpack/msgpack": "2.7.1",
         "axios": "0.21.4",
         "core-js": "3.21.1",
@@ -2944,6 +2945,19 @@
         "svgpath": "2.5.0",
         "unzip": "0.1.11",
         "xmldom": "0.6.0"
+      }
+    },
+    "node_modules/@mattermost/types": {
+      "version": "6.7.0-0",
+      "resolved": "https://registry.npmjs.org/@mattermost/types/-/types-6.7.0-0.tgz",
+      "integrity": "sha512-mT8wJwWEp20KPo9D12y7bW7EdUHO7VhUHxr3gH8nPGapWooGcl0Ra0H3u1iCjPpqPWvp7LiodcneU0IysunYKQ==",
+      "peerDependencies": {
+        "typescript": "^4.3"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@msgpack/msgpack": {
@@ -16760,6 +16774,12 @@
         "unzip": "0.1.11",
         "xmldom": "0.6.0"
       }
+    },
+    "@mattermost/types": {
+      "version": "6.7.0-0",
+      "resolved": "https://registry.npmjs.org/@mattermost/types/-/types-6.7.0-0.tgz",
+      "integrity": "sha512-mT8wJwWEp20KPo9D12y7bW7EdUHO7VhUHxr3gH8nPGapWooGcl0Ra0H3u1iCjPpqPWvp7LiodcneU0IysunYKQ==",
+      "requires": {}
     },
     "@msgpack/msgpack": {
       "version": "2.7.1"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -60,6 +60,7 @@
     "webpack-cli": "4.7.2"
   },
   "dependencies": {
+    "@mattermost/types": "6.7.0-0",
     "@msgpack/msgpack": "2.7.1",
     "axios": "0.21.4",
     "core-js": "3.21.1",

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -1,7 +1,7 @@
 import {Dispatch} from 'redux';
 import axios from 'axios';
 
-import {ActionFunc, DispatchFunc, GenericAction, GetStateFunc} from '@mattermost/types/actions';
+import {ActionFunc, DispatchFunc, GenericAction, GetStateFunc} from 'mattermost-redux/types/actions';
 
 import {bindClientFunc} from 'mattermost-redux/actions/helpers';
 

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -1,7 +1,7 @@
 import {Dispatch} from 'redux';
 import axios from 'axios';
 
-import {ActionFunc, DispatchFunc, GenericAction, GetStateFunc} from 'mattermost-redux/types/actions';
+import {ActionFunc, DispatchFunc, GenericAction, GetStateFunc} from '@mattermost/types/actions';
 
 import {bindClientFunc} from 'mattermost-redux/actions/helpers';
 

--- a/webapp/src/cloud_pricing/modals.tsx
+++ b/webapp/src/cloud_pricing/modals.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 
 import {useDispatch, useSelector} from 'react-redux';
 
-import {Thunk} from '@mattermost/types/actions';
+import {Thunk} from 'mattermost-redux/types/actions';
 
 import GenericModal from 'src/components/generic_modal';
 import {displayCloudPricing, notifyAdminCloudFreeTrial} from 'src/actions';

--- a/webapp/src/cloud_pricing/modals.tsx
+++ b/webapp/src/cloud_pricing/modals.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 
 import {useDispatch, useSelector} from 'react-redux';
 
-import {Thunk} from 'mattermost-redux/types/actions';
+import {Thunk} from '@mattermost/types/actions';
 
 import GenericModal from 'src/components/generic_modal';
 import {displayCloudPricing, notifyAdminCloudFreeTrial} from 'src/actions';

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -3,10 +3,10 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import moment from 'moment-timezone';
 import {compareSemVer} from 'semver-parser';
 
-import {UserProfile} from 'mattermost-redux/types/users';
-import {Channel} from 'mattermost-redux/types/channels';
-import {Team} from 'mattermost-redux/types/teams';
-import {IDMappedObjects} from 'mattermost-redux/types/utilities';
+import {UserProfile} from '@mattermost/types/users';
+import {Channel} from '@mattermost/types/channels';
+import {Team} from '@mattermost/types/teams';
+import {IDMappedObjects} from '@mattermost/types/utilities';
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
 
 import {UserState} from 'src/types/types';

--- a/webapp/src/components/call_widget/index.ts
+++ b/webapp/src/components/call_widget/index.ts
@@ -1,8 +1,8 @@
 import {bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
-import {UserProfile} from 'mattermost-redux/types/users';
-import {IDMappedObjects} from 'mattermost-redux/types/utilities';
+import {GlobalState} from '@mattermost/types/store';
+import {UserProfile} from '@mattermost/types/users';
+import {IDMappedObjects} from '@mattermost/types/utilities';
 
 import {getUsers} from 'mattermost-redux/selectors/entities/common';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';

--- a/webapp/src/components/channel_call_toast/component.tsx
+++ b/webapp/src/components/channel_call_toast/component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment-timezone';
 
-import {UserProfile} from 'mattermost-redux/types/users';
+import {UserProfile} from '@mattermost/types/users';
 
 import ActiveCallIcon from '../../components/icons/active_call_icon';
 import ConnectedProfiles from '../../components/connected_profiles';

--- a/webapp/src/components/channel_header_button/index.ts
+++ b/webapp/src/components/channel_header_button/index.ts
@@ -1,5 +1,5 @@
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from '@mattermost/types/store';
 
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 

--- a/webapp/src/components/channel_header_dropdown_button/index.ts
+++ b/webapp/src/components/channel_header_dropdown_button/index.ts
@@ -1,5 +1,5 @@
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from '@mattermost/types/store';
 
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 

--- a/webapp/src/components/channel_header_menu_button/index.ts
+++ b/webapp/src/components/channel_header_menu_button/index.ts
@@ -1,5 +1,5 @@
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from '@mattermost/types/store';
 
 import {isVoiceEnabled} from '../../selectors';
 

--- a/webapp/src/components/channel_link_label/component.tsx
+++ b/webapp/src/components/channel_link_label/component.tsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
-import {Channel} from 'mattermost-redux/types/channels';
-import {UserProfile} from 'mattermost-redux/types/users';
+import {Channel} from '@mattermost/types/channels';
+import {UserProfile} from '@mattermost/types/users';
 
 import {getUserDisplayName, getUsersList} from '../../utils';
 

--- a/webapp/src/components/channel_link_label/index.ts
+++ b/webapp/src/components/channel_link_label/index.ts
@@ -1,6 +1,6 @@
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
-import {Channel} from 'mattermost-redux/types/channels';
+import {GlobalState} from '@mattermost/types/store';
+import {Channel} from '@mattermost/types/channels';
 
 import {voiceConnectedChannels, voiceConnectedProfilesInChannel} from '../../selectors';
 

--- a/webapp/src/components/connected_profiles.tsx
+++ b/webapp/src/components/connected_profiles.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
-import {UserProfile} from 'mattermost-redux/types/users';
+import {UserProfile} from '@mattermost/types/users';
 
 import {getUserDisplayName, getUsersList} from '../utils';
 

--- a/webapp/src/components/custom_post_types/post_text.tsx
+++ b/webapp/src/components/custom_post_types/post_text.tsx
@@ -4,8 +4,8 @@
 import React, {ReactNode, ReactNodeArray} from 'react';
 import {useSelector} from 'react-redux';
 
-import {GlobalState} from 'mattermost-redux/types/store';
-import {Team} from 'mattermost-redux/types/teams';
+import {GlobalState} from '@mattermost/types/store';
+import {Team} from '@mattermost/types/teams';
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
 
 import styled from 'styled-components';

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import moment from 'moment-timezone';
 import styled from 'styled-components';
 
-import {UserProfile} from 'mattermost-redux/types/users';
-import {Post} from 'mattermost-redux/types/posts';
+import {UserProfile} from '@mattermost/types/users';
+import {Post} from '@mattermost/types/posts';
 
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 

--- a/webapp/src/components/custom_post_types/post_type/index.ts
+++ b/webapp/src/components/custom_post_types/post_type/index.ts
@@ -1,7 +1,7 @@
 import {bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
-import {Post} from 'mattermost-redux/types/posts';
+import {GlobalState} from '@mattermost/types/store';
+import {Post} from '@mattermost/types/posts';
 
 import {Client4} from 'mattermost-redux/client';
 

--- a/webapp/src/components/custom_post_types/post_type_cloud_trial_request.tsx
+++ b/webapp/src/components/custom_post_types/post_type_cloud_trial_request.tsx
@@ -2,12 +2,12 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {Post} from 'mattermost-redux/types/posts';
+import {Post} from '@mattermost/types/posts';
 import {useDispatch, useSelector} from 'react-redux';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-import {Channel} from 'mattermost-redux/types/channels';
-import {GlobalState} from 'mattermost-redux/types/store';
-import {Team} from 'mattermost-redux/types/teams';
+import {Channel} from '@mattermost/types/channels';
+import {GlobalState} from '@mattermost/types/store';
+import {Team} from '@mattermost/types/teams';
 import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {FormattedMessage} from 'react-intl';

--- a/webapp/src/components/custom_post_types/types.ts
+++ b/webapp/src/components/custom_post_types/types.ts
@@ -1,4 +1,4 @@
-import {Channel} from 'mattermost-redux/types/channels';
+import {Channel} from '@mattermost/types/channels';
 
 export type ChannelNamesMap = {
     [name: string]: {

--- a/webapp/src/components/end_call_modal/component.tsx
+++ b/webapp/src/components/end_call_modal/component.tsx
@@ -2,8 +2,8 @@ import React, {CSSProperties} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
-import {Channel} from 'mattermost-redux/types/channels';
-import {UserProfile} from 'mattermost-redux/types/users';
+import {Channel} from '@mattermost/types/channels';
+import {UserProfile} from '@mattermost/types/users';
 
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
 

--- a/webapp/src/components/end_call_modal/index.ts
+++ b/webapp/src/components/end_call_modal/index.ts
@@ -1,6 +1,6 @@
 import {bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from '@mattermost/types/store';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -3,8 +3,8 @@ import moment from 'moment-timezone';
 import {compareSemVer} from 'semver-parser';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
-import {UserProfile} from 'mattermost-redux/types/users';
-import {Channel} from 'mattermost-redux/types/channels';
+import {UserProfile} from '@mattermost/types/users';
+import {Channel} from '@mattermost/types/channels';
 
 import {getUserDisplayName, getScreenStream, isDMChannel, hasExperimentalFlag} from 'src/utils';
 import {UserState} from 'src/types/types';

--- a/webapp/src/components/expanded_view/index.ts
+++ b/webapp/src/components/expanded_view/index.ts
@@ -1,7 +1,7 @@
 import {bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
-import {UserProfile} from 'mattermost-redux/types/users';
+import {GlobalState} from '@mattermost/types/store';
+import {UserProfile} from '@mattermost/types/users';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';

--- a/webapp/src/components/screen_source_modal/component.tsx
+++ b/webapp/src/components/screen_source_modal/component.tsx
@@ -2,7 +2,7 @@ import React, {CSSProperties} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
-import {Channel} from 'mattermost-redux/types/channels';
+import {Channel} from '@mattermost/types/channels';
 
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
 

--- a/webapp/src/components/screen_source_modal/index.ts
+++ b/webapp/src/components/screen_source_modal/index.ts
@@ -1,6 +1,6 @@
 import {bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from '@mattermost/types/store';
 import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
 import {hideScreenSourceModal} from '../../actions';

--- a/webapp/src/components/switch_call_modal/component.tsx
+++ b/webapp/src/components/switch_call_modal/component.tsx
@@ -2,8 +2,8 @@ import React, {CSSProperties} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
-import {Channel} from 'mattermost-redux/types/channels';
-import {UserProfile} from 'mattermost-redux/types/users';
+import {Channel} from '@mattermost/types/channels';
+import {UserProfile} from '@mattermost/types/users';
 
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
 

--- a/webapp/src/components/switch_call_modal/index.ts
+++ b/webapp/src/components/switch_call_modal/index.ts
@@ -1,6 +1,6 @@
 import {bindActionCreators, Dispatch} from 'redux';
 import {connect} from 'react-redux';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from '@mattermost/types/store';
 import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -1,6 +1,6 @@
 import {combineReducers} from 'redux';
 
-import {UserProfile} from 'mattermost-redux/types/users';
+import {UserProfile} from '@mattermost/types/users';
 
 import {CallsConfigDefault, CallsConfig, UserState} from './types/types';
 

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -1,5 +1,5 @@
 import {getCurrentChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from '@mattermost/types/store';
 
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {createSelector} from 'reselect';

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -1,6 +1,6 @@
 import {Store as BaseStore} from 'redux';
 import {ThunkDispatch} from 'redux-thunk';
-import {GlobalState} from 'mattermost-redux/types/store';
+import {GlobalState} from '@mattermost/types/store';
 
 export interface PluginRegistry {
     registerPostTypeComponent(typeName: string, component: React.ElementType)

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -9,12 +9,12 @@ import {Client4} from 'mattermost-redux/client';
 import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {isDirectChannel, isGroupChannel} from 'mattermost-redux/utils/channel_utils';
 
-import {Team} from 'mattermost-redux/types/teams';
-import {Channel, ChannelMembership} from 'mattermost-redux/types/channels';
-import {UserProfile} from 'mattermost-redux/types/users';
+import {Team} from '@mattermost/types/teams';
+import {Channel, ChannelMembership} from '@mattermost/types/channels';
+import {UserProfile} from '@mattermost/types/users';
 
-import {GlobalState} from 'mattermost-redux/types/store';
-import {ClientConfig} from 'mattermost-redux/types/config';
+import {GlobalState} from '@mattermost/types/store';
+import {ClientConfig} from '@mattermost/types/config';
 
 import {UserState} from './types/types';
 
@@ -22,13 +22,11 @@ import {pluginId} from './manifest';
 import {logErr} from './log';
 
 export function getPluginStaticPath() {
-    return window.basename ? `${window.basename}/static/plugins/${pluginId}` :
-        `/static/plugins/${pluginId}`;
+    return window.basename ? `${window.basename}/static/plugins/${pluginId}` : `/static/plugins/${pluginId}`;
 }
 
 export function getPluginPath() {
-    return window.basename ? `${window.basename}/plugins/${pluginId}` :
-        `/plugins/${pluginId}`;
+    return window.basename ? `${window.basename}/plugins/${pluginId}` : `/plugins/${pluginId}`;
 }
 
 export function getWSConnectionURL(config: Partial<ClientConfig>): string {


### PR DESCRIPTION
#### Summary
Moved off of `mattermost-redux` for importing types and on to the new npm package `@mattermost/types`. This should make keeping up to date with new types easier.

Did a quick find and replace and a quick package/test on my local server. Everything seemed to work like a charm.

@hmhealey let me know if I missed step or did something wrong here.

