### PR TITLE
e2e: Gitlab -> Github status reporting

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
 include:
   - project: qa/calls-e2e-testing
-    ref: main
+    ref: gh-report-status
     file: private.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
 include:
   - project: qa/calls-e2e-testing
-    ref: gh-report-status
+    ref: main
     file: private.yml

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -35,5 +35,10 @@ const config: PlaywrightTestConfig = {
             },
         },
     ],
+    reporter: process.env.CI ? [
+        ['html', {open: 'never'}],
+        ['json', {outputFile: 'pw-results.json'}],
+        ['list'],
+    ] : 'list',
 };
 export default config;


### PR DESCRIPTION
Minor config update to support reporting statuses back to Github. Examples can be seen in the recent commit checks on this branch.

![Screenshot from 2022-07-26 12-07-52](https://user-images.githubusercontent.com/3723666/181056371-19c6a829-8eb2-41c8-ae6c-1cdf6a8d5b39.png)

![Screenshot from 2022-07-26 12-04-40](https://user-images.githubusercontent.com/3723666/181055526-0c6a5002-6f9c-426a-98ff-3560961545f2.png)

Also a note for the moment, mirroring from Github -> Gitlab currently happens every 30 minutes so the new check won't always appear immediately. This will change after [DOPS-1131](https://mattermost.atlassian.net/browse/DOPS-1131) is handled.