### PR TITLE
[MM-46099] Return error on joining call through slash command if calls are disabled

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -11,6 +11,8 @@ async function globalSetup(config: FullConfig) {
 
     const adminContext = await request.newContext({
         baseURL,
+
+        // prevents initial desktop app prompt from showing
         storageState: {
             cookies: [{
                 name: '',
@@ -51,8 +53,11 @@ async function globalSetup(config: FullConfig) {
             },
             headers,
         });
+
         const requestContext = await request.newContext({
             baseURL,
+
+            // prevents initial desktop app prompt from showing
             storageState: {
                 cookies: [{
                     name: '',
@@ -110,9 +115,12 @@ async function globalSetup(config: FullConfig) {
             },
             headers,
         });
+
+        // disable various onboarding flows
         await adminContext.put(`/api/v4/users/${user.id}/preferences`, {
             data: [
                 {user_id: user.id, category: 'recommended_next_steps', name: 'skip', value: 'true'},
+                {user_id: user.id, category: 'recommended_next_steps', name: 'hide', value: 'true'},
                 {user_id: user.id, category: 'insights', name: 'insights_tutorial_state', value: '{"insights_modal_viewed":true}'},
             ],
             headers,

--- a/e2e/tests/start_call.spec.ts
+++ b/e2e/tests/start_call.spec.ts
@@ -3,8 +3,7 @@ import {readFile} from 'fs/promises';
 import {test, expect, chromium} from '@playwright/test';
 
 import PlaywrightDevPage from '../page';
-import {userState, baseURL} from '../constants';
-import plugin from '../../plugin.json';
+import {userState} from '../constants';
 
 declare global {
     interface Window {

--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -1,7 +1,5 @@
 import {pluginId} from './manifest';
 
-export const VOICE_CHANNEL_ENABLE = pluginId + '_voice_channel_enable';
-export const VOICE_CHANNEL_DISABLE = pluginId + '_voice_channel_disable';
 export const VOICE_CHANNEL_USER_CONNECTED = pluginId + '_voice_channel_user_connected';
 export const VOICE_CHANNEL_USER_DISCONNECTED = pluginId + '_voice_channel_user_disconnected';
 export const VOICE_CHANNEL_USER_MUTED = pluginId + '_voice_channel_user_muted';
@@ -31,4 +29,5 @@ export const SHOW_END_CALL_MODAL = pluginId + '_show_end_call_modal';
 export const HIDE_END_CALL_MODAL = pluginId + '_hide_end_call_modal';
 
 export const RECEIVED_CALLS_CONFIG = pluginId + '_received_calls_config';
+export const RECEIVED_CHANNEL_STATE = pluginId + 'received_channel_state';
 

--- a/webapp/src/components/channel_header_button/index.ts
+++ b/webapp/src/components/channel_header_button/index.ts
@@ -6,7 +6,7 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import {
     voiceConnectedUsers,
     connectedChannelID,
-    channelState,
+    callsEnabled,
     isCloudFeatureRestricted,
     isCloudProfessionalOrEnterprise,
     isLimitRestricted,
@@ -16,7 +16,7 @@ import {
 import ChannelHeaderButton from './component';
 
 const mapStateToProps = (state: GlobalState) => ({
-    show: Boolean(channelState(state, getCurrentChannelId(state))?.enabled),
+    show: callsEnabled(state, getCurrentChannelId(state)),
     inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
     hasCall: voiceConnectedUsers(state).length > 0,
     isCloudFeatureRestricted: isCloudFeatureRestricted(state),

--- a/webapp/src/components/channel_header_button/index.ts
+++ b/webapp/src/components/channel_header_button/index.ts
@@ -6,7 +6,7 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import {
     voiceConnectedUsers,
     connectedChannelID,
-    isVoiceEnabled,
+    channelState,
     isCloudFeatureRestricted,
     isCloudProfessionalOrEnterprise,
     isLimitRestricted,
@@ -16,7 +16,7 @@ import {
 import ChannelHeaderButton from './component';
 
 const mapStateToProps = (state: GlobalState) => ({
-    show: isVoiceEnabled(state),
+    show: Boolean(channelState(state, getCurrentChannelId(state))?.enabled),
     inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
     hasCall: voiceConnectedUsers(state).length > 0,
     isCloudFeatureRestricted: isCloudFeatureRestricted(state),

--- a/webapp/src/components/channel_header_dropdown_button/index.ts
+++ b/webapp/src/components/channel_header_dropdown_button/index.ts
@@ -6,7 +6,7 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import {
     voiceConnectedUsers,
     connectedChannelID,
-    channelState,
+    callsEnabled,
     isCloudFeatureRestricted,
     isCloudProfessionalOrEnterprise,
     isLimitRestricted,
@@ -16,7 +16,7 @@ import {
 import ChannelHeaderDropdownButton from './component';
 
 const mapStateToProps = (state: GlobalState) => ({
-    show: Boolean(channelState(state, getCurrentChannelId(state))?.enabled),
+    show: callsEnabled(state, getCurrentChannelId(state)),
     inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
     hasCall: voiceConnectedUsers(state).length > 0,
     isCloudFeatureRestricted: isCloudFeatureRestricted(state),

--- a/webapp/src/components/channel_header_dropdown_button/index.ts
+++ b/webapp/src/components/channel_header_dropdown_button/index.ts
@@ -6,7 +6,7 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import {
     voiceConnectedUsers,
     connectedChannelID,
-    isVoiceEnabled,
+    channelState,
     isCloudFeatureRestricted,
     isCloudProfessionalOrEnterprise,
     isLimitRestricted,
@@ -16,7 +16,7 @@ import {
 import ChannelHeaderDropdownButton from './component';
 
 const mapStateToProps = (state: GlobalState) => ({
-    show: isVoiceEnabled(state),
+    show: Boolean(channelState(state, getCurrentChannelId(state))?.enabled),
     inCall: Boolean(connectedChannelID(state) && connectedChannelID(state) === getCurrentChannelId(state)),
     hasCall: voiceConnectedUsers(state).length > 0,
     isCloudFeatureRestricted: isCloudFeatureRestricted(state),

--- a/webapp/src/components/channel_header_menu_button/index.ts
+++ b/webapp/src/components/channel_header_menu_button/index.ts
@@ -3,12 +3,12 @@ import {GlobalState} from '@mattermost/types/store';
 
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
-import {channelState} from '../../selectors';
+import {callsEnabled} from '../../selectors';
 
 import ChannelHeaderMenuButton from './component';
 
 const mapStateToProps = (state: GlobalState) => ({
-    enabled: Boolean(channelState(state, getCurrentChannelId(state))?.enabled),
+    enabled: callsEnabled(state, getCurrentChannelId(state)),
 });
 
 export default connect(mapStateToProps)(ChannelHeaderMenuButton);

--- a/webapp/src/components/channel_header_menu_button/index.ts
+++ b/webapp/src/components/channel_header_menu_button/index.ts
@@ -1,12 +1,14 @@
 import {connect} from 'react-redux';
 import {GlobalState} from '@mattermost/types/store';
 
-import {isVoiceEnabled} from '../../selectors';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+
+import {channelState} from '../../selectors';
 
 import ChannelHeaderMenuButton from './component';
 
 const mapStateToProps = (state: GlobalState) => ({
-    enabled: isVoiceEnabled(state),
+    enabled: Boolean(channelState(state, getCurrentChannelId(state))?.enabled),
 });
 
 export default connect(mapStateToProps)(ChannelHeaderMenuButton);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -16,7 +16,7 @@ import {displayFreeTrial, getCallsConfig} from 'src/actions';
 import {PostTypeCloudTrialRequest} from 'src/components/custom_post_types/post_type_cloud_trial_request';
 
 import {
-    channelState,
+    callsEnabled,
     connectedChannelID,
     voiceConnectedUsers,
     voiceConnectedUsersInChannel,
@@ -322,7 +322,7 @@ export default class Plugin {
             switch (subCmd) {
             case 'join':
             case 'start':
-                if (!channelState(store.getState(), args.channel_id)?.enabled) {
+                if (!callsEnabled(store.getState(), args.channel_id)) {
                     return {error: {message: 'Cannot start or join call: calls are disabled in this channel.'}};
                 }
 
@@ -528,7 +528,7 @@ export default class Plugin {
                 async (channelID) => {
                     try {
                         const resp = await axios.post(`${getPluginPath()}/${currChannelId}`,
-                            {enabled: !channelState(store.getState(), currChannelId).enabled},
+                            {enabled: !callsEnabled(store.getState(), currChannelId)},
                             {headers: {'X-Requested-With': 'XMLHttpRequest'}});
                         store.dispatch({
                             type: RECEIVED_CHANNEL_STATE,

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -16,7 +16,7 @@ import {displayFreeTrial, getCallsConfig} from 'src/actions';
 import {PostTypeCloudTrialRequest} from 'src/components/custom_post_types/post_type_cloud_trial_request';
 
 import {
-    isVoiceEnabled,
+    channelState,
     connectedChannelID,
     voiceConnectedUsers,
     voiceConnectedUsersInChannel,
@@ -66,8 +66,7 @@ import {
 import {logErr, logDebug} from './log';
 
 import {
-    VOICE_CHANNEL_ENABLE,
-    VOICE_CHANNEL_DISABLE,
+    RECEIVED_CHANNEL_STATE,
     VOICE_CHANNEL_USER_CONNECTED,
     VOICE_CHANNEL_USER_DISCONNECTED,
     VOICE_CHANNEL_USERS_CONNECTED,
@@ -106,15 +105,17 @@ export default class Plugin {
     }
 
     private registerWebSocketEvents(registry: PluginRegistry, store: Store, followThread: (channelID: string, teamID: string) => Promise<void>) {
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_channel_enable_voice`, (data) => {
+        registry.registerWebSocketEventHandler(`custom_${pluginId}_channel_enable_voice`, (ev) => {
             store.dispatch({
-                type: VOICE_CHANNEL_ENABLE,
+                type: RECEIVED_CHANNEL_STATE,
+                data: {id: ev.broadcast.channel_id, enabled: true},
             });
         });
 
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_channel_disable_voice`, (data) => {
+        registry.registerWebSocketEventHandler(`custom_${pluginId}_channel_disable_voice`, (ev) => {
             store.dispatch({
-                type: VOICE_CHANNEL_DISABLE,
+                type: RECEIVED_CHANNEL_STATE,
+                data: {id: ev.broadcast.channel_id, enabled: false},
             });
         });
 
@@ -321,6 +322,10 @@ export default class Plugin {
             switch (subCmd) {
             case 'join':
             case 'start':
+                if (!channelState(store.getState(), args.channel_id)?.enabled) {
+                    return {error: {message: 'Cannot start or join call: calls are disabled in this channel.'}};
+                }
+
                 if (subCmd === 'start') {
                     if (voiceConnectedUsersInChannel(store.getState(), args.channel_id).length > 0) {
                         return {error: {message: 'A call is already ongoing in the channel.'}};
@@ -523,10 +528,11 @@ export default class Plugin {
                 async (channelID) => {
                     try {
                         const resp = await axios.post(`${getPluginPath()}/${currChannelId}`,
-                            {enabled: !isVoiceEnabled(store.getState())},
+                            {enabled: !channelState(store.getState(), currChannelId).enabled},
                             {headers: {'X-Requested-With': 'XMLHttpRequest'}});
                         store.dispatch({
-                            type: resp.data.enabled ? VOICE_CHANNEL_ENABLE : VOICE_CHANNEL_DISABLE,
+                            type: RECEIVED_CHANNEL_STATE,
+                            data: {id: currChannelId, enabled: resp.data.enabled},
                         });
                     } catch (err) {
                         logErr(err);
@@ -600,7 +606,8 @@ export default class Plugin {
             try {
                 const resp = await axios.get(`${getPluginPath()}/${channelID}`);
                 store.dispatch({
-                    type: resp.data.enabled ? VOICE_CHANNEL_ENABLE : VOICE_CHANNEL_DISABLE,
+                    type: RECEIVED_CHANNEL_STATE,
+                    data: {id: channelID, enabled: resp.data.enabled},
                 });
                 store.dispatch({
                     type: VOICE_CHANNEL_USERS_CONNECTED,
@@ -654,7 +661,8 @@ export default class Plugin {
             } catch (err) {
                 logErr(err);
                 store.dispatch({
-                    type: VOICE_CHANNEL_DISABLE,
+                    type: RECEIVED_CHANNEL_STATE,
+                    data: {id: channelID, enabled: false},
                 });
             }
         };

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -5,8 +5,6 @@ import {UserProfile} from '@mattermost/types/users';
 import {CallsConfigDefault, CallsConfig, UserState} from './types/types';
 
 import {
-    VOICE_CHANNEL_ENABLE,
-    VOICE_CHANNEL_DISABLE,
     VOICE_CHANNEL_USER_CONNECTED,
     VOICE_CHANNEL_USER_DISCONNECTED,
     VOICE_CHANNEL_USERS_CONNECTED,
@@ -34,16 +32,25 @@ import {
     RECEIVED_CALLS_CONFIG,
     SHOW_END_CALL_MODAL,
     HIDE_END_CALL_MODAL,
+    RECEIVED_CHANNEL_STATE,
 } from './action_types';
 
-const isVoiceEnabled = (state = false, action: { type: string }) => {
+interface channelState {
+    id: string,
+    enabled: boolean,
+}
+
+interface channelStateAction {
+    type: string,
+    data: channelState,
+}
+
+const channelState = (state: {[channelID: string]: channelState} = {}, action: channelStateAction) => {
     switch (action.type) {
-    case VOICE_CHANNEL_UNINIT:
-        return false;
-    case VOICE_CHANNEL_ENABLE:
-        return true;
-    case VOICE_CHANNEL_DISABLE:
-        return false;
+    case RECEIVED_CHANNEL_STATE:
+        return {
+            [action.data.id]: action.data,
+        };
     default:
         return state;
     }
@@ -504,7 +511,7 @@ const callsConfig = (state = CallsConfigDefault, action: { type: string, data: C
 };
 
 export default combineReducers({
-    isVoiceEnabled,
+    channelState,
     voiceConnectedChannels,
     connectedChannelID,
     voiceConnectedProfiles,

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -206,3 +206,5 @@ export const isCloudTrialNeverStarted: (state: GlobalState) => boolean = createS
 );
 
 export const channelState = (state: GlobalState, channelID: string) => getPluginState(state).channelState[channelID];
+
+export const callsEnabled = (state: GlobalState, channelID: string) => Boolean(channelState(state, channelID)?.enabled);

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -15,7 +15,6 @@ import {pluginId} from './manifest';
 //@ts-ignore GlobalState is not complete
 const getPluginState = (state: GlobalState) => state['plugins-' + pluginId] || {};
 
-export const isVoiceEnabled = (state: GlobalState) => getPluginState(state).isVoiceEnabled;
 export const voiceConnectedChannels = (state: GlobalState) => getPluginState(state).voiceConnectedChannels;
 export const voiceConnectedUsers = (state: GlobalState) => {
     const currentChannelID = getCurrentChannelId(state);
@@ -205,3 +204,5 @@ export const isCloudTrialNeverStarted: (state: GlobalState) => boolean = createS
         return subscription?.trial_end_at === 0;
     },
 );
+
+export const channelState = (state: GlobalState, channelID: string) => getPluginState(state).channelState[channelID];


### PR DESCRIPTION
#### Summary

PR adds an error message in case `/call start` or `/call join` slash commands are sent in a channel where calls are not enabled. As an added bonus this PR led to some small refactor on the redux side.

#### Screenshot

![image](https://user-images.githubusercontent.com/1832946/185964071-dbdd3c66-d743-40c4-a296-88f4a65ea934.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46099