### PR TITLE
[MM-45001] Add support for generating short-lived TURN credentials

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -67,6 +67,27 @@
           "placeholder": "[{\n \"urls\": \"[\"turn:turnserver.example.org:3478\"]\",\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]"
         },
         {
+          "key": "TURNStaticAuthSecret",
+          "display_name": "TURN Static Auth Secret",
+          "type": "text",
+          "default": "",
+          "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials."
+        },
+        {
+          "key": "TURNCredentialsExpirationMinutes",
+          "display_name": "TURN Credentials Expiration (minutes)",
+          "type": "number",
+          "default": 1440,
+          "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for."
+        },
+        {
+          "key": "ServerSideTURN",
+          "display_name": "Server Side TURN",
+          "type": "bool",
+          "default": false,
+          "help_text": "(Optional) When set to true it will pass and use configured TURN candidates to server initiated connections."
+        },
+        {
           "key": "RTCDServiceURL",
           "display_name": "RTCD service URL",
           "type": "text",

--- a/server/activate.go
+++ b/server/activate.go
@@ -103,11 +103,16 @@ func (p *Plugin) OnActivate() error {
 		}()
 	}
 
-	rtcServer, err := rtc.NewServer(rtc.ServerConfig{
-		ICEPortUDP:      *cfg.UDPServerPort,
-		ICEHostOverride: cfg.ICEHostOverride,
-		ICEServers:      rtc.ICEServers(cfg.getICEServers()),
-	}, newLogger(p), p.metrics.RTCMetrics())
+	rtcServerConfig := rtc.ServerConfig{
+		ICEPortUDP:                       *cfg.UDPServerPort,
+		ICEHostOverride:                  cfg.ICEHostOverride,
+		ICEServers:                       rtc.ICEServers(cfg.getICEServers(false)),
+		TURNCredentialsExpirationMinutes: *cfg.TURNCredentialsExpirationMinutes,
+	}
+	if *cfg.ServerSideTURN {
+		rtcServerConfig.TURNStaticAuthSecret = cfg.TURNStaticAuthSecret
+	}
+	rtcServer, err := rtc.NewServer(rtcServerConfig, newLogger(p), p.metrics.RTCMetrics())
 	if err != nil {
 		p.LogError(err.Error())
 		return err

--- a/server/activate.go
+++ b/server/activate.go
@@ -104,13 +104,15 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	rtcServerConfig := rtc.ServerConfig{
-		ICEPortUDP:                       *cfg.UDPServerPort,
-		ICEHostOverride:                  cfg.ICEHostOverride,
-		ICEServers:                       rtc.ICEServers(cfg.getICEServers(false)),
-		TURNCredentialsExpirationMinutes: *cfg.TURNCredentialsExpirationMinutes,
+		ICEPortUDP:      *cfg.UDPServerPort,
+		ICEHostOverride: cfg.ICEHostOverride,
+		ICEServers:      rtc.ICEServers(cfg.getICEServers(false)),
+		TURNConfig: rtc.TURNConfig{
+			CredentialsExpirationMinutes: *cfg.TURNCredentialsExpirationMinutes,
+		},
 	}
 	if *cfg.ServerSideTURN {
-		rtcServerConfig.TURNStaticAuthSecret = cfg.TURNStaticAuthSecret
+		rtcServerConfig.TURNConfig.StaticAuthSecret = cfg.TURNStaticAuthSecret
 	}
 	rtcServer, err := rtc.NewServer(rtcServerConfig, newLogger(p), p.metrics.RTCMetrics())
 	if err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"golang.org/x/time/rate"
+
 	"github.com/mattermost/mattermost-plugin-calls/server/performance"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -26,5 +28,6 @@ func main() {
 		clusterEvCh: make(chan model.PluginClusterEvent, clusterEventQueueSize),
 		sessions:    map[string]*session{},
 		metrics:     performance.NewMetrics(),
+		apiLimiters: map[string]*rate.Limiter{},
 	})
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/mattermost/mattermost-plugin-calls/server/enterprise"
 	"github.com/mattermost/mattermost-plugin-calls/server/performance"
 	"github.com/mattermost/mattermost-plugin-calls/server/telemetry"
@@ -42,6 +44,11 @@ type Plugin struct {
 
 	rtcServer   *rtc.Server
 	rtcdManager *rtcdClientManager
+
+	// A map of userID -> limiter to implement basic, user based API rate-limiting.
+	// TODO: consider moving this to a dedicated API object.
+	apiLimiters    map[string]*rate.Limiter
+	apiLimitersMut sync.RWMutex
 }
 
 func (p *Plugin) startSession(us *session, senderID string) {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -27,6 +27,7 @@ import {
     voiceChannelRootPost,
     allowEnableCalls,
     iceServers,
+    needsTURNCredentials,
 } from './selectors';
 
 import {pluginId} from './manifest';
@@ -466,9 +467,20 @@ export default class Plugin {
                     return;
                 }
 
+                const iceConfigs = [...iceServers(store.getState())];
+                if (needsTURNCredentials(store.getState())) {
+                    logDebug('turn credentials needed');
+                    try {
+                        const resp = await axios.get(`${getPluginPath()}/turn-credentials`);
+                        iceConfigs.push(...resp.data);
+                    } catch (err) {
+                        logErr(err);
+                    }
+                }
+
                 window.callsClient = new CallsClient({
                     wsURL: getWSConnectionURL(getConfig(store.getState())),
-                    iceServers: iceServers(store.getState()),
+                    iceServers: iceConfigs,
                 });
                 const globalComponentID = registry.registerGlobalComponent(CallWidget);
                 const rootComponentID = registry.registerRootComponent(ExpandedView);

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -95,7 +95,7 @@ const callsConfig = (state: GlobalState): CallsConfig => {
 export const iceServers: (state: GlobalState) => RTCIceServer[] = createSelector(
     'iceServers',
     callsConfig,
-    (config) => config.ICEServersConfigs,
+    (config) => config.ICEServersConfigs || [],
 );
 
 export const allowEnableCalls: (state: GlobalState) => boolean = createSelector(
@@ -108,6 +108,12 @@ export const maxParticipants: (state: GlobalState) => number = createSelector(
     'maxParticipants',
     callsConfig,
     (config) => config.MaxCallParticipants,
+);
+
+export const needsTURNCredentials: (state: GlobalState) => boolean = createSelector(
+    'maxParticipants',
+    callsConfig,
+    (config) => config.NeedsTURNCredentials,
 );
 
 export const isLimitRestricted: (state: GlobalState) => boolean = createSelector(

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -60,6 +60,7 @@ export type CallsConfig = {
     AllowEnableCalls: boolean,
     DefaultEnabled: boolean,
     MaxCallParticipants: number,
+    NeedsTURNCredentials: boolean,
     sku_short_name: string,
 }
 
@@ -69,6 +70,7 @@ export const CallsConfigDefault = {
     AllowEnableCalls: false,
     DefaultEnabled: false,
     MaxCallParticipants: 0,
+    NeedsTURNCredentials: false,
     sku_short_name: '',
 } as CallsConfig;
 


### PR DESCRIPTION
#### Summary

PR adds support for generating short-lived TURN credentials as described in https://datatracker.ietf.org/doc/html/draft-uberti-behave-turn-rest-00#section-2.2

Addresses https://github.com/mattermost/mattermost-plugin-calls/issues/49

#### Related PRs

https://github.com/mattermost/rtcd/pull/63

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45001