### PR TITLE
Remove ts and webpack mappings of @mattermost/types

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -91,6 +91,7 @@
       "^.+\\.(css|less|scss)$": "identity-obj-proxy",
       "^.*i18n.*\\.(json)$": "<rootDir>/tests/i18n_mock.json",
       "^bundle-loader\\?lazy\\!(.*)$": "$1",
+      "^@mattermost/types/(.*)$": "<rootDir>/node_modules/@mattermost/types/lib/$1",
       "^mattermost-redux(.*)$": "<rootDir>/node_modules/mattermost-webapp/packages/mattermost-redux/src$1",
       "^reselect": "<rootDir>/node_modules/mattermost-webapp/packages/reselect/src"
     },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -92,7 +92,6 @@
       "^.*i18n.*\\.(json)$": "<rootDir>/tests/i18n_mock.json",
       "^bundle-loader\\?lazy\\!(.*)$": "$1",
       "^mattermost-redux(.*)$": "<rootDir>/node_modules/mattermost-webapp/packages/mattermost-redux/src$1",
-      "^@mattermost/types(.*)$": "<rootDir>/node_modules/mattermost-webapp/packages/types/src/$1",
       "^reselect": "<rootDir>/node_modules/mattermost-webapp/packages/reselect/src"
     },
     "moduleDirectories": [

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -23,6 +23,7 @@
     "baseUrl": ".",
     "paths": {
       "src": ["src"],
+      "@mattermost/types/*": ["node_modules/@mattermost/types/lib/*"],
       "mattermost-redux/*": ["node_modules/mattermost-webapp/packages/mattermost-redux/src/*"],
       "reselect": ["node_modules/mattermost-webapp/packages/reselect/src"]
     },

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -23,7 +23,6 @@
     "baseUrl": ".",
     "paths": {
       "src": ["src"],
-      "@mattermost/types/*": ["node_modules/mattermost-webapp/packages/types/src/*"],
       "mattermost-redux/*": ["node_modules/mattermost-webapp/packages/mattermost-redux/src/*"],
       "reselect": ["node_modules/mattermost-webapp/packages/reselect/src"]
     },

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -48,7 +48,6 @@ module.exports = {
         alias: {
             src: path.resolve(__dirname, './src/'),
             'mattermost-redux': path.resolve(__dirname, './node_modules/mattermost-webapp/packages/mattermost-redux/src/'),
-            '@mattermost/types': path.resolve(__dirname, './node_modules/mattermost-webapp/packages/types/src/'),
             reselect: path.resolve(__dirname, './node_modules/mattermost-webapp/packages/reselect/src/index'),
         },
         modules: [


### PR DESCRIPTION
#### Summary
Per @trilopin's comment [here](https://community.mattermost.com/core/pl/zua17j1jsfg87bfhe4bxx7r8pc) we were still importing `@mattermost/types` through the `mattermost-webapp` import instead of via npm. This PR removes those mappings.