### PR TITLE
Use base64 payload

### DIFF
--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -109,18 +110,21 @@ func handleStatsCommand(fields []string) (*model.CommandResponse, error) {
 		return nil, fmt.Errorf("Invalid number of arguments provided")
 	}
 
-	if len(fields[2]) < 2 {
+	js, err := base64.StdEncoding.DecodeString(fields[2])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to decode payload: %w", err)
+	}
+
+	if len(js) < 2 {
 		return nil, fmt.Errorf("Invalid stats object")
 	}
 
-	js := fields[2][1 : len(fields[2])-1]
-
-	if js == "{}" {
+	if string(js) == "{}" {
 		return nil, fmt.Errorf("Empty stats object")
 	}
 
 	var buf bytes.Buffer
-	if err := json.Indent(&buf, []byte(js), "", " "); err != nil {
+	if err := json.Indent(&buf, js, "", " "); err != nil {
 		return nil, fmt.Errorf("Failed to indent JSON: %w", err)
 	}
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -379,16 +379,18 @@ export default class Plugin {
                     window.localStorage.removeItem('calls_experimental_features');
                 }
                 break;
-            case 'stats':
+            case 'stats': {
                 if (window.callsClient) {
                     try {
                         const stats = await window.callsClient.getStats();
-                        return {message: `/call stats "${JSON.stringify(stats)}"`, args};
+                        return {message: `/call stats ${btoa(JSON.stringify(stats))}`, args};
                     } catch (err) {
                         return {error: {message: err}};
                     }
                 }
-                return {message: `/call stats '${sessionStorage.getItem('calls_client_stats') || '{}'}'`, args};
+                const data = sessionStorage.getItem('calls_client_stats') || '{}';
+                return {message: `/call stats ${btoa(data)}`, args};
+            }
             }
 
             return {message, args};


### PR DESCRIPTION
#### Summary

So it wasn't the quotes but the audio device labels containing spaces that would mess the output of `strings.Fields`. Sending a base64-encoded payload to avoid this kind of issues.


