### PR TITLE
Support joining multiple calls

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -120,7 +120,7 @@ export default class Plugin {
             const channelID = ev.broadcast.channel_id;
             const currentUserID = getCurrentUserId(store.getState());
 
-            if (window.callsClient) {
+            if (window.callsClient?.channelID === channelID) {
                 if (userID === currentUserID) {
                     const audio = new Audio(getPluginStaticPath() + JoinSelfSound);
                     audio.play();

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -156,13 +156,15 @@ const connectedChannelID = (state: string | null = null, action: { type: string,
     switch (action.type) {
     case VOICE_CHANNEL_UNINIT:
         return null;
-    case VOICE_CHANNEL_USER_CONNECTED:
-        if (action.data.currentUserID === action.data.userID) {
+    case VOICE_CHANNEL_USER_CONNECTED: {
+        const callsClient = window.callsClient || window.opener?.callsClient;
+        if (action.data.currentUserID === action.data.userID && callsClient?.channelID === action.data.channelID) {
             return action.data.channelID;
         }
         return state;
+    }
     case VOICE_CHANNEL_USER_DISCONNECTED:
-        if (action.data.currentUserID === action.data.userID) {
+        if (action.data.currentUserID === action.data.userID && state === action.data.channelID) {
             return null;
         }
         return state;


### PR DESCRIPTION
#### Summary

Allowing users to join multiple calls at the same time (from separate clients). This change is mainly needed to unblock concurrent recordings on our community servers. We are still enforcing users to be connected to at most one call per client (e.g. browser tab/window).