### PR TITLE
[feat] Notice.txt generation configuration

### DIFF
--- a/.config/notice-file/Readme.md
+++ b/.config/notice-file/Readme.md
@@ -1,0 +1,28 @@
+# Notice.txt File Configuration
+
+We are automatically generating Notice.txt by using first-level dependencies of the project. The related pipeline uses `config.yaml` stored in this folder.
+
+
+## Configuration
+
+Sample:
+
+```
+title: "Mattermost Playbooks"
+copyright: "©2015-present Mattermost, Inc.  All Rights Reserved.  See LICENSE for license information."
+description: "This document includes a list of open source components used in Mattermost Playbooks, including those that have been modified."
+search:
+  - "go.mod"
+  - "client/go.mod"
+dependencies: []
+devDependencies: []
+```
+
+| Field | Type   | Purpose |
+| :--   | :--    | :--     |
+| title | string | Field content will be used as a title of the application. See first line of `NOTICE.txt` file. |
+| copyright | string | Field content will be used as a copyright message. See second line of `NOTICE.txt` file. |
+| description | string | Field content will be used as notice file description. See third line of `NOTICE.txt` file. |
+| dependencies | array | If any dependency name mentioned, it will be automatically added even if it is not a first-level dependency. |
+| devDependencies | array | If any dependency name mentioned, it will be added when it is referenced in devDependency section. |
+| search | array | Pipeline will search for package.json/go.mod files mentioned here. Globstar format is supported ie. `x/**/go.mod`. |

--- a/.config/notice-file/config.yaml
+++ b/.config/notice-file/config.yaml
@@ -1,0 +1,12 @@
+---
+
+title: "Mattermost Calls"
+copyright: "©2015-present Mattermost,Inc. All Rights Reserved. See LICENSE for license information."
+description: "This document includes a list of open source components used in Mattermost Calls plugin, including those that have been modified."
+search:
+  - "go.mod"
+  - "build/go.mod"
+dependencies: []
+devDependencies: []
+
+...


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Building on https://github.com/mattermost/mattermost-plugin-playbooks/pull/1255 we continue the effort to automate `notice.txt` generation for `mattermost-plugin-calls` 

We selected `.config/notice-file` directory, to store the configuration files. Let us know if we need to relocate this. 

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-3697
