### PR TITLE
[MM-45128] Disable join sounds after number of participants threshold

### DIFF
--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -31,4 +31,5 @@ export const SHOW_END_CALL_MODAL = pluginId + '_show_end_call_modal';
 export const HIDE_END_CALL_MODAL = pluginId + '_hide_end_call_modal';
 
 export const RECEIVED_CALLS_CONFIG = pluginId + '_received_calls_config';
+export const RECEIVED_CALLS_USER_PREFERENCES = pluginId + '_received_calls_user_preferences';
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -28,7 +28,7 @@ import {
     allowEnableCalls,
     iceServers,
     needsTURNCredentials,
-    callsUserPreferences,
+    shouldPlayJoinUserSound,
 } from './selectors';
 
 import {pluginId} from './manifest';
@@ -127,8 +127,7 @@ export default class Plugin {
             if (window.callsClient?.channelID === channelID) {
                 if (userID === currentUserID) {
                     playSound(getPluginStaticPath() + JoinSelfSound);
-                } else if (channelID === connectedChannelID(store.getState()) &&
-                    voiceConnectedUsersInChannel(store.getState(), channelID)?.length < callsUserPreferences(store.getState()).joinSoundParticipantsThreshold) {
+                } else if (shouldPlayJoinUserSound(store.getState())) {
                     playSound(getPluginStaticPath() + JoinUserSound);
                 }
             }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -28,6 +28,7 @@ import {
     allowEnableCalls,
     iceServers,
     needsTURNCredentials,
+    callsUserPreferences,
 } from './selectors';
 
 import {pluginId} from './manifest';
@@ -126,7 +127,8 @@ export default class Plugin {
             if (window.callsClient?.channelID === channelID) {
                 if (userID === currentUserID) {
                     playSound(getPluginStaticPath() + JoinSelfSound);
-                } else if (channelID === connectedChannelID(store.getState())) {
+                } else if (channelID === connectedChannelID(store.getState()) &&
+                    voiceConnectedUsersInChannel(store.getState(), channelID)?.length < callsUserPreferences(store.getState()).joinSoundParticipantsThreshold) {
                     playSound(getPluginStaticPath() + JoinUserSound);
                 }
             }

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -2,7 +2,13 @@ import {combineReducers} from 'redux';
 
 import {UserProfile} from '@mattermost/types/users';
 
-import {CallsConfigDefault, CallsConfig, UserState} from './types/types';
+import {
+    CallsConfigDefault,
+    CallsConfig,
+    UserState,
+    CallsUserPreferences,
+    CallsUserPreferencesDefault,
+} from './types/types';
 
 import {
     VOICE_CHANNEL_ENABLE,
@@ -34,6 +40,7 @@ import {
     RECEIVED_CALLS_CONFIG,
     SHOW_END_CALL_MODAL,
     HIDE_END_CALL_MODAL,
+    RECEIVED_CALLS_USER_PREFERENCES,
 } from './action_types';
 
 const isVoiceEnabled = (state = false, action: { type: string }) => {
@@ -503,6 +510,15 @@ const callsConfig = (state = CallsConfigDefault, action: { type: string, data: C
     }
 };
 
+const callsUserPreferences = (state = CallsUserPreferencesDefault, action: { type: string, data: CallsUserPreferences}) => {
+    switch (action.type) {
+    case RECEIVED_CALLS_USER_PREFERENCES:
+        return action.data;
+    default:
+        return state;
+    }
+};
+
 export default combineReducers({
     isVoiceEnabled,
     voiceConnectedChannels,
@@ -517,4 +533,5 @@ export default combineReducers({
     screenSourceModal,
     voiceChannelRootPost,
     callsConfig,
+    callsUserPreferences,
 });

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -8,7 +8,7 @@ import {LicenseSkus} from '@mattermost/types/general';
 
 import {isDMChannel} from 'src/utils';
 
-import {CallsConfig} from 'src/types/types';
+import {CallsConfig, CallsUserPreferences} from 'src/types/types';
 
 import {pluginId} from './manifest';
 
@@ -205,3 +205,7 @@ export const isCloudTrialNeverStarted: (state: GlobalState) => boolean = createS
         return subscription?.trial_end_at === 0;
     },
 );
+
+export const callsUserPreferences = (state: GlobalState): CallsUserPreferences => {
+    return getPluginState(state).callsUserPreferences;
+};

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -42,6 +42,13 @@ export const voiceConnectedUsersInChannel = (state: GlobalState, channelID: stri
 
 export const connectedChannelID = (state: GlobalState) => getPluginState(state).connectedChannelID;
 
+const numUsersInConnectedChannel: (state: GlobalState) => number = createSelector(
+    'numUsersInConnectedChannel',
+    connectedChannelID,
+    voiceConnectedChannels,
+    (channelID, channels) => channels ? channels[channelID]?.length || 0 : 0,
+);
+
 export const voiceConnectedProfiles = (state: GlobalState) => {
     if (!getPluginState(state).voiceConnectedProfiles) {
         return [];
@@ -209,3 +216,12 @@ export const isCloudTrialNeverStarted: (state: GlobalState) => boolean = createS
 export const callsUserPreferences = (state: GlobalState): CallsUserPreferences => {
     return getPluginState(state).callsUserPreferences;
 };
+
+export const shouldPlayJoinUserSound: (state: GlobalState) => boolean = createSelector(
+    'shouldPlayJoinUserSound',
+    numUsersInConnectedChannel,
+    callsUserPreferences,
+    (numUsers, preferences) => {
+        return numUsers < preferences.joinSoundParticipantsThreshold;
+    },
+);

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -46,7 +46,7 @@ const numUsersInConnectedChannel: (state: GlobalState) => number = createSelecto
     'numUsersInConnectedChannel',
     connectedChannelID,
     voiceConnectedChannels,
-    (channelID, channels) => channels ? channels[channelID]?.length || 0 : 0,
+    (channelID, channels) => channels[channelID]?.length || 0,
 );
 
 export const voiceConnectedProfiles = (state: GlobalState) => {

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -83,3 +83,11 @@ export type AudioDevices = {
     inputs: MediaDeviceInfo[],
     outputs: MediaDeviceInfo[],
 }
+
+export type CallsUserPreferences = {
+    joinSoundParticipantsThreshold: number,
+}
+
+export const CallsUserPreferencesDefault = {
+    joinSoundParticipantsThreshold: 8,
+};


### PR DESCRIPTION
#### Summary

PR disables the "user has joined the call" sound after reaching a threshold of 8 participants. 

Since we are looking to make this configurable at some point in the future, I opted not to check against a simple constant but add the necessary boilerplate to support the more advanced use case.

/cc @tanmay-des @itao 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45128