### PR TITLE
Replace `simple-peer` with `RTCPeer`

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14,7 +14,6 @@
         "react-redux": "7.2.4",
         "redux": "4.1.0",
         "semver-parser": "4.0.0",
-        "simple-peer": "9.11.0",
         "styled-components": "5.3.5",
         "typescript": "4.3.4"
       },
@@ -4283,24 +4282,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -4503,28 +4484,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -5598,10 +5557,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/err-code": {
-      "version": "3.0.1",
-      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -7104,10 +7059,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-browser-rtc": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -7532,24 +7483,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -7624,6 +7557,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inobounce": {
@@ -11728,6 +11662,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11769,6 +11704,7 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -12470,6 +12406,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -12763,6 +12700,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
@@ -12956,33 +12894,6 @@
       "version": "3.0.4",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-peer": {
-      "version": "9.11.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "debug": "^4.3.1",
-        "err-code": "^3.0.1",
-        "get-browser-rtc": "^1.1.0",
-        "queue-microtask": "^1.2.3",
-        "randombytes": "^2.1.0",
-        "readable-stream": "^3.6.0"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -13197,6 +13108,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -13204,6 +13116,7 @@
     },
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14030,6 +13943,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -17780,9 +17694,6 @@
       "version": "1.0.2",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1"
-    },
     "big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -17926,13 +17837,6 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -18742,9 +18646,6 @@
     "envinfo": {
       "version": "7.8.1",
       "dev": true
-    },
-    "err-code": {
-      "version": "3.0.1"
     },
     "error-ex": {
       "version": "1.3.2",
@@ -19811,9 +19712,6 @@
       "version": "1.0.0-beta.2",
       "dev": true
     },
-    "get-browser-rtc": {
-      "version": "1.1.0"
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -20106,9 +20004,6 @@
       "dev": true,
       "requires": {}
     },
-    "ieee754": {
-      "version": "1.2.1"
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -20157,7 +20052,8 @@
       }
     },
     "inherits": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "dev": true
     },
     "inobounce": {
       "version": "0.2.0",
@@ -23161,7 +23057,8 @@
       }
     },
     "queue-microtask": {
-      "version": "1.2.3"
+      "version": "1.2.3",
+      "dev": true
     },
     "raf": {
       "version": "3.4.1",
@@ -23182,6 +23079,7 @@
     },
     "randombytes": {
       "version": "2.1.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -23712,6 +23610,7 @@
     },
     "readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -23910,7 +23809,8 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2"
+      "version": "5.1.2",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -24031,18 +23931,6 @@
     "signal-exit": {
       "version": "3.0.4",
       "dev": true
-    },
-    "simple-peer": {
-      "version": "9.11.0",
-      "requires": {
-        "buffer": "^6.0.3",
-        "debug": "^4.3.1",
-        "err-code": "^3.0.1",
-        "get-browser-rtc": "^1.1.0",
-        "queue-microtask": "^1.2.3",
-        "randombytes": "^2.1.0",
-        "readable-stream": "^3.6.0"
-      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -24224,12 +24112,14 @@
     },
     "string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.1"
+          "version": "5.2.1",
+          "dev": true
         }
       }
     },
@@ -24853,7 +24743,8 @@
       }
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -69,7 +69,6 @@
     "react-redux": "7.2.4",
     "redux": "4.1.0",
     "semver-parser": "4.0.0",
-    "simple-peer": "9.11.0",
     "styled-components": "5.3.5",
     "typescript": "4.3.4"
   },

--- a/webapp/src/rtcpeer/index.ts
+++ b/webapp/src/rtcpeer/index.ts
@@ -1,0 +1,149 @@
+import {EventEmitter} from 'events';
+
+import {
+    RTCPeerConfig,
+} from './types';
+
+export default class RTCPeer extends EventEmitter {
+    private pc: RTCPeerConnection | null;
+    private senders: {[key: string]: RTCRtpSender};
+
+    constructor(config: RTCPeerConfig) {
+        super();
+
+        // We keep a map of track IDs -> RTP sender so that we can easily
+        // replace tracks when muting/unmuting.
+        this.senders = {};
+
+        this.pc = new RTCPeerConnection(config);
+        this.pc.onnegotiationneeded = () => this.onNegotiationNeeded();
+        this.pc.onicecandidate = (ev) => this.onICECandidate(ev);
+        this.pc.onconnectionstatechange = () => this.onConnectionStateChange();
+        this.pc.ontrack = (ev) => this.onTrack(ev);
+
+        // We create a data channel for two reasons:
+        // - Initiate a connection without preemptively add audio/video tracks.
+        // - Use this communication channel for further negotiation (to be implemented).
+        this.pc.createDataChannel('calls-dc');
+    }
+
+    private onICECandidate(ev: RTCPeerConnectionIceEvent) {
+        if (ev.candidate) {
+            this.emit('candidate', ev.candidate);
+        }
+    }
+
+    private onConnectionStateChange() {
+        switch (this.pc?.connectionState) {
+        case 'connected':
+            this.emit('connect');
+            break;
+        case 'disconnected':
+            this.emit('disconnect');
+            break;
+        case 'failed':
+            this.emit('error', new Error('rtc connection failed'));
+            break;
+        case 'closed':
+            this.emit('close');
+            break;
+        default:
+        }
+    }
+
+    private async onNegotiationNeeded() {
+        try {
+            await this.pc?.setLocalDescription(await this.pc?.createOffer());
+            this.emit('offer', this.pc?.localDescription);
+        } catch (err) {
+            this.emit('error', err);
+        }
+    }
+
+    private onTrack(ev: RTCTrackEvent) {
+        if (ev.streams.length === 0) {
+            this.emit('stream', new MediaStream([ev.track]));
+            return;
+        }
+        this.emit('stream', ev.streams[0]);
+    }
+
+    public async signal(data: string) {
+        if (!this.pc) {
+            throw new Error('peer has been destroyed');
+        }
+
+        const msg = JSON.parse(data);
+
+        switch (msg.type) {
+        case 'candidate':
+            await this.pc.addIceCandidate(msg.candidate);
+            break;
+        case 'offer':
+            await this.pc.setRemoteDescription(msg);
+            await this.pc.setLocalDescription(await this.pc.createAnswer());
+            this.emit('answer', this.pc.localDescription);
+            break;
+        case 'answer':
+            await this.pc.setRemoteDescription(msg);
+            break;
+        default:
+            throw new Error('invalid signaling data received');
+        }
+    }
+
+    public async addTrack(track: MediaStreamTrack, stream?: MediaStream) {
+        if (!this.pc) {
+            throw new Error('peer has been destroyed');
+        }
+        const sender = await this.pc.addTrack(track, stream!);
+        if (sender) {
+            this.senders[track.id] = sender;
+        }
+    }
+
+    public addStream(stream: MediaStream) {
+        stream.getTracks().forEach(track => {
+            this.addTrack(track, stream);
+        });
+    }
+
+    public replaceTrack(oldTrackID: string, newTrack: MediaStreamTrack) {
+        const sender = this.senders[oldTrackID];
+        if (!sender) {
+            throw new Error('sender for track not found');
+        }
+        if (newTrack && newTrack.id !== oldTrackID) {
+            delete this.senders[oldTrackID];
+            this.senders[newTrack.id] = sender;
+        }
+        sender.replaceTrack(newTrack);
+    }
+
+    public getStats() {
+        if (!this.pc) {
+            throw new Error('peer has been destroyed');
+        }
+        return this.pc.getStats(null);
+    }
+
+    public destroy() {
+        if (!this.pc) {
+            throw new Error('peer has been destroyed already');
+        }
+        this.removeAllListeners('close');
+        this.removeAllListeners('connect');
+        this.removeAllListeners('signal');
+        this.removeAllListeners('offer');
+        this.removeAllListeners('answer');
+        this.removeAllListeners('candidate');
+        this.removeAllListeners('stream');
+        this.removeAllListeners('error');
+        this.pc.onnegotiationneeded = null;
+        this.pc.onicecandidate = null;
+        this.pc.onconnectionstatechange = null;
+        this.pc.ontrack = null;
+        this.pc.close();
+        this.pc = null;
+    }
+}

--- a/webapp/src/rtcpeer/types.ts
+++ b/webapp/src/rtcpeer/types.ts
@@ -1,0 +1,3 @@
+export type RTCPeerConfig = {
+    iceServers: RTCIceServer[],
+}


### PR DESCRIPTION
#### Summary

Some recent issues (e.g. [MM-45977](https://mattermost.atlassian.net/browse/MM-45977)) surfaced a need to have more control on lower level APIs of WebRTC connections. Moreover, future work (e.g. implementing simulcast) will pose similar needs as well .

I decided to spend part of last Open Source Friday to replace `simple-peer` with our own version of a WebRTC connection wrapper (which I should have probably named simpler-peer :p). Pun aside, `simple-peer` let us focus on delivering calls in a very efficient way without worrying too much about anything low level on the client side of which I am very grateful :raised_hands: . 

That said, I feel this is the right time to move on, especially with mobile v2 support going live soon. What this means, in practice:

- Lighter implementation (~150 [SLOC](https://en.wikipedia.org/wiki/Source_lines_of_code)) with only the strictly necessary to retain functionality and no unnecessary hack.
- Direct, low level control over the WebRTC API.
- Unified implementation across Web and Mobile. This is mostly doable today with a couple of *injections*. We may consider extracting this into a standalone module/npm package (tbd).
- 100% Typescript.