### PR TITLE
[MM-46291] Fix possible undefined access

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -299,7 +299,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 // Fixing this properly requires extensive and potentially breaking changes.
                 // Waiting for a second before unmuting is a decent workaround that should work in most cases.
                 setTimeout(() => {
-                    window.callsClient.unmute();
+                    window.callsClient?.unmute();
                 }, 1000);
             }
             this.setState({currentAudioInputDevice: window.callsClient.currentAudioInputDevice});


### PR DESCRIPTION
#### Summary

Quickly ending a call before the timer fires would cause the reported error.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46291
