### PR TITLE
[MM-46476] Temporarily persist stats for last call

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -374,16 +374,15 @@ export default class Plugin {
                 }
                 break;
             case 'stats':
-                if (!window.callsClient) {
-                    return {error: {message: 'You\'re not connected to any call'}};
+                if (window.callsClient) {
+                    try {
+                        const stats = await window.callsClient.getStats();
+                        return {message: `/call stats "${JSON.stringify(stats)}"`, args};
+                    } catch (err) {
+                        return {error: {message: err}};
+                    }
                 }
-                try {
-                    const stats = await window.callsClient.getStats();
-                    logDebug(JSON.stringify(stats, null, 2));
-                    return {message: `/call stats "${JSON.stringify(stats)}"`, args};
-                } catch (err) {
-                    return {error: {message: err}};
-                }
+                return {message: `/call stats "${sessionStorage.getItem('calls_client_stats') || '{}'}"`, args};
             }
 
             return {message, args};

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -83,3 +83,19 @@ export type AudioDevices = {
     inputs: MediaDeviceInfo[],
     outputs: MediaDeviceInfo[],
 }
+
+export type TrackInfo = {
+    id: string,
+    streamID: string,
+    kind: string,
+    label: string,
+    enabled: boolean,
+    readyState: MediaStreamTrackState,
+}
+
+export type CallsClientStats = {
+    initTime: number,
+    callID: string,
+    tracksInfo: TrackInfo[],
+    rtcStats: RTCStats | null,
+}


### PR DESCRIPTION
#### Summary

We use [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) to temporarily store statistics for the last call the user has joined. This way the `/call stats` slash command can return useful information even after leaving a call.

/cc @lieut-data 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46476

