### PR TITLE
[MM-45110] Fix overflow for long names

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -646,8 +646,8 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         return (
             <div style={{fontSize: '12px', display: 'flex', whiteSpace: 'pre'}}>
                 <span style={{fontWeight: speakingProfile ? 600 : 400, overflow: 'hidden', textOverflow: 'ellipsis'}}>
-                    {speakingProfile ? getUserDisplayName(speakingProfile) : 'No one'}
-                </span><span>{' is talking...'}</span>
+                    {speakingProfile ? getUserDisplayName(speakingProfile) : 'No one'} <span style={{fontWeight: 400}}>{'is talking...'}</span>
+                </span>
             </div>
         );
     }
@@ -1201,7 +1201,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         <div style={this.style.profiles}>
                             {this.renderProfiles()}
                         </div>
-                        <div style={{width: '85%'}}>
+                        <div style={{width: hasTeamSidebar ? '204px' : '140px'}}>
                             {this.renderSpeaking()}
                             <div style={this.style.callInfo}>
                                 <div style={{fontWeight: 600}}>{this.getCallDuration()}</div>

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1201,7 +1201,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         <div style={this.style.profiles}>
                             {this.renderProfiles()}
                         </div>
-                        <div style={{width: hasTeamSidebar ? '204px' : '140px'}}>
+                        <div style={{width: hasTeamSidebar ? '200px' : '136px'}}>
                             {this.renderSpeaking()}
                             <div style={this.style.callInfo}>
                                 <div style={{fontWeight: 600}}>{this.getCallDuration()}</div>


### PR DESCRIPTION
#### Summary

Just fixing the display of long names in the widget.

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/1832946/180487899-90a4efd6-c790-4a52-993a-fe97d3dc2c00.png)

![image](https://user-images.githubusercontent.com/1832946/180487978-4f55c4e1-e2bc-463d-a4b1-3d9f7d70aec8.png)

After

![image](https://user-images.githubusercontent.com/1832946/180487645-804bd55a-bf49-492f-ae13-f27ca9b51141.png)

![image](https://user-images.githubusercontent.com/1832946/180487767-16533268-6854-46cf-a8bb-0d864515139e.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45110