### PR TITLE
Add pluggable to Widget

### DIFF
--- a/webapp/src/components/call_widget/component.scss
+++ b/webapp/src/components/call_widget/component.scss
@@ -132,3 +132,10 @@ a.calls-channel-link {
     }
   }
 }
+
+.integrations-icon {
+  color: rgba(var(--center-channel-color-rgb), 0.56);
+  margin-right: 8px;
+  width: 17px;
+  margin-left: -3px;
+}

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -907,6 +907,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     {!hasTeamSidebar && this.renderScreenSharingMenuItem()}
                     {this.renderAudioDevices('output')}
                     {this.renderAudioDevices('input')}
+                    <div style={{width: '100%', borderTop: '1px', borderTopStyle: 'solid', borderTopColor: changeOpacity(this.props.theme.centerChannelColor, 0.16), marginTop: '5px', marginBottom: '5px'}}/>
                     {this.renderIntegrations()}
                 </ul>
             </div>
@@ -914,6 +915,43 @@ export default class CallWidget extends React.PureComponent<Props, State> {
     }
 
     renderIntegrations = () => {
+        if (!this.props.integrations) {
+            return (
+                <li
+                    className='MenuItem'
+                >
+                    <div style={{display: 'flex', flexDirection: 'column'}}>
+                        <div style={{display: 'flex', alignItems: 'center', justifyContent: 'flex-start', width: '100%'}}>
+                            <CompassIcon
+                                icon='apps'
+                                className='integrations-icon'
+                            />
+                            <span
+                                className='MenuItem__primary-text'
+                                style={{padding: '0'}}
+                            >{'Integrations'}</span>
+
+                        </div>
+                        <span
+                            style={{
+                                color: changeOpacity(this.props.theme.centerChannelColor, 0.56),
+                                fontSize: '12px',
+                                width: '100%',
+                                whiteSpace: 'normal',
+                                lineHeight: '16px',
+                            }}
+                        >
+                            {'Ask your system administrator to install plugins integrated with calls like Matterpoll'}
+                        </span>
+                    </div>
+                </li>
+            );
+        }
+
+        if (this.props.integrations.length === 1) {
+            return this.renderIntegrationsItem(this.props.integrations[0], true);
+        }
+
         const onClickHandler = () => {
             this.setState({...clearSubmenusState, showIntegrations: !this.state.showIntegrations});
         };
@@ -931,8 +969,9 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         onClick={onClickHandler}
                     >
                         <div style={{display: 'flex', alignItems: 'center', justifyContent: 'flex-start', width: '100%'}}>
-                            <ExpandIcon
-                                style={{width: '14px', height: '14px', marginRight: '8px', fill: changeOpacity(this.props.theme.centerChannelColor, 0.56)}}
+                            <CompassIcon
+                                icon='apps'
+                                className='integrations-icon'
                             />
                             <span
                                 className='MenuItem__primary-text'
@@ -963,33 +1002,10 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             return null;
         }
 
-        let content;
-        if (this.props.integrations?.length) {
-            content = this.props.integrations?.map((integration: any) => {
-                return (
-                    <li
-                        className='MenuItem'
-                        key={`integration-${integration.pluginId}-${integration.text}`}
-                    >
-                        <button
-                            className='style--none'
-                            onClick={() => this.runIntegrationAction(integration)}
-                        >
-                            <span style={{color: changeOpacity(this.props.theme.centerChannelColor, 0.56), fontSize: '12px', width: '100%'}}>{integration.text}</span>
-                        </button>
-                    </li>
-                );
-            });
-        } else {
-            content = (
-                <li
-                    className='MenuItem'
-                    key={'integration-no-integrations'}
-                >
-                    <span style={{color: changeOpacity(this.props.theme.centerChannelColor, 0.56), fontSize: '12px', width: '100%', paddingLeft: '12px', paddingRight: '12px'}}>{'Ask your system administrator to install plugins integrated with calls like Matterpoll'}</span>
-                </li>
-            );
-        }
+        const content = this.props.integrations?.map((integration: any) => {
+            return this.renderIntegrationsItem(integration);
+        });
+
         return (
             <div className='Menu'>
                 <ul
@@ -1000,6 +1016,29 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     {content}
                 </ul>
             </div>
+        );
+    }
+
+    renderIntegrationsItem = (integration: any, isMain = false) => {
+        const spanClass = isMain ? 'MenuItem__primary-text' : '';
+        const spanStyle = isMain ? {} : {color: changeOpacity(this.props.theme.centerChannelColor, 0.56), fontSize: '12px', width: '100%'};
+        return (
+            <li
+                className='MenuItem'
+                key={`integration-${integration.pluginId}-${integration.text}`}
+            >
+                <button
+                    className='style--none'
+                    onClick={() => this.runIntegrationAction(integration)}
+                >
+                    <span
+                        className={spanClass}
+                        style={spanStyle}
+                    >
+                        {integration.text}
+                    </span>
+                </button>
+            </li>
         );
     }
 

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -915,7 +915,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
     }
 
     renderIntegrations = () => {
-        if (!this.props.integrations) {
+        if (!this.props.integrations?.length) {
             return (
                 <li
                     className='MenuItem'

--- a/webapp/src/components/call_widget/index.ts
+++ b/webapp/src/components/call_widget/index.ts
@@ -15,7 +15,7 @@ import {UserState} from '../../types/types';
 
 import {showExpandedView, showScreenSourceModal} from '../../actions';
 
-import {connectedChannelID, voiceConnectedProfiles, voiceUsersStatuses, voiceChannelCallStartAt, voiceChannelScreenSharingID, expandedView} from '../../selectors';
+import {connectedChannelID, voiceConnectedProfiles, voiceUsersStatuses, voiceChannelCallStartAt, voiceChannelScreenSharingID, expandedView, voiceChannelRootPost} from '../../selectors';
 
 import {getChannelURL, alphaSortProfiles, stateSortProfiles} from '../../utils';
 
@@ -44,8 +44,10 @@ const mapStateToProps = (state: GlobalState) => {
     }
 
     let channelURL = '';
+    let postId = '';
     if (channel) {
         channelURL = getChannelURL(state, channel, channel.team_id);
+        postId = voiceChannelRootPost(state, channel.id);
     }
 
     return {
@@ -60,6 +62,8 @@ const mapStateToProps = (state: GlobalState) => {
         callStartAt: voiceChannelCallStartAt(state, channel?.id) || 0,
         screenSharingID,
         show: !expandedView(state),
+        integrations: (state as any).plugins.components.CallsDropdownMenu,
+        postId,
     };
 };
 

--- a/webapp/src/components/expanded_view/component.scss
+++ b/webapp/src/components/expanded_view/component.scss
@@ -40,3 +40,10 @@
     color: white;
   }
 }
+
+.expanded-integrations-icon {
+  font-size: 28px;
+  &:hover {
+    color: white;
+  }
+}

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -21,7 +21,6 @@ import UnraisedHandIcon from '../../components/icons/unraised_hand';
 import ParticipantsIcon from '../../components/icons/participants';
 
 import './component.scss';
-import ExpandIcon from '../icons/expand';
 import {logErr} from 'src/log';
 
 interface Props {
@@ -40,7 +39,7 @@ interface Props {
     screenSharingID: string,
     channel: Channel,
     connectedDMUser: UserProfile | undefined,
-    integrations: any,
+    integrations?: any[],
     postId: string,
 }
 
@@ -458,6 +457,52 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         const currentID = this.props.currentUserID;
         const isSharing = sharingID === currentID;
 
+        let integrationsButton;
+        if (this.props.integrations?.length === 1) {
+            const integration = this.props.integrations[0];
+            integrationsButton = (
+                <>
+                    <button
+                        className='button-center-controls'
+                        onClick={() => this.runIntegrationAction(integration)}
+                        style={{background: this.state.showIntegrations ? 'rgba(var(--dnd-indicator-rgb), 0.12)' : '', width: '68px', height: '68px'}}
+                    >
+                        <CompassIcon
+                            icon={integration.icon || 'apps'}
+                            className={'expanded-integrations-icon'}
+                            style={{color: this.state.showIntegrations ? 'rgba(var(--dnd-indicator-rgb))' : 'white'}}
+                        />
+                    </button>
+                    <span
+                        style={{fontSize: '14px', fontWeight: 600, marginTop: '12px'}}
+                    >
+                        {integration.text}
+                    </span>
+                </>
+            );
+        } else {
+            integrationsButton = (
+                <>
+                    <button
+                        className='button-center-controls'
+                        onClick={() => this.setState({showIntegrations: !this.state.showIntegrations})}
+                        style={{background: this.state.showIntegrations ? 'rgba(var(--dnd-indicator-rgb), 0.12)' : '', width: '68px', height: '68px'}}
+                    >
+                        <CompassIcon
+                            icon='apps'
+                            className={'expanded-integrations-icon'}
+                            style={{color: this.state.showIntegrations ? 'rgba(var(--dnd-indicator-rgb))' : 'white'}}
+                        />
+                    </button>
+                    <span
+                        style={{fontSize: '14px', fontWeight: 600, marginTop: '12px'}}
+                    >
+                        {'Integrations'}
+                    </span>
+                    {this.renderIntegrations()}
+                </>
+            );
+        }
         return (
             <div
                 id='calls-expanded-view'
@@ -544,22 +589,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                                 >{raiseHandText}</span>
                             </div>
                             <div style={{...style.buttonContainer, position: 'relative'} as CSSProperties}>
-                                <button
-                                    className='button-center-controls'
-                                    onClick={() => this.setState({showIntegrations: !this.state.showIntegrations})}
-                                    style={{background: this.state.showIntegrations ? 'rgba(var(--dnd-indicator-rgb), 0.12)' : ''}}
-                                >
-                                    <ExpandIcon
-                                        style={{width: '28px', height: '28px'}}
-                                        fill={this.state.showIntegrations ? 'rgb(var(--dnd-indicator-rgb))' : 'white'}
-                                    />
-                                </button>
-                                <span
-                                    style={{fontSize: '14px', fontWeight: 600, marginTop: '12px'}}
-                                >
-                                    {'Integrations'}
-                                </span>
-                                {this.renderIntegrations()}
+                                {integrationsButton}
                             </div>
                             { (isSharing || !sharingID) &&
                             <div style={style.buttonContainer as CSSProperties}>

--- a/webapp/src/components/expanded_view/index.ts
+++ b/webapp/src/components/expanded_view/index.ts
@@ -12,7 +12,7 @@ import {UserState} from '../../types/types';
 
 import {alphaSortProfiles, stateSortProfiles, isDMChannel, getUserIdFromDM} from '../../utils';
 import {hideExpandedView, showScreenSourceModal} from '../../actions';
-import {expandedView, voiceChannelCallStartAt, connectedChannelID, voiceConnectedProfiles, voiceUsersStatuses, voiceChannelScreenSharingID} from '../../selectors';
+import {expandedView, voiceChannelCallStartAt, connectedChannelID, voiceConnectedProfiles, voiceUsersStatuses, voiceChannelScreenSharingID, voiceChannelRootPost} from '../../selectors';
 
 import ExpandedView from './component';
 
@@ -38,6 +38,8 @@ const mapStateToProps = (state: GlobalState) => {
         connectedDMUser = getUser(state, otherID);
     }
 
+    const postId = channel ? voiceChannelRootPost(state, channel.id) : '';
+
     return {
         show: expandedView(state),
         currentUserID: getCurrentUserId(state),
@@ -48,6 +50,8 @@ const mapStateToProps = (state: GlobalState) => {
         screenSharingID,
         channel,
         connectedDMUser,
+        integrations: (state as any).plugins.components.CallsDropdownMenu,
+        postId,
     };
 };
 

--- a/webapp/src/components/icons/compassIcon.tsx
+++ b/webapp/src/components/icons/compassIcon.tsx
@@ -6,12 +6,16 @@ import React from 'react';
 type Props = {
     icon: string,
     className?: string,
+    style?: React.CSSProperties,
 }
 
 export default function CompassIcon(props: Props): JSX.Element {
     // All compass icon classes start with icon,
     // so not expecting that prefix in props.
     return (
-        <i className={`CompassIcon icon-${props.icon} ${props.className}`}/>
+        <i
+            className={`CompassIcon icon-${props.icon} ${props.className}`}
+            style={props.style}
+        />
     );
 }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -7,7 +7,7 @@ import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getMyChannelRoles, getMySystemRoles} from 'mattermost-redux/selectors/entities/roles';
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
-import {getChannel as getChannelAction} from 'mattermost-redux/actions/channels';
+import {getChannel as getChannelAction, selectChannel} from 'mattermost-redux/actions/channels';
 import {getProfilesByIds as getProfilesByIdsAction} from 'mattermost-redux/actions/users';
 import {setThreadFollow} from 'mattermost-redux/actions/threads';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -674,6 +674,7 @@ export default class Plugin {
                             currentUserID: getCurrentUserId(store.getState()),
                         },
                     });
+                    await store.dispatch(selectChannel(expandedID));
                     fetchChannelData(expandedID);
                 }
             }


### PR DESCRIPTION
#### Summary
Add a pluggable menu item to the call widget.

Next step: Create similar pluggable (with the same elements) for the expanded view.

#### Related PR
https://github.com/matterpoll/matterpoll/pull/435
https://github.com/mattermost/mattermost-webapp/pull/10636

#### Screenshots
![Screenshot from 2022-06-23 12-59-08](https://user-images.githubusercontent.com/1933730/175332794-e610ac35-f880-446f-92b9-1e7fa6732830.png)
![Screenshot from 2022-06-23 14-43-52](https://user-images.githubusercontent.com/1933730/175332795-2895cc09-6180-4ff0-9755-348ae438ff71.png)
![Screenshot from 2022-06-23 14-44-14](https://user-images.githubusercontent.com/1933730/175332798-d3b37c34-65bf-4da9-9362-86726d298db4.png)
![Screenshot from 2022-06-23 14-44-24](https://user-images.githubusercontent.com/1933730/175332800-e4d0bdfb-2a97-4827-b68e-d26367d6b4d4.png)



#### Ticket Link
Hackaton
