### PR TITLE
[MM-44949] Disable video pause by clicking on screen sharing player

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -204,6 +204,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                     height='100%'
                     muted={true}
                     autoPlay={true}
+                    onClick={(ev) => ev.preventDefault()}
                     controls={true}
                 />
                 <span


### PR DESCRIPTION
#### Summary

Had a couple more reports of this unexpected behaviour so decided to fix it since it's trivial. Video can still be paused if necessary by using the available controls.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44949