### PR TITLE
[MM-46412] Disable calls in archived channels

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -393,6 +393,9 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title string) error {
 	if appErr != nil {
 		return appErr
 	}
+	if channel.DeleteAt > 0 {
+		return fmt.Errorf("cannot join call in archived channel")
+	}
 
 	state, err := p.addUserSession(userID, connID, channel)
 	if err != nil {

--- a/webapp/src/components/channel_header_button/component.tsx
+++ b/webapp/src/components/channel_header_button/component.tsx
@@ -15,6 +15,7 @@ interface Props {
     isCloudPaid: boolean,
     isLimitRestricted: boolean,
     maxParticipants: number,
+    isChannelArchived: boolean,
 }
 
 const ChannelHeaderButton = ({
@@ -25,12 +26,13 @@ const ChannelHeaderButton = ({
     isCloudPaid,
     isLimitRestricted,
     maxParticipants,
+    isChannelArchived,
 }: Props) => {
     if (!show) {
         return null;
     }
 
-    const restricted = isLimitRestricted || isCloudFeatureRestricted;
+    const restricted = isLimitRestricted || isCloudFeatureRestricted || isChannelArchived;
 
     const button = (
         <CallButton
@@ -45,6 +47,24 @@ const ChannelHeaderButton = ({
             </span>
         </CallButton>
     );
+
+    if (isChannelArchived) {
+        return (
+            <OverlayTrigger
+                placement='bottom'
+                rootClose={true}
+                overlay={
+                    <Tooltip id='tooltip-limit-header'>
+                        {'Calls are not available in archived channels.'}
+                    </Tooltip>
+                }
+            >
+                <Wrapper>
+                    {button}
+                </Wrapper>
+            </OverlayTrigger>
+        );
+    }
 
     if (isCloudFeatureRestricted) {
         return (

--- a/webapp/src/components/channel_header_button/index.ts
+++ b/webapp/src/components/channel_header_button/index.ts
@@ -1,7 +1,7 @@
 import {connect} from 'react-redux';
 import {GlobalState} from '@mattermost/types/store';
 
-import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {
     voiceConnectedUsers,
@@ -15,14 +15,18 @@ import {
 
 import ChannelHeaderButton from './component';
 
-const mapStateToProps = (state: GlobalState) => ({
-    show: isVoiceEnabled(state),
-    inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
-    hasCall: voiceConnectedUsers(state).length > 0,
-    isCloudFeatureRestricted: isCloudFeatureRestricted(state),
-    isCloudPaid: isCloudProfessionalOrEnterprise(state),
-    isLimitRestricted: isLimitRestricted(state),
-    maxParticipants: maxParticipants(state),
-});
+const mapStateToProps = (state: GlobalState) => {
+    const channel = getCurrentChannel(state);
+    return {
+        show: isVoiceEnabled(state),
+        inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === channel?.id),
+        hasCall: voiceConnectedUsers(state).length > 0,
+        isCloudFeatureRestricted: isCloudFeatureRestricted(state),
+        isCloudPaid: isCloudProfessionalOrEnterprise(state),
+        isLimitRestricted: isLimitRestricted(state),
+        maxParticipants: maxParticipants(state),
+        isChannelArchived: channel?.delete_at > 0,
+    };
+};
 
 export default connect(mapStateToProps)(ChannelHeaderButton);

--- a/webapp/src/components/channel_header_dropdown_button/component.tsx
+++ b/webapp/src/components/channel_header_dropdown_button/component.tsx
@@ -15,6 +15,7 @@ interface Props {
     isCloudPaid: boolean,
     isLimitRestricted: boolean,
     maxParticipants: number,
+    isChannelArchived: boolean,
 }
 
 const ChannelHeaderDropdownButton = ({
@@ -25,11 +26,12 @@ const ChannelHeaderDropdownButton = ({
     isCloudPaid,
     isLimitRestricted,
     maxParticipants,
+    isChannelArchived,
 }: Props) => {
     if (!show) {
         return null;
     }
-    const restricted = isLimitRestricted || isCloudFeatureRestricted;
+    const restricted = isLimitRestricted || isCloudFeatureRestricted || isChannelArchived;
     const isCloudLimitRestricted = isCloudPaid && isLimitRestricted;
     const withUpsellIcon = isCloudFeatureRestricted || (isCloudLimitRestricted && !inCall);
 
@@ -53,6 +55,22 @@ const ChannelHeaderDropdownButton = ({
             }
         </CallButton>
     );
+
+    if (isChannelArchived) {
+        return (
+            <OverlayTrigger
+                placement='bottom'
+                rootClose={true}
+                overlay={
+                    <Tooltip id='tooltip-limit-header'>
+                        {'Calls are not available in archived channels.'}
+                    </Tooltip>
+                }
+            >
+                {button}
+            </OverlayTrigger>
+        );
+    }
 
     if (isCloudFeatureRestricted) {
         return (

--- a/webapp/src/components/channel_header_dropdown_button/index.ts
+++ b/webapp/src/components/channel_header_dropdown_button/index.ts
@@ -1,7 +1,7 @@
 import {connect} from 'react-redux';
 import {GlobalState} from '@mattermost/types/store';
 
-import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {
     voiceConnectedUsers,
@@ -15,14 +15,18 @@ import {
 
 import ChannelHeaderDropdownButton from './component';
 
-const mapStateToProps = (state: GlobalState) => ({
-    show: isVoiceEnabled(state),
-    inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
-    hasCall: voiceConnectedUsers(state).length > 0,
-    isCloudFeatureRestricted: isCloudFeatureRestricted(state),
-    isCloudPaid: isCloudProfessionalOrEnterprise(state),
-    isLimitRestricted: isLimitRestricted(state),
-    maxParticipants: maxParticipants(state),
-});
+const mapStateToProps = (state: GlobalState) => {
+    const channel = getCurrentChannel(state);
+    return {
+        show: isVoiceEnabled(state),
+        inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === channel?.id),
+        hasCall: voiceConnectedUsers(state).length > 0,
+        isCloudFeatureRestricted: isCloudFeatureRestricted(state),
+        isCloudPaid: isCloudProfessionalOrEnterprise(state),
+        isLimitRestricted: isLimitRestricted(state),
+        maxParticipants: maxParticipants(state),
+        isChannelArchived: channel?.delete_at > 0,
+    };
+};
 
 export default connect(mapStateToProps)(ChannelHeaderDropdownButton);


### PR DESCRIPTION
#### Summary

PR disables calls in archived channels. While technically nothing was preventing them up until now, the client would error out.
We are now disabling the Start/Join button and providing some information on hover.

What's potentially left to handle is the automatically joining through URL case. With the error fixed nothing would happen upon visiting the URL. If we'd like to be more informative we may consider opening up a modal or give some other kind of feedback to the user. Let me know your thoughts.

/cc @itao 

#### Screenshots

![image](https://user-images.githubusercontent.com/1832946/185896663-2f1b8511-5828-4ef8-bcb8-52a68877a5b2.png)

![image](https://user-images.githubusercontent.com/1832946/185896503-776fbb0b-e81a-46f3-bf3c-fd30d5ef6f1c.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46412

