### PR TITLE
[MM-45977] Workaround to prevent signaling race

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -293,7 +293,13 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
         window.callsClient.on('connect', () => {
             if (isDMChannel(this.props.channel) || isGMChannel(this.props.channel)) {
-                window.callsClient.unmute();
+                // FIXME (MM-46048) - HACK
+                // There's a race condition between unmuting and receiving existing tracks from other participants.
+                // Fixing this properly requires extensive and potentially breaking changes.
+                // Waiting for a second before unmuting is a decent workaround that should work in most cases.
+                setTimeout(() => {
+                    window.callsClient.unmute();
+                }, 1000);
             }
             this.setState({currentAudioInputDevice: window.callsClient.currentAudioInputDevice});
             this.setState({currentAudioOutputDevice: window.callsClient.currentAudioOutputDevice});


### PR DESCRIPTION
#### Summary

This is not the kind of fix I like to merge but after some consideration I decided to go ahead with it since the implementation effort for a properly fix would be significant and this simple hack covers the main use case (joining calls in DMs/GMs). Looking to address the underlying problem in [MM-46048](https://mattermost.atlassian.net/browse/MM-46048) 

**Context**

This is a [well-known](https://www.ietf.org/proceedings/82/slides/rtcweb-10.pdf) problem with WebRTC signaling and a [pretty decent solution](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation) has been devised already. Unfortunately this is not supported by either the server side implementation (pion), nor our version of the mobile native dependency (implemented in [c81846](https://github.com/react-native-webrtc/react-native-webrtc/commit/c8184641cbee054b92f67cfe6ee7ba428e2ca235) though). 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45977