### PR TITLE
[MM-46124] Improve session deinitialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.0.27
-	github.com/mattermost/rtcd v0.6.10-0.20220803124044-a0b1fde04be3
+	github.com/mattermost/rtcd v0.6.10
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.0.27
-	github.com/mattermost/rtcd v0.6.9
+	github.com/mattermost/rtcd v0.6.10-0.20220803124044-a0b1fde04be3
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/mattermost/mattermost-server/v6 v6.6.0 h1:47XbXSJu9fdbhZWG5bQ5dj3ySrI
 github.com/mattermost/mattermost-server/v6 v6.6.0/go.mod h1:oR6UCRo+SEvnfN2FEOdzHs1UljrskyCKU8tWeKlxgMo=
 github.com/mattermost/morph v0.0.0-20220401091636-39f834798da8/go.mod h1:jxM3g1bx+k2Thz7jofcHguBS8TZn5Pc+o5MGmORObhw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/rtcd v0.6.9 h1:higp9/tb1EcAwql4eB6NaFngtIGsaV6LhkyVuFj2uD8=
-github.com/mattermost/rtcd v0.6.9/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
+github.com/mattermost/rtcd v0.6.10-0.20220803124044-a0b1fde04be3 h1:zXB5mVHS0vzeHNrBoaaiNm+rsyMkkt80qtt6+F6oul8=
+github.com/mattermost/rtcd v0.6.10-0.20220803124044-a0b1fde04be3/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -974,8 +974,8 @@ github.com/mattermost/mattermost-server/v6 v6.6.0 h1:47XbXSJu9fdbhZWG5bQ5dj3ySrI
 github.com/mattermost/mattermost-server/v6 v6.6.0/go.mod h1:oR6UCRo+SEvnfN2FEOdzHs1UljrskyCKU8tWeKlxgMo=
 github.com/mattermost/morph v0.0.0-20220401091636-39f834798da8/go.mod h1:jxM3g1bx+k2Thz7jofcHguBS8TZn5Pc+o5MGmORObhw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/rtcd v0.6.10-0.20220803124044-a0b1fde04be3 h1:zXB5mVHS0vzeHNrBoaaiNm+rsyMkkt80qtt6+F6oul8=
-github.com/mattermost/rtcd v0.6.10-0.20220803124044-a0b1fde04be3/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
+github.com/mattermost/rtcd v0.6.10 h1:C4L6m7oFz+4ugUmr9aSID0wYczzV4dmCdJxnWyziPtQ=
+github.com/mattermost/rtcd v0.6.10/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/server/rtcd.go
+++ b/server/rtcd.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	rtcd "github.com/mattermost/rtcd/service"
@@ -502,6 +503,25 @@ func (m *rtcdClientManager) handleClientMsg(msg rtcd.ClientMessage) error {
 			return fmt.Errorf("unexpected data type %T", msg.Data)
 		}
 		m.ctx.LogDebug("received hello message from rtcd", "connID", msgData["connID"])
+		return nil
+	} else if msg.Type == rtcd.ClientMessageClose {
+		msgData, ok := msg.Data.(map[string]string)
+		if !ok {
+			return fmt.Errorf("unexpected data type %T", msg.Data)
+		}
+		sessionID := msgData["sessionID"]
+		if sessionID == "" {
+			return fmt.Errorf("missing sessionID")
+		}
+		m.ctx.LogDebug("received close message from rtcd", "sessionID", sessionID)
+		m.ctx.mut.RLock()
+		us := m.ctx.sessions[sessionID]
+		m.ctx.mut.RUnlock()
+		if us != nil && atomic.CompareAndSwapInt32(&us.rtcClosed, 0, 1) {
+			m.ctx.LogDebug("closing rtc close channel", "sessionID", sessionID)
+			close(us.rtcCloseCh)
+			return m.ctx.removeSession(us)
+		}
 		return nil
 	}
 

--- a/server/session.go
+++ b/server/session.go
@@ -218,7 +218,7 @@ func (p *Plugin) removeSession(us *session) error {
 		"userID": us.userID,
 	}, &model.WebsocketBroadcast{ChannelId: us.channelID, ReliableClusterSend: true})
 
-	p.LogDebug("removing session from state", "userID", us.userID)
+	p.LogDebug("removing session from state", "userID", us.userID, "connID", us.connID, "originalConnID", us.originalConnID)
 
 	p.mut.Lock()
 	delete(p.sessions, us.connID)

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -290,6 +290,8 @@ func (p *Plugin) wsReader(us *session, handlerID string) {
 			return
 		case <-us.wsCloseCh:
 			return
+		case <-us.rtcCloseCh:
+			return
 		}
 	}
 }
@@ -340,6 +342,9 @@ func (p *Plugin) handleLeave(us *session, userID, connID, channelID string) erro
 		return nil
 	case <-us.leaveCh:
 		p.LogDebug("user left call", "userID", userID, "connID", connID, "channelID", us.channelID)
+	case <-us.rtcCloseCh:
+		p.LogDebug("rtc connection was closed", "userID", userID, "connID", connID, "channelID", us.channelID)
+		return nil
 	case <-time.After(wsReconnectionTimeout):
 		p.LogDebug("timeout waiting for reconnection", "userID", userID, "connID", connID, "channelID", channelID)
 	}


### PR DESCRIPTION
#### Summary

Two main changes here to avoid leaking the `handleJoin` goroutine:

- Handling the new `ClientMessageClose` event that gets sent by `rtcd`.
- Exiting from `wsReader`/`handleLeave` `select` blocks when the `rtcCloseCh` gets closed.

It's important to notice that this PR does not fix the race but simply makes it much more unlikely to cause a leak. This is because the logic is non trivial and serializing everything using a mutex feels like an excessive constraint just to cover a rare edge case so we allow this to happen but react accordingly.

#### Related PRs

https://github.com/mattermost/rtcd/pull/68

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46124