### PR TITLE
[MM-42395] Extract call duration to avoid unnecessary parent component re-render

### DIFF
--- a/webapp/src/components/call_widget/call_duration.tsx
+++ b/webapp/src/components/call_widget/call_duration.tsx
@@ -1,0 +1,34 @@
+import React, {CSSProperties, useState, useEffect} from 'react';
+import moment from 'moment-timezone';
+
+type Props = {
+    startAt: number,
+    style?: CSSProperties,
+}
+
+function getCallDuration(startAt: number) {
+    const dur = moment.utc(moment().diff(moment(startAt)));
+    if (dur.hours() === 0) {
+        return dur.format('mm:ss');
+    }
+    return dur.format('HH:mm:ss');
+}
+
+export default function CallDuration(props: Props) {
+    // This is needed to force a re-render to periodically update
+    // the time displayed.
+    const [, updateState] = useState({});
+    useEffect(() => {
+        const interval = setInterval(() => updateState({}), 500);
+        return () => clearInterval(interval);
+    });
+
+    const style = props.style || {};
+    if (!style.fontWeight) {
+        style.fontWeight = 600;
+    }
+
+    return (
+        <div style={style}>{getCallDuration(props.startAt)}</div>
+    );
+}

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -1,5 +1,4 @@
 import React, {CSSProperties} from 'react';
-import moment from 'moment-timezone';
 import {compareSemVer} from 'semver-parser';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
@@ -19,6 +18,7 @@ import ScreenIcon from '../../components/icons/screen_icon';
 import RaisedHandIcon from '../../components/icons/raised_hand';
 import UnraisedHandIcon from '../../components/icons/unraised_hand';
 import ParticipantsIcon from '../../components/icons/participants';
+import CallDuration from '../call_widget/call_duration';
 
 import './component.scss';
 
@@ -41,7 +41,6 @@ interface Props {
 }
 
 interface State {
-    intervalID?: NodeJS.Timer,
     screenStream: MediaStream | null,
     showParticipantsList: boolean,
 }
@@ -61,14 +60,6 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             const callsClient = window.opener.callsClient;
             callsClient.on('close', () => window.close());
         }
-    }
-
-    getCallDuration = () => {
-        const dur = moment.utc(moment().diff(moment(this.props.callStartAt)));
-        if (dur.hours() === 0) {
-            return dur.format('mm:ss');
-        }
-        return dur.format('HH:mm:ss');
     }
 
     onDisconnectClick = () => {
@@ -161,20 +152,10 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
 
         const screenStream = callsClient.getLocalScreenStream() || callsClient.getRemoteScreenStream();
 
-        // This is needed to force a re-render to periodically update
-        // the start time.
-        const id = setInterval(() => this.forceUpdate(), 1000);
         // eslint-disable-next-line react/no-did-mount-set-state
         this.setState({
-            intervalID: id,
             screenStream,
         });
-    }
-
-    public componentWillUnmount() {
-        if (this.state.intervalID) {
-            clearInterval(this.state.intervalID);
-        }
     }
 
     renderScreenSharingPlayer = () => {
@@ -399,7 +380,10 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                 <div style={style.main as CSSProperties}>
                     <div style={{display: 'flex', alignItems: 'center', width: '100%'}}>
                         <div style={style.topLeftContainer as CSSProperties}>
-                            <span style={{margin: '4px', fontWeight: 600}}>{this.getCallDuration()}</span>
+                            <CallDuration
+                                style={{margin: '4px'}}
+                                startAt={this.props.callStartAt}
+                            />
                             <span style={{margin: '4px'}}>{'•'}</span>
                             <span style={{margin: '4px'}}>{`${this.props.profiles.length} participants`}</span>
 


### PR DESCRIPTION
#### Summary

This was a low hanging fruit especially as we are trying to optimize the widget to be as performance as possible.

**Before**
![before png](https://user-images.githubusercontent.com/1832946/184635905-2934241d-1f84-4bd3-a7ee-dbd6c550f55a.png)
**After**
![after png](https://user-images.githubusercontent.com/1832946/184635911-0ed99dfa-62df-4740-8869-6f6142841b95.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42395