### PR TITLE
[MM-43838] WebSocket reconnection support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.0.27
-	github.com/mattermost/rtcd v0.6.9-0.20220720125636-1c9fc9d4f040
+	github.com/mattermost/rtcd v0.6.9
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.0.27
-	github.com/mattermost/rtcd v0.6.8
+	github.com/mattermost/rtcd v0.6.9-0.20220720125636-1c9fc9d4f040
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/mattermost/mattermost-server/v6 v6.6.0 h1:47XbXSJu9fdbhZWG5bQ5dj3ySrI
 github.com/mattermost/mattermost-server/v6 v6.6.0/go.mod h1:oR6UCRo+SEvnfN2FEOdzHs1UljrskyCKU8tWeKlxgMo=
 github.com/mattermost/morph v0.0.0-20220401091636-39f834798da8/go.mod h1:jxM3g1bx+k2Thz7jofcHguBS8TZn5Pc+o5MGmORObhw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/rtcd v0.6.9-0.20220720125636-1c9fc9d4f040 h1:bYTMZqCKrWInOZgg3NvaTrlrgG7sKuiOwcF1cbZ1J/o=
-github.com/mattermost/rtcd v0.6.9-0.20220720125636-1c9fc9d4f040/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
+github.com/mattermost/rtcd v0.6.9 h1:higp9/tb1EcAwql4eB6NaFngtIGsaV6LhkyVuFj2uD8=
+github.com/mattermost/rtcd v0.6.9/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/mattermost/mattermost-server/v6 v6.6.0 h1:47XbXSJu9fdbhZWG5bQ5dj3ySrI
 github.com/mattermost/mattermost-server/v6 v6.6.0/go.mod h1:oR6UCRo+SEvnfN2FEOdzHs1UljrskyCKU8tWeKlxgMo=
 github.com/mattermost/morph v0.0.0-20220401091636-39f834798da8/go.mod h1:jxM3g1bx+k2Thz7jofcHguBS8TZn5Pc+o5MGmORObhw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/rtcd v0.6.8 h1:SHRsqty7wZuAG92iX7omq1ASaB5AxhakVQlkYekeHNo=
-github.com/mattermost/rtcd v0.6.8/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
+github.com/mattermost/rtcd v0.6.9-0.20220720125636-1c9fc9d4f040 h1:bYTMZqCKrWInOZgg3NvaTrlrgG7sKuiOwcF1cbZ1J/o=
+github.com/mattermost/rtcd v0.6.9-0.20220720125636-1c9fc9d4f040/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/server/activate.go
+++ b/server/activate.go
@@ -27,7 +27,7 @@ func (p *Plugin) OnActivate() error {
 	p.pluginAPI = pluginAPIClient
 	p.licenseChecker = enterprise.NewLicenseChecker(pluginAPIClient)
 
-	if !p.isHAEnabled() {
+	if p.isSingleHandler() {
 		if err := p.cleanUpState(); err != nil {
 			p.LogError(err.Error())
 			return err
@@ -74,6 +74,8 @@ func (p *Plugin) OnActivate() error {
 		p.LogDebug("rtcd client manager initialized successfully")
 
 		p.rtcdManager = rtcdManager
+
+		go p.clusterEventsHandler()
 
 		p.LogDebug("activated", "ClusterID", status.ClusterId)
 
@@ -154,7 +156,7 @@ func (p *Plugin) OnDeactivate() error {
 		}
 	}
 
-	if !p.isHAEnabled() {
+	if p.isSingleHandler() {
 		if err := p.cleanUpState(); err != nil {
 			p.LogError(err.Error())
 		}

--- a/server/client_message.go
+++ b/server/client_message.go
@@ -14,6 +14,8 @@ type clientMessage struct {
 
 const (
 	clientMessageTypeJoin        = "join"
+	clientMessageTypeLeave       = "leave"
+	clientMessageTypeReconnect   = "reconnect"
 	clientMessageTypeSDP         = "sdp"
 	clientMessageTypeICE         = "ice"
 	clientMessageTypeMute        = "mute"

--- a/server/client_message.go
+++ b/server/client_message.go
@@ -9,7 +9,7 @@ import (
 
 type clientMessage struct {
 	Type string          `json:"type"`
-	Data json.RawMessage `json:"data"`
+	Data json.RawMessage `json:"data,omitempty"`
 }
 
 const (

--- a/server/cluster_message.go
+++ b/server/cluster_message.go
@@ -12,7 +12,6 @@ import (
 
 type clusterMessage struct {
 	ConnID        string        `json:"conn_id,omitempty"`
-	PrevConnID    string        `json:"prev_conn_id,omitempty"`
 	UserID        string        `json:"user_id,omitempty"`
 	ChannelID     string        `json:"channel_id,omitempty"`
 	SenderID      string        `json:"sender_id,omitempty"`

--- a/server/cluster_message.go
+++ b/server/cluster_message.go
@@ -11,12 +11,12 @@ import (
 )
 
 type clusterMessage struct {
-	ConnID        string        `json:"conn_id"`
+	ConnID        string        `json:"conn_id,omitempty"`
 	PrevConnID    string        `json:"prev_conn_id,omitempty"`
-	UserID        string        `json:"user_id"`
-	ChannelID     string        `json:"channel_id"`
-	SenderID      string        `json:"sender_id"`
-	ClientMessage clientMessage `json:"client_message"`
+	UserID        string        `json:"user_id,omitempty"`
+	ChannelID     string        `json:"channel_id,omitempty"`
+	SenderID      string        `json:"sender_id,omitempty"`
+	ClientMessage clientMessage `json:"client_message,omitempty"`
 }
 
 type clusterMessageType string

--- a/server/cluster_message.go
+++ b/server/cluster_message.go
@@ -12,6 +12,7 @@ import (
 
 type clusterMessage struct {
 	ConnID        string        `json:"conn_id"`
+	PrevConnID    string        `json:"prev_conn_id,omitempty"`
 	UserID        string        `json:"user_id"`
 	ChannelID     string        `json:"channel_id"`
 	SenderID      string        `json:"sender_id"`
@@ -23,6 +24,8 @@ type clusterMessageType string
 const (
 	clusterMessageTypeConnect    clusterMessageType = "connect"
 	clusterMessageTypeDisconnect clusterMessageType = "disconnect"
+	clusterMessageTypeLeave      clusterMessageType = "leave"
+	clusterMessageTypeReconnect  clusterMessageType = "reconnect"
 	clusterMessageTypeSignaling  clusterMessageType = "signaling"
 	clusterMessageTypeUserState  clusterMessageType = "user_state"
 )

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -346,9 +346,25 @@ func (p *Plugin) setOverrides(cfg *configuration) {
 	}
 }
 
-func (p *Plugin) isHAEnabled() bool {
+func (p *Plugin) isSingleHandler() bool {
 	cfg := p.API.GetConfig()
-	return cfg != nil && cfg.ClusterSettings.Enable != nil && *cfg.ClusterSettings.Enable
+	pluginCfg := p.getConfiguration()
+
+	if cfg == nil || pluginCfg == nil || p.licenseChecker == nil {
+		return false
+	}
+
+	rtcdURL := pluginCfg.getRTCDURL()
+	hasRTCD := rtcdURL != "" && p.licenseChecker.RTCDAllowed()
+
+	if hasRTCD {
+		return false
+	}
+
+	isHA := cfg.ClusterSettings.Enable != nil && *cfg.ClusterSettings.Enable
+	hasEnvVar := os.Getenv("MM_CALLS_IS_HANDLER") != ""
+
+	return !isHA || (isHA && hasEnvVar)
 }
 
 func (c *configuration) getICEServers(forClient bool) ICEServersConfigs {

--- a/server/main.go
+++ b/server/main.go
@@ -20,7 +20,7 @@ var rudderDataplaneURL string
 // This value should be high enough to handle up to N events where N is the maximum
 // expected number of concurrent user sessions in calls handled by a single
 // instance.
-const clusterEventQueueSize = 1024
+const clusterEventQueueSize = 4096
 
 func main() {
 	plugin.ClientMain(&Plugin{

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -133,16 +133,12 @@ func (p *Plugin) handleEvent(ev model.PluginClusterEvent) error {
 		go p.startSession(us, msg.SenderID)
 		return nil
 	case clusterMessageTypeReconnect:
-		p.LogDebug("reconnect event", "UserID", msg.UserID, "ConnID", msg.ConnID, "PrevConnID", msg.PrevConnID)
+		p.LogDebug("reconnect event", "UserID", msg.UserID, "ConnID", msg.ConnID)
 
 		p.mut.Lock()
 		defer p.mut.Unlock()
 
 		us := p.sessions[msg.ConnID]
-		if us == nil && msg.PrevConnID != "" {
-			us = p.sessions[msg.PrevConnID]
-		}
-
 		if us == nil {
 			return nil
 		}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -133,7 +133,7 @@ func (p *Plugin) handleEvent(ev model.PluginClusterEvent) error {
 		go p.startSession(us, msg.SenderID)
 		return nil
 	case clusterMessageTypeReconnect:
-		p.LogDebug("reconnect event", "ChannelID", msg.ChannelID, "UserID", msg.UserID, "ConnID", msg.ConnID, "PrevConnID", msg.PrevConnID)
+		p.LogDebug("reconnect event", "UserID", msg.UserID, "ConnID", msg.ConnID, "PrevConnID", msg.PrevConnID)
 
 		p.mut.Lock()
 		defer p.mut.Unlock()
@@ -159,7 +159,7 @@ func (p *Plugin) handleEvent(ev model.PluginClusterEvent) error {
 
 		return nil
 	case clusterMessageTypeLeave:
-		p.LogDebug("leave event", "ChannelID", msg.ChannelID, "UserID", msg.UserID, "ConnID", msg.ConnID)
+		p.LogDebug("leave event", "UserID", msg.UserID, "ConnID", msg.ConnID)
 
 		p.mut.RLock()
 		us := p.sessions[msg.ConnID]

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -52,23 +53,27 @@ type Plugin struct {
 }
 
 func (p *Plugin) startSession(us *session, senderID string) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-	defer func() {
-		wg.Wait()
-		p.LogDebug("exiting session handler")
-	}()
-
-	go func() {
-		defer wg.Done()
-		cfg := rtc.SessionConfig{
-			GroupID:   "default",
-			CallID:    us.channelID,
-			UserID:    us.userID,
-			SessionID: us.connID,
+	cfg := rtc.SessionConfig{
+		GroupID:   "default",
+		CallID:    us.channelID,
+		UserID:    us.userID,
+		SessionID: us.connID,
+	}
+	if err := p.rtcServer.InitSession(cfg, func() error {
+		p.LogDebug("rtc session close cb", "sessionID", us.connID)
+		if atomic.CompareAndSwapInt32(&us.rtcClosed, 0, 1) {
+			close(us.rtcCloseCh)
 		}
-		if err := p.rtcServer.InitSession(cfg, nil); err != nil {
-			p.LogError(err.Error(), "sessionConfig", fmt.Sprintf("%+v", cfg))
+		return p.removeSession(us)
+	}); err != nil {
+		p.LogError(err.Error(), "sessionConfig", fmt.Sprintf("%+v", cfg))
+		return
+	}
+
+	defer func() {
+		p.LogDebug("closing rtc session", "sessionID", us.connID)
+		if err := p.rtcServer.CloseSession(us.connID); err != nil {
+			p.LogError("failed to close session", "error", err.Error())
 		}
 	}()
 
@@ -91,7 +96,7 @@ func (p *Plugin) startSession(us *session, senderID string) {
 			if err := p.sendClusterMessage(clusterMsg, clusterMessageTypeSignaling, senderID); err != nil {
 				p.LogError(err.Error())
 			}
-		case <-us.closeCh:
+		case <-us.rtcCloseCh:
 			return
 		}
 	}
@@ -113,36 +118,80 @@ func (p *Plugin) handleEvent(ev model.PluginClusterEvent) error {
 		return err
 	}
 
-	p.mut.RLock()
-	us := p.sessions[msg.ConnID]
-	p.mut.RUnlock()
-
 	switch clusterMessageType(ev.Id) {
 	case clusterMessageTypeConnect:
+		p.LogDebug("connect event", "ChannelID", msg.ChannelID, "UserID", msg.UserID, "ConnID", msg.ConnID)
+		p.mut.Lock()
+		defer p.mut.Unlock()
+		us := p.sessions[msg.ConnID]
 		if us != nil {
 			return fmt.Errorf("session already exists, userID=%q, connID=%q, channelID=%q",
 				us.userID, msg.ConnID, us.channelID)
 		}
-		us := newUserSession(msg.UserID, msg.ChannelID, msg.ConnID)
-		p.mut.Lock()
+		us = newUserSession(msg.UserID, msg.ChannelID, msg.ConnID, true)
 		p.sessions[msg.ConnID] = us
-		p.mut.Unlock()
 		go p.startSession(us, msg.SenderID)
+		return nil
+	case clusterMessageTypeReconnect:
+		p.LogDebug("reconnect event", "ChannelID", msg.ChannelID, "UserID", msg.UserID, "ConnID", msg.ConnID, "PrevConnID", msg.PrevConnID)
+
+		p.mut.Lock()
+		defer p.mut.Unlock()
+
+		us := p.sessions[msg.ConnID]
+		if us == nil && msg.PrevConnID != "" {
+			us = p.sessions[msg.PrevConnID]
+		}
+
+		if us == nil {
+			return nil
+		}
+
+		if atomic.CompareAndSwapInt32(&us.wsReconnected, 0, 1) {
+			p.LogDebug("closing reconnectCh", "connID", msg.ConnID)
+			close(us.wsReconnectCh)
+			if !us.rtc {
+				delete(p.sessions, us.connID)
+			}
+		} else {
+			return fmt.Errorf("session already reconnected, connID=%q", msg.ConnID)
+		}
+
+		return nil
+	case clusterMessageTypeLeave:
+		p.LogDebug("leave event", "ChannelID", msg.ChannelID, "UserID", msg.UserID, "ConnID", msg.ConnID)
+
+		p.mut.RLock()
+		us := p.sessions[msg.ConnID]
+		p.mut.RUnlock()
+
+		if us == nil {
+			return nil
+		}
+
+		if atomic.CompareAndSwapInt32(&us.left, 0, 1) {
+			p.LogDebug("closing leaveCh", "connID", msg.ConnID)
+			close(us.leaveCh)
+		}
 	case clusterMessageTypeDisconnect:
+		p.LogDebug("disconnect event", "ChannelID", msg.ChannelID, "UserID", msg.UserID, "ConnID", msg.ConnID)
+		p.mut.RLock()
+		us := p.sessions[msg.ConnID]
+		p.mut.RUnlock()
 		if us == nil {
 			return fmt.Errorf("session doesn't exist, ev=%s, userID=%q, connID=%q, channelID=%q",
 				ev.Id, msg.UserID, msg.ConnID, msg.ChannelID)
 		}
-		p.LogDebug("disconnect event", "ChannelID", msg.ChannelID, "UserID", msg.UserID)
-		p.mut.Lock()
-		delete(p.sessions, us.connID)
-		p.mut.Unlock()
-		close(us.signalInCh)
-		close(us.closeCh)
-		if err := p.rtcServer.CloseSession(us.connID); err != nil {
-			return fmt.Errorf("failed to close session: %w", err)
+		if atomic.CompareAndSwapInt32(&us.rtcClosed, 0, 1) {
+			close(us.rtcCloseCh)
 		}
+		return nil
 	case clusterMessageTypeSignaling:
+		p.LogDebug("signaling event", "ChannelID", msg.ChannelID, "UserID", msg.UserID, "ConnID", msg.ConnID)
+		p.mut.RLock()
+		us := p.sessions[msg.ConnID]
+		p.mut.RUnlock()
+
 		if us == nil {
 			return fmt.Errorf("session doesn't exist, ev=%s, userID=%q, connID=%q, channelID=%q",
 				ev.Id, msg.UserID, msg.ConnID, msg.ChannelID)
@@ -165,6 +214,11 @@ func (p *Plugin) handleEvent(ev model.PluginClusterEvent) error {
 			return fmt.Errorf("failed to send RTC message: %w", err)
 		}
 	case clusterMessageTypeUserState:
+		p.LogDebug("user state event", "ChannelID", msg.ChannelID, "UserID", msg.UserID, "ConnID", msg.ConnID)
+		p.mut.RLock()
+		us := p.sessions[msg.ConnID]
+		p.mut.RUnlock()
+
 		if us == nil {
 			return fmt.Errorf("session doesn't exist, ev=%s, userID=%q, connID=%q, channelID=%q",
 				ev.Id, msg.UserID, msg.ConnID, msg.ChannelID)

--- a/server/session.go
+++ b/server/session.go
@@ -24,18 +24,26 @@ type session struct {
 	originalConnID string
 
 	// WebSocket
-	signalOutCh   chan []byte
-	wsMsgCh       chan clientMessage
-	wsCloseCh     chan struct{}
-	wsClosed      int32
+
+	signalOutCh chan []byte
+	wsMsgCh     chan clientMessage
+	// to notify of websocket disconnect.
+	wsCloseCh chan struct{}
+	wsClosed  int32
+	// to notify of websocket reconnection.
 	wsReconnectCh chan struct{}
 	wsReconnected int32
 
 	// RTC
+
+	// to notify of rtc session disconnect.
 	rtcCloseCh chan struct{}
 	rtcClosed  int32
-	rtc        bool
+	// rtc indicates whether or not the session is also handling the WebRTC
+	// connection.
+	rtc bool
 
+	// to notify of session leaving a call.
 	leaveCh chan struct{}
 	left    int32
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -540,10 +540,9 @@ func (p *Plugin) handleReconnect(userID, connID, channelID, originalConnID, prev
 	p.mut.Unlock()
 
 	if err := p.sendClusterMessage(clusterMessage{
-		ConnID:     connID,
-		PrevConnID: prevConnID,
-		UserID:     userID,
-		SenderID:   p.nodeID,
+		ConnID:   prevConnID,
+		UserID:   userID,
+		SenderID: p.nodeID,
 	}, clusterMessageTypeReconnect, ""); err != nil {
 		p.LogError(err.Error())
 	}
@@ -631,7 +630,7 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 			return
 		}
 		prevConnID, _ := req.Data["prevConnID"].(string)
-		if connID != originalConnID && prevConnID == "" {
+		if prevConnID == "" {
 			p.LogError("missing prevConnID")
 			return
 		}

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -543,7 +543,6 @@ func (p *Plugin) handleReconnect(userID, connID, channelID, originalConnID, prev
 		ConnID:     connID,
 		PrevConnID: prevConnID,
 		UserID:     userID,
-		ChannelID:  channelID,
 		SenderID:   p.nodeID,
 	}, clusterMessageTypeReconnect, ""); err != nil {
 		p.LogError(err.Error())
@@ -647,21 +646,14 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 	case clientMessageTypeLeave:
 		p.LogDebug("leave message", "userID", userID, "connID", connID)
 
-		channelID, ok := req.Data["channelID"].(string)
-		if !ok {
-			p.LogError("missing channelID")
-			return
-		}
-
 		if us != nil && atomic.CompareAndSwapInt32(&us.left, 0, 1) {
 			close(us.leaveCh)
 		}
 
 		if err := p.sendClusterMessage(clusterMessage{
-			ConnID:    connID,
-			UserID:    userID,
-			ChannelID: channelID,
-			SenderID:  p.nodeID,
+			ConnID:   connID,
+			UserID:   userID,
+			SenderID: p.nodeID,
 		}, clusterMessageTypeLeave, ""); err != nil {
 			p.LogError(err.Error())
 		}

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	rtcd "github.com/mattermost/rtcd/service"
@@ -32,6 +32,7 @@ const (
 	wsEventUserUnraiseHand  = "user_unraise_hand"
 	wsEventJoin             = "join"
 	wsEventError            = "error"
+	wsReconnectionTimeout   = 10 * time.Second
 )
 
 func (p *Plugin) handleClientMessageTypeScreen(us *session, msg clientMessage, handlerID string) error {
@@ -78,7 +79,7 @@ func (p *Plugin) handleClientMessageTypeScreen(us *session, msg clientMessage, h
 
 	if handlerID != p.nodeID {
 		if err := p.sendClusterMessage(clusterMessage{
-			ConnID:        us.connID,
+			ConnID:        us.originalConnID,
 			UserID:        us.userID,
 			ChannelID:     us.channelID,
 			SenderID:      p.nodeID,
@@ -88,7 +89,7 @@ func (p *Plugin) handleClientMessageTypeScreen(us *session, msg clientMessage, h
 		}
 	} else {
 		rtcMsg := rtc.Message{
-			SessionID: us.connID,
+			SessionID: us.originalConnID,
 			Type:      msgType,
 			Data:      msg.Data,
 		}
@@ -113,7 +114,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 		if handlerID != p.nodeID {
 			// need to relay signaling.
 			if err := p.sendClusterMessage(clusterMessage{
-				ConnID:        us.connID,
+				ConnID:        us.originalConnID,
 				UserID:        us.userID,
 				ChannelID:     us.channelID,
 				SenderID:      p.nodeID,
@@ -123,7 +124,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 			}
 		} else {
 			rtcMsg := rtc.Message{
-				SessionID: us.connID,
+				SessionID: us.originalConnID,
 				Type:      rtc.SDPMessage,
 				Data:      msg.Data,
 			}
@@ -136,7 +137,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 		p.LogDebug("candidate!")
 		if handlerID == p.nodeID {
 			rtcMsg := rtc.Message{
-				SessionID: us.connID,
+				SessionID: us.originalConnID,
 				Type:      rtc.ICEMessage,
 				Data:      msg.Data,
 			}
@@ -147,7 +148,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 		} else {
 			// need to relay signaling.
 			if err := p.sendClusterMessage(clusterMessage{
-				ConnID:        us.connID,
+				ConnID:        us.originalConnID,
 				UserID:        us.userID,
 				ChannelID:     us.channelID,
 				SenderID:      p.nodeID,
@@ -160,7 +161,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 		if handlerID != p.nodeID {
 			// need to relay track event.
 			if err := p.sendClusterMessage(clusterMessage{
-				ConnID:        us.connID,
+				ConnID:        us.originalConnID,
 				UserID:        us.userID,
 				ChannelID:     us.channelID,
 				SenderID:      p.nodeID,
@@ -175,7 +176,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 			}
 
 			rtcMsg := rtc.Message{
-				SessionID: us.connID,
+				SessionID: us.originalConnID,
 				Type:      msgType,
 				Data:      msg.Data,
 			}
@@ -265,17 +266,13 @@ func (p *Plugin) OnWebSocketDisconnect(connID, userID string) {
 	p.mut.RLock()
 	us := p.sessions[connID]
 	p.mut.RUnlock()
-
 	if us != nil {
-		go func() {
-			p.LogDebug("closing channel for session", "userID", userID, "connID", connID, "channelID", us.channelID)
+		if atomic.CompareAndSwapInt32(&us.wsClosed, 0, 1) {
+			p.LogDebug("closing ws channel for session", "userID", userID, "connID", connID, "channelID", us.channelID)
 			close(us.wsCloseCh)
-			<-us.doneCh
-			p.LogDebug("done, removing session", "userID", userID, "connID", connID, "channelID", us.channelID)
-			p.mut.Lock()
-			delete(p.sessions, connID)
-			p.mut.Unlock()
-		}()
+		} else {
+			p.LogError("ws channel already closed", "userID", userID, "connID", connID, "channelID", us.channelID)
+		}
 	}
 }
 
@@ -287,6 +284,10 @@ func (p *Plugin) wsReader(us *session, handlerID string) {
 				return
 			}
 			p.handleClientMsg(us, msg, handlerID)
+		case <-us.wsReconnectCh:
+			return
+		case <-us.leaveCh:
+			return
 		case <-us.wsCloseCh:
 			return
 		}
@@ -330,6 +331,53 @@ func (p *Plugin) wsWriter() {
 	}
 }
 
+func (p *Plugin) handleLeave(us *session, userID, connID, channelID string) error {
+	p.LogDebug("handleLeave", "userID", userID, "connID", connID, "channelID", channelID)
+
+	select {
+	case <-us.wsReconnectCh:
+		p.LogDebug("reconnected, returning", "userID", userID, "connID", connID, "channelID", channelID)
+		return nil
+	case <-us.leaveCh:
+		p.LogDebug("user left call", "userID", userID, "connID", connID, "channelID", us.channelID)
+	case <-time.After(wsReconnectionTimeout):
+		p.LogDebug("timeout waiting for reconnection", "userID", userID, "connID", connID, "channelID", channelID)
+	}
+
+	state, err := p.kvGetChannelState(channelID)
+	if err != nil {
+		return err
+	} else if state != nil && state.Call != nil && state.Call.ScreenSharingID == userID {
+		p.API.PublishWebSocketEvent(wsEventUserScreenOff, map[string]interface{}{}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
+	}
+
+	handlerID, err := p.getHandlerID()
+	if err != nil {
+		p.LogError(err.Error())
+	}
+	if handlerID == "" && state != nil {
+		handlerID = state.NodeID
+	}
+
+	if err := p.closeRTCSession(userID, us.originalConnID, channelID, handlerID); err != nil {
+		p.LogError(err.Error())
+	}
+
+	if err := p.removeSession(us); err != nil {
+		p.LogError(err.Error())
+	}
+
+	if state != nil && state.Call != nil {
+		p.track(evCallUserLeft, map[string]interface{}{
+			"ParticipantID": userID,
+			"ChannelID":     channelID,
+			"CallID":        state.Call.ID,
+		})
+	}
+
+	return nil
+}
+
 func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 	p.LogDebug("handleJoin", "userID", userID, "connID", connID, "channelID", channelID)
 
@@ -340,19 +388,6 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 	if appErr != nil {
 		return appErr
 	}
-
-	p.mut.Lock()
-	if _, exists := p.sessions[connID]; exists {
-		p.mut.Unlock()
-		p.LogDebug("session already exists", "userID", userID, "connID", connID, "channelID", channelID)
-		return fmt.Errorf("session already exists")
-	}
-	us := newUserSession(userID, channelID, connID)
-	p.sessions[connID] = us
-	p.mut.Unlock()
-	defer func() {
-		close(us.doneCh)
-	}()
 
 	state, err := p.addUserSession(userID, connID, channel)
 	if err != nil {
@@ -382,35 +417,25 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 		}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
 	}
 
-	defer func() {
-		p.LogDebug("removing session from state", "userID", userID)
-		if currState, prevState, err := p.removeUserSession(userID, connID, channelID); err != nil {
-			p.LogError(err.Error())
-		} else if currState.Call == nil && prevState.Call != nil {
-			// call has ended
-			if dur, err := p.updateCallThreadEnded(prevState.Call.ThreadID); err != nil {
-				p.LogError(err.Error())
-			} else {
-				p.track(evCallEnded, map[string]interface{}{
-					"ChannelID":    channelID,
-					"CallID":       prevState.Call.ID,
-					"Duration":     dur,
-					"Participants": prevState.Call.Stats.Participants,
-				})
-			}
-		}
-	}()
-
 	handlerID, err := p.getHandlerID()
-	p.LogDebug("got handlerID", "handlerID", handlerID)
 	if err != nil {
 		p.LogError(err.Error())
 	}
 	if handlerID == "" {
 		handlerID = state.NodeID
 	}
+	p.LogDebug("got handlerID", "handlerID", handlerID)
 
-	var wg sync.WaitGroup
+	us := newUserSession(userID, channelID, connID, p.rtcdManager == nil && handlerID == p.nodeID)
+	p.mut.Lock()
+	p.sessions[connID] = us
+	p.mut.Unlock()
+	defer func() {
+		if err := p.handleLeave(us, userID, connID, channelID); err != nil {
+			p.LogError(err.Error())
+		}
+	}()
+
 	if p.rtcdManager != nil {
 		msg := rtcd.ClientMessage{
 			Type: rtcd.ClientMessageJoin,
@@ -432,7 +457,13 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 				SessionID: connID,
 			}
 			p.LogDebug("initializing RTC session", "userID", userID, "connID", connID, "channelID", channelID)
-			if err = p.rtcServer.InitSession(cfg, nil); err != nil {
+			if err = p.rtcServer.InitSession(cfg, func() error {
+				if atomic.CompareAndSwapInt32(&us.rtcClosed, 0, 1) {
+					close(us.rtcCloseCh)
+					return p.removeSession(us)
+				}
+				return nil
+			}); err != nil {
 				return fmt.Errorf("failed to init session: %w", err)
 			}
 		} else {
@@ -464,39 +495,85 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 		"CallID":        state.Call.ID,
 	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		p.wsReader(us, handlerID)
-	}()
+	p.wsReader(us, handlerID)
 
-	select {
-	case <-p.stopCh:
-		p.LogDebug("stop received, exiting")
-	case <-us.wsCloseCh:
-		p.LogDebug("done", "userID", userID, "connID", connID, "channelID", channelID)
+	return nil
+}
+
+func (p *Plugin) handleReconnect(userID, connID, channelID, originalConnID, prevConnID string) error {
+	p.LogDebug("handleReconnect", "userID", userID, "connID", connID, "channelID", channelID,
+		"originalConnID", originalConnID, "prevConnID", prevConnID)
+
+	if !p.API.HasPermissionToChannel(userID, channelID, model.PermissionCreatePost) {
+		return fmt.Errorf("forbidden")
 	}
 
-	if state, err := p.kvGetChannelState(channelID); err != nil {
+	state, err := p.kvGetChannelState(channelID)
+	if err != nil {
+		return err
+	} else if state == nil || state.Call == nil {
+		return fmt.Errorf("call state not found")
+	} else if _, ok := state.Call.Sessions[originalConnID]; !ok {
+		return fmt.Errorf("session not found in call state")
+	}
+
+	var rtc bool
+	p.mut.Lock()
+	us := p.sessions[connID]
+	if us != nil {
+		rtc = us.rtc
+		if atomic.CompareAndSwapInt32(&us.wsReconnected, 0, 1) {
+			p.LogDebug("closing reconnectCh", "userID", userID, "connID", connID, "channelID", channelID,
+				"originalConnID", originalConnID)
+			close(us.wsReconnectCh)
+		} else {
+			p.mut.Unlock()
+			return fmt.Errorf("session already reconnected")
+		}
+	} else {
+		p.LogDebug("session not found", "connID", connID)
+	}
+
+	us = newUserSession(userID, channelID, connID, rtc)
+	us.originalConnID = originalConnID
+	p.sessions[connID] = us
+	p.mut.Unlock()
+
+	if err := p.sendClusterMessage(clusterMessage{
+		ConnID:     connID,
+		PrevConnID: prevConnID,
+		UserID:     userID,
+		ChannelID:  channelID,
+		SenderID:   p.nodeID,
+	}, clusterMessageTypeReconnect, ""); err != nil {
 		p.LogError(err.Error())
-	} else if state != nil && state.Call != nil && state.Call.ScreenSharingID == userID {
-		p.API.PublishWebSocketEvent(wsEventUserScreenOff, map[string]interface{}{}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
 	}
 
-	if err := p.closeRTCSession(userID, connID, channelID, handlerID); err != nil {
+	if p.rtcdManager != nil {
+		msg := rtcd.ClientMessage{
+			Type: rtcd.ClientMessageReconnect,
+			Data: map[string]string{
+				"sessionID": originalConnID,
+			},
+		}
+		if err := p.rtcdManager.Send(msg, channelID); err != nil {
+			return fmt.Errorf("failed to send client reconnect message: %w", err)
+		}
+	}
+
+	handlerID, err := p.getHandlerID()
+	if err != nil {
 		p.LogError(err.Error())
 	}
+	if handlerID == "" && state != nil {
+		handlerID = state.NodeID
+	}
 
-	wg.Wait()
+	p.wsReader(us, handlerID)
 
-	p.API.PublishWebSocketEvent(wsEventUserDisconnected, map[string]interface{}{
-		"userID": userID,
-	}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
-	p.track(evCallUserLeft, map[string]interface{}{
-		"ParticipantID": userID,
-		"ChannelID":     channelID,
-		"CallID":        state.Call.ID,
-	})
+	if err := p.handleLeave(us, userID, connID, channelID); err != nil {
+		p.LogError(err.Error())
+	}
 
 	return nil
 }
@@ -509,7 +586,9 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 	us := p.sessions[connID]
 	p.mut.RUnlock()
 
-	if msg.Type != clientMessageTypeJoin && us == nil {
+	if msg.Type != clientMessageTypeJoin &&
+		msg.Type != clientMessageTypeLeave &&
+		msg.Type != clientMessageTypeReconnect && us == nil {
 		return
 	}
 
@@ -525,6 +604,7 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 			p.LogError("missing channelID")
 			return
 		}
+
 		// Title is optional, so if it's not present,
 		// it will be an empty string.
 		title, _ := req.Data["title"].(string)
@@ -539,6 +619,53 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 				return
 			}
 		}()
+		return
+	case clientMessageTypeReconnect:
+		channelID, _ := req.Data["channelID"].(string)
+		if channelID == "" {
+			p.LogError("missing channelID")
+			return
+		}
+		originalConnID, _ := req.Data["originalConnID"].(string)
+		if originalConnID == "" {
+			p.LogError("missing originalConnID")
+			return
+		}
+		prevConnID, _ := req.Data["prevConnID"].(string)
+		if connID != originalConnID && prevConnID == "" {
+			p.LogError("missing prevConnID")
+			return
+		}
+
+		go func() {
+			if err := p.handleReconnect(userID, connID, channelID, originalConnID, prevConnID); err != nil {
+				p.LogError(err.Error(), "userID", userID, "connID", connID,
+					"originalConnID", originalConnID, "prevConnID", prevConnID, "channelID", channelID)
+			}
+		}()
+		return
+	case clientMessageTypeLeave:
+		p.LogDebug("leave message", "userID", userID, "connID", connID)
+
+		channelID, ok := req.Data["channelID"].(string)
+		if !ok {
+			p.LogError("missing channelID")
+			return
+		}
+
+		if us != nil && atomic.CompareAndSwapInt32(&us.left, 0, 1) {
+			close(us.leaveCh)
+		}
+
+		if err := p.sendClusterMessage(clusterMessage{
+			ConnID:    connID,
+			UserID:    userID,
+			ChannelID: channelID,
+			SenderID:  p.nodeID,
+		}, clusterMessageTypeLeave, ""); err != nil {
+			p.LogError(err.Error())
+		}
+
 		return
 	case clientMessageTypeSDP:
 		msgData, ok := req.Data["data"].([]byte)
@@ -570,6 +697,7 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 }
 
 func (p *Plugin) closeRTCSession(userID, connID, channelID, handlerID string) error {
+	p.LogDebug("closeRTCSession", "userID", userID, "connID", connID, "channelID", channelID)
 	if p.rtcServer != nil {
 		if handlerID == p.nodeID {
 			if err := p.rtcServer.CloseSession(connID); err != nil {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -345,9 +345,7 @@ export default class CallsClient extends EventEmitter {
         });
 
         if (this.ws) {
-            this.ws.send('leave', {
-                channelID: this.channelID,
-            });
+            this.ws.send('leave');
             this.ws.close();
             this.ws = null;
         }

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -326,6 +326,12 @@ export default class CallsClient extends EventEmitter {
 
     public disconnect() {
         logDebug('disconnect');
+
+        if (this.closed) {
+            logErr('client already disconnected');
+            return;
+        }
+
         this.closed = true;
         if (this.peer) {
             this.peer.destroy();

--- a/webapp/src/websocket.ts
+++ b/webapp/src/websocket.ts
@@ -3,28 +3,56 @@ import {EventEmitter} from 'events';
 import {encode} from '@msgpack/msgpack/dist';
 
 import {pluginId} from './manifest';
-import {logWarn, logErr} from './log';
+import {logDebug, logInfo, logWarn, logErr} from './log';
 
-export default class WebSocketClient extends EventEmitter {
-    private ws: WebSocket | null;
+const wsMinReconnectRetryTimeMs = 1000; // 1 second
+const wsReconnectionTimeout = 30000; // 30 seconds
+const wsReconnectTimeIncrement = 500; // 0.5 seconds
+export const wsReconnectionTimeoutErr = new Error('max disconnected time reached');
+
+export class WebSocketClient extends EventEmitter {
+    private ws: WebSocket | null = null;
+    private wsURL: string;
     private seqNo = 1;
+    private serverSeqNo = 0;
     private connID = '';
+    private originalConnID = '';
     private eventPrefix: string = 'custom_' + pluginId;
+    private lastDisconnect = 0;
+    private reconnectRetryTime = wsMinReconnectRetryTimeMs;
+    private closed = false;
 
     constructor(wsURL: string) {
         super();
-        this.ws = new WebSocket(wsURL);
+        this.wsURL = wsURL;
+        this.init(false);
+    }
+
+    private init(isReconnect: boolean) {
+        if (this.closed) {
+            logWarn('client is closed!');
+            return;
+        }
+        this.ws = new WebSocket(`${this.wsURL}?connection_id=${this.connID}&sequence_number=${this.serverSeqNo}`);
 
         this.ws.onerror = (err) => {
             this.emit('error', err);
-            this.ws = null;
-            this.close();
         };
 
         this.ws.onclose = ({code}) => {
             this.ws = null;
-            this.close(code);
+            if (!this.closed) {
+                this.close(code);
+            }
         };
+
+        if (isReconnect) {
+            this.ws.onopen = () => {
+                this.lastDisconnect = 0;
+                this.reconnectRetryTime = wsMinReconnectRetryTimeMs;
+                this.emit('open', this.originalConnID, this.connID, true);
+            };
+        }
 
         this.ws.onmessage = ({data}) => {
             if (!data) {
@@ -35,6 +63,11 @@ export default class WebSocketClient extends EventEmitter {
                 msg = JSON.parse(data);
             } catch (err) {
                 logErr('ws msg parse error', err);
+                return;
+            }
+
+            if (msg) {
+                this.serverSeqNo = msg.seq + 1;
             }
 
             if (!msg || !msg.event || !msg.data) {
@@ -42,15 +75,25 @@ export default class WebSocketClient extends EventEmitter {
             }
 
             if (msg.event === 'hello') {
-                this.connID = msg.data.connection_id;
-                this.emit('open');
+                if (msg.data.connection_id !== this.connID) {
+                    logDebug('ws: new conn id from server');
+                    this.connID = msg.data.connection_id;
+                    this.serverSeqNo = 0;
+                    if (this.originalConnID === '') {
+                        logDebug('ws: setting original conn id');
+                        this.originalConnID = this.connID;
+                    }
+                }
+                if (!isReconnect) {
+                    this.emit('open', this.originalConnID, this.connID, false);
+                }
                 return;
             } else if (!this.connID) {
                 logWarn('ws message received while waiting for hello');
                 return;
             }
 
-            if (msg.data.connID !== this.connID) {
+            if (msg.data.connID !== this.connID && msg.data.connID !== this.originalConnID) {
                 return;
             }
 
@@ -85,12 +128,35 @@ export default class WebSocketClient extends EventEmitter {
 
     close(code?: number) {
         if (this.ws) {
+            this.closed = true;
             this.ws.close();
             this.ws = null;
+            this.seqNo = 1;
+            this.serverSeqNo = 0;
+            this.connID = '';
+            this.originalConnID = '';
         } else {
             this.emit('close', code);
+
+            const now = Date.now();
+            if (this.lastDisconnect === 0) {
+                this.lastDisconnect = now;
+            }
+
+            if ((now - this.lastDisconnect) >= wsReconnectionTimeout) {
+                this.closed = true;
+                this.emit('error', wsReconnectionTimeoutErr);
+                return;
+            }
+
+            setTimeout(() => {
+                if (!this.ws && !this.closed) {
+                    logInfo('ws: reconnecting');
+                    this.init(true);
+                }
+            }, this.reconnectRetryTime);
+
+            this.reconnectRetryTime += wsReconnectTimeIncrement;
         }
-        this.seqNo = 1;
-        this.connID = '';
     }
 }

--- a/webapp/src/websocket.ts
+++ b/webapp/src/websocket.ts
@@ -48,6 +48,7 @@ export class WebSocketClient extends EventEmitter {
 
         if (isReconnect) {
             this.ws.onopen = () => {
+                logDebug('ws: reconnected');
                 this.lastDisconnect = 0;
                 this.reconnectRetryTime = wsMinReconnectRetryTimeMs;
                 this.emit('open', this.originalConnID, this.connID, true);


### PR DESCRIPTION
#### Summary

PR adds WebSocket reconnection support to the signaling channel by decoupling as much as possible the two connections (RTC and WS). What this means in practice is that a call can survive websocket disconnects and even server restarts (if using `rtcd`).

The main complexity involved here was state handling and consistency in all the various modes we support, namely:

- Single instance with plugin hosting calls (e.g. team edition).
- Single instance with `rtcd` hosting calls.
- HA cluster with plugin hosting calls, load balanced across the nodes.
- HA cluster with single node hosting the calls.
- HA cluster with `rtcd` hosting calls.

Before this PR, upon websocket disconnect we would cleanup everything related to a session, closing the RTC channel, and cleaning up the state. To support reconnects we need to wait instead and potentially deal with clients never coming back (through timeouts). Furthermore a client could come back on a different node than the one it was originally connected to, or the server could have restarted completely and having to setup a session from (almost) scratch.

We are adding two client events:

- `leave` This is to explicitly signal that a client is leaving a call. Upon receiving this we can cleanup everything just like we did before. Of course we still need to support the case that the event never gets in and cleanup resources appropriately.
- `reconnect` This is a new event sent by a client looking to reconnect to an existing session. Client will include the original connection id along with the previous connection id for proper state tracking.

Changes have been stress tested for a couple of weeks now to spot any potential leak, race condition or regression. I've updated the [load-test client](https://github.com/mattermost/mattermost-plugin-calls/pull/44) acconrdingly.

**Note**
This work does not yet address the potential case of sending/receiving new tracks while disconnected. To support that we either need to implement some extra queuing on the server side or rely on the existing data channel ([MM-45894](https://mattermost.atlassian.net/browse/MM-45894)).

#### Related PRs

https://github.com/mattermost/rtcd/pull/65
https://github.com/mattermost/mattermost-mobile/pull/6497

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43838
