### PR TITLE
[MM-42138] Avoid duplicate profiles in the redux state

### DIFF
--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -79,9 +79,10 @@ const voiceConnectedProfiles = (state: connectedProfilesState = {}, action: conn
                 [action.data.channelID]: [action.data.profile],
             };
         }
+
         // avoid duplicates
         for (const profile of state[action.data.channelID]) {
-            if (profile.id === action.data.profile.id) {
+            if (profile.id === action.data.profile?.id) {
                 return state;
             }
         }

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -79,6 +79,12 @@ const voiceConnectedProfiles = (state: connectedProfilesState = {}, action: conn
                 [action.data.channelID]: [action.data.profile],
             };
         }
+        // avoid duplicates
+        for (const profile of state[action.data.channelID]) {
+            if (profile.id === action.data.profile.id) {
+                return state;
+            }
+        }
         return {
             ...state,
             [action.data.channelID]: [


### PR DESCRIPTION
#### Summary

This one took some effort as for a long time I couldn't explain how a duplicate could cause all the mess reported (and seen from screenshots) and also couldn't explain the server going crazy and sending multiple events just like that. Turns out that having a single duplicate was enough to create a chain of bad DOM updates due to relying on the profile id as key in the `<li>` element. This meant the elements weren't getting deleted properly but constantly accumulating. 

To avoid all this I added some trivial deduplication check in the reducer. I understand it's far from ideal from a performance perspective but switching to anything more complex (e.g. using maps) is much more work that has its own drawbacks. I think it's okay to have this for the time being while we plan some proper redux overhaul.

The root cause is still uncertain but one theory I have is the following:

1. User is on an unstable connection, MM websocket drops at the same time some other participant leaves the call. 
2. Disconnected event for the leaving participant is missed due to the dropped ws connection. 
3. Ws reconnects.
4. When the same participant that left joins back a new `user_connected` event is received, causing a duplicate.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42138

