### PR TITLE
Relay `devicechange` event to properly sync devices

### DIFF
--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -3,7 +3,7 @@ import {EventEmitter} from 'events';
 // @ts-ignore
 import {deflate} from 'pako/lib/deflate.js';
 
-import {CallsClientConfig, RTCStats} from 'src/types/types';
+import {CallsClientConfig, RTCStats, AudioDevices} from 'src/types/types';
 
 import RTCPeer from './rtcpeer';
 
@@ -27,7 +27,7 @@ export default class CallsClient extends EventEmitter {
     private voiceTrackAdded: boolean;
     private streams: MediaStream[];
     private stream: MediaStream | null;
-    private audioDevices: { inputs: MediaDeviceInfo[]; outputs: MediaDeviceInfo[]; };
+    private audioDevices: AudioDevices;
     private audioTrack: MediaStreamTrack | null;
     public isHandRaised: boolean;
     private onDeviceChange: () => void;
@@ -83,7 +83,7 @@ export default class CallsClient extends EventEmitter {
             inputs: devices.filter((device) => device.kind === 'audioinput'),
             outputs: devices.filter((device) => device.kind === 'audiooutput'),
         };
-        this.emit('devicechange');
+        this.emit('devicechange', this.audioDevices);
     }
 
     public async init(channelID: string, title?: string) {
@@ -273,10 +273,6 @@ export default class CallsClient extends EventEmitter {
         this.removeAllListeners('devicechange');
         window.removeEventListener('beforeunload', this.onBeforeUnload);
         navigator.mediaDevices.removeEventListener('devicechange', this.onDeviceChange);
-    }
-
-    public getAudioDevices() {
-        return this.audioDevices;
     }
 
     public async setAudioInputDevice(device: MediaDeviceInfo) {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -83,6 +83,7 @@ export default class CallsClient extends EventEmitter {
             inputs: devices.filter((device) => device.kind === 'audioinput'),
             outputs: devices.filter((device) => device.kind === 'audiooutput'),
         };
+        this.emit('devicechange');
     }
 
     public async init(channelID: string, title?: string) {
@@ -269,6 +270,7 @@ export default class CallsClient extends EventEmitter {
         this.removeAllListeners('connect');
         this.removeAllListeners('remoteVoiceStream');
         this.removeAllListeners('remoteScreenStream');
+        this.removeAllListeners('devicechange');
         window.removeEventListener('beforeunload', this.onBeforeUnload);
         navigator.mediaDevices.removeEventListener('devicechange', this.onDeviceChange);
     }

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -8,7 +8,7 @@ import {Team} from '@mattermost/types/teams';
 import {IDMappedObjects} from '@mattermost/types/utilities';
 import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
 
-import {UserState} from 'src/types/types';
+import {UserState, AudioDevices} from 'src/types/types';
 import {
     getUserDisplayName,
     isPublicChannel,
@@ -288,9 +288,9 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             });
         });
 
-        window.callsClient.on('devicechange', () => {
+        window.callsClient.on('devicechange', (devices: AudioDevices) => {
             this.setState({
-                devices: window.callsClient?.getAudioDevices(),
+                devices,
             });
         });
 

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -288,6 +288,12 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             });
         });
 
+        window.callsClient.on('devicechange', () => {
+            this.setState({
+                devices: window.callsClient?.getAudioDevices(),
+            });
+        });
+
         window.callsClient.on('connect', () => {
             if (isDMChannel(this.props.channel) || isGMChannel(this.props.channel)) {
                 // FIXME (MM-46048) - HACK
@@ -442,7 +448,6 @@ export default class CallWidget extends React.PureComponent<Props, State> {
     onMenuClick = () => {
         this.setState({
             showMenu: !this.state.showMenu,
-            devices: window.callsClient?.getAudioDevices(),
             showParticipantsList: false,
         });
     }
@@ -793,11 +798,10 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         const DeviceIcon = deviceType === 'input' ? UnmutedIcon : SpeakerIcon;
 
         const onClickHandler = () => {
-            const devices = window.callsClient?.getAudioDevices();
             if (deviceType === 'input') {
-                this.setState({showAudioInputDevicesMenu: !this.state.showAudioInputDevicesMenu, showAudioOutputDevicesMenu: false, devices});
+                this.setState({showAudioInputDevicesMenu: !this.state.showAudioInputDevicesMenu, showAudioOutputDevicesMenu: false});
             } else {
-                this.setState({showAudioOutputDevicesMenu: !this.state.showAudioOutputDevicesMenu, showAudioInputDevicesMenu: false, devices});
+                this.setState({showAudioOutputDevicesMenu: !this.state.showAudioOutputDevicesMenu, showAudioInputDevicesMenu: false});
             }
         };
 

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -78,3 +78,8 @@ export type CallsClientConfig = {
     wsURL: string,
     iceServers: RTCIceServer[],
 }
+
+export type AudioDevices = {
+    inputs: MediaDeviceInfo[],
+    outputs: MediaDeviceInfo[],
+}


### PR DESCRIPTION
#### Summary

This is probably the way it should have been implemented since the start. We relay the `devicechange` event to the component to keep everything in sync and avoid having to constantly poll. This has the added bonus that the menu will update even when fully open and visible.
