### PR TITLE
Fixed invalid json format

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -64,7 +64,7 @@
           "type": "longtext",
           "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
           "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]",
-          "placeholder": "[{\n \"urls\": \"[\"turn:turnserver.example.org:3478\"]\",\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]"
+          "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]"
         },
         {
           "key": "TURNStaticAuthSecret",


### PR DESCRIPTION
#### Summary
The json format of the ICE Servers Configurations placeholder was incorrect.
