### PR TITLE
[MM-46107] Fix audio resources leaks

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -281,6 +281,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
             document.body.appendChild(audioEl);
             voiceTrack.onended = () => {
+                audioEl.srcObject = null;
                 audioEl.remove();
             };
         });

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -61,6 +61,7 @@ import {
     isDMChannel,
     getUserIdFromDM,
     getWSConnectionURL,
+    playSound,
 } from './utils';
 import {logErr, logDebug} from './log';
 
@@ -124,11 +125,9 @@ export default class Plugin {
 
             if (window.callsClient?.channelID === channelID) {
                 if (userID === currentUserID) {
-                    const audio = new Audio(getPluginStaticPath() + JoinSelfSound);
-                    audio.play();
+                    playSound(getPluginStaticPath() + JoinSelfSound);
                 } else if (channelID === connectedChannelID(store.getState())) {
-                    const audio = new Audio(getPluginStaticPath() + JoinUserSound);
-                    audio.play();
+                    playSound(getPluginStaticPath() + JoinUserSound);
                 }
             }
 
@@ -490,9 +489,7 @@ export default class Plugin {
                     if (window.callsClient) {
                         window.callsClient.destroy();
                         delete window.callsClient;
-                        const sound = getPluginStaticPath() + LeaveSelfSound;
-                        const audio = new Audio(sound);
-                        audio.play();
+                        playSound(getPluginStaticPath() + LeaveSelfSound);
                     }
                 });
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -292,3 +292,12 @@ export function getUsersList(profiles: UserProfile[]) {
     }).join(', ');
     return list + ' and ' + getUserDisplayName(profiles[profiles.length - 1]);
 }
+
+export function playSound(src: string) {
+    const audio = new Audio(src);
+    audio.play();
+    audio.onended = () => {
+        audio.src = '';
+        audio.remove();
+    };
+}

--- a/webapp/src/vad.ts
+++ b/webapp/src/vad.ts
@@ -3,6 +3,7 @@ import {EventEmitter} from 'events';
 import {logDebug} from './log';
 
 export default class VoiceActivityDetector extends EventEmitter {
+    private audioContext: AudioContext;
     private inputStream: MediaStream;
     private sourceNode: MediaStreamAudioSourceNode;
     private analyserNode: AnalyserNode;
@@ -14,6 +15,7 @@ export default class VoiceActivityDetector extends EventEmitter {
     constructor(audioContext: AudioContext, stream: MediaStream) {
         super();
 
+        this.audioContext = audioContext;
         this.inputStream = stream;
 
         const config = {
@@ -134,6 +136,7 @@ export default class VoiceActivityDetector extends EventEmitter {
         this.inputStream.getTracks().forEach((track) => {
             track.stop();
         });
+        this.audioContext.close();
     }
 }
 


### PR DESCRIPTION
#### Summary

This was an interesting one. It started with just some hard to explain high CPU usage in Firefox (I usually test stuff locally on a Chrome + Firefox setup). Then in the last few days I was getting random issues with my audio service (`pulseaudio`) not being able to playback. Closing the Chrome tab I was testing Calls on temporarily fixed this odd behaviour. 

But it was only today, after failing once again to hear people due to a playback failure that I realized I was leaking dozens of audio resources that were still in the playback state even long after ending calls. 

PR reviews and fixes any outstanding leak of audio resources.

@lieut-data I just couldn't believe that it was simply a Linux quirk, so dug further, thank you :grin: 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46107
