### PR TITLE
[MM-46807] Implement client-side telemetry

### DIFF
--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -23,6 +23,7 @@ var (
 	telemetryClientTypes  = []string{"web", "mobile", "desktop"}
 	telemetryClientEvents = []string{
 		"user_open_expanded_view",
+		"user_close_expanded_view",
 		"user_open_participants_list",
 		"user_close_participants_list",
 		"user_share_screen",

--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -17,21 +17,27 @@ const (
 	evCallUserJoined  = "call_user_joined"
 	evCallUserLeft    = "call_user_left"
 	evCallNotifyAdmin = "call_notify_admin"
-
-	// client-side events
-	evUserOpenExpandedView       = "user_open_expanded_view"
-	evUserToggleParticipantsList = "user_toggle_participants_list"
 )
 
-var telemetryClientEvents = map[string]struct{}{
-	evUserOpenExpandedView:       {},
-	evUserToggleParticipantsList: {},
-}
+var (
+	telemetryClientTypes  = []string{"web", "mobile", "desktop"}
+	telemetryClientEvents = []string{
+		"user_open_expanded_view",
+		"user_toggle_participants_list",
+	}
+	telemetryClientTypesMap  map[string]struct{}
+	telemetryClientEventsMap map[string]struct{}
+)
 
-var telemetryClientTypes = map[string]struct{}{
-	"web":     {},
-	"mobile":  {},
-	"desktop": {},
+func init() {
+	telemetryClientEventsMap = make(map[string]struct{}, len(telemetryClientEvents))
+	for _, eventType := range telemetryClientEvents {
+		telemetryClientEventsMap[eventType] = struct{}{}
+	}
+	telemetryClientTypesMap = make(map[string]struct{}, len(telemetryClientTypes))
+	for _, clientType := range telemetryClientTypes {
+		telemetryClientTypesMap[clientType] = struct{}{}
+	}
 }
 
 type trackEventRequest struct {
@@ -116,13 +122,13 @@ func (p *Plugin) handleTrackEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := telemetryClientEvents[data.Event]; !ok {
+	if _, ok := telemetryClientEventsMap[data.Event]; !ok {
 		res.Err = "invalid telemetry event"
 		res.Code = http.StatusBadRequest
 		return
 	}
 
-	if _, ok := telemetryClientTypes[data.ClientType]; !ok {
+	if _, ok := telemetryClientTypesMap[data.ClientType]; !ok {
 		res.Err = "invalid client type"
 		res.Code = http.StatusBadRequest
 		return

--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -23,7 +23,13 @@ var (
 	telemetryClientTypes  = []string{"web", "mobile", "desktop"}
 	telemetryClientEvents = []string{
 		"user_open_expanded_view",
-		"user_toggle_participants_list",
+		"user_open_participants_list",
+		"user_close_participants_list",
+		"user_share_screen",
+		"user_unshare_screen",
+		"user_raise_hand",
+		"user_lower_hand",
+		"user_open_channel_link",
 	}
 	telemetryClientTypesMap  map[string]struct{}
 	telemetryClientEventsMap map[string]struct{}

--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -333,12 +333,8 @@
     ],
     "no-self-compare": 2,
     "no-sequences": 2,
-    "no-shadow": [
-      2,
-      {
-        "hoist": "functions"
-      }
-    ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
     "no-shadow-restricted-names": 2,
     "no-spaced-func": 2,
     "no-tabs": 0,

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -143,3 +143,19 @@ export const endCall = (channelID: string) => {
     return axios.post(`${getPluginPath()}/calls/${channelID}/end`, null,
         {headers: {'X-Requested-With': 'XMLHttpRequest'}});
 };
+
+export const trackEvent = (event: string, source: string, props?: Record<string, any>) => {
+    if (!props) {
+        props = {};
+    }
+    const eventData = {
+        event,
+        clientType: window.desktop ? 'desktop' : 'web',
+        source,
+        props,
+    };
+    return Client4.doFetch(
+        `${getPluginPath()}/telemetry/track`,
+        {method: 'post', body: JSON.stringify(eventData)},
+    );
+};

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -13,6 +13,7 @@ import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/user
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {CallsConfig} from 'src/types/types';
+import * as Telemetry from 'src/types/telemetry';
 import {getPluginPath} from 'src/utils';
 
 import {modals, openPricingModal} from 'src/webapp_globals';
@@ -145,7 +146,7 @@ export const endCall = (channelID: string) => {
         {headers: {'X-Requested-With': 'XMLHttpRequest'}});
 };
 
-export const trackEvent = (event: string, source: string, props?: Record<string, any>) => {
+export const trackEvent = (event: Telemetry.Event, source: Telemetry.Source, props?: Record<string, any>) => {
     return (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const config = getConfig(getState());
         if (config.DiagnosticsEnabled !== 'true') {

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -10,6 +10,7 @@ import {Client4} from 'mattermost-redux/client';
 import {CloudCustomer} from '@mattermost/types/cloud';
 
 import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {CallsConfig} from 'src/types/types';
 import {getPluginPath} from 'src/utils';
@@ -145,17 +146,23 @@ export const endCall = (channelID: string) => {
 };
 
 export const trackEvent = (event: string, source: string, props?: Record<string, any>) => {
-    if (!props) {
-        props = {};
-    }
-    const eventData = {
-        event,
-        clientType: window.desktop ? 'desktop' : 'web',
-        source,
-        props,
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const config = getConfig(getState());
+        if (config.DiagnosticsEnabled !== 'true') {
+            return;
+        }
+        if (!props) {
+            props = {};
+        }
+        const eventData = {
+            event,
+            clientType: window.desktop ? 'desktop' : 'web',
+            source,
+            props,
+        };
+        Client4.doFetch(
+            `${getPluginPath()}/telemetry/track`,
+            {method: 'post', body: JSON.stringify(eventData)},
+        );
     };
-    return Client4.doFetch(
-        `${getPluginPath()}/telemetry/track`,
-        {method: 'post', body: JSON.stringify(eventData)},
-    );
 };

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -11,6 +11,7 @@ import {changeOpacity} from 'mattermost-redux/utils/theme_utils';
 import {isDirectChannel, isGroupChannel, isOpenChannel, isPrivateChannel} from 'mattermost-redux/utils/channel_utils';
 
 import {UserState, AudioDevices} from 'src/types/types';
+import * as Telemetry from 'src/types/telemetry';
 import {
     getUserDisplayName,
     hasExperimentalFlag,
@@ -68,6 +69,7 @@ interface Props {
     show: boolean,
     showExpandedView: () => void,
     showScreenSourceModal: () => void,
+    trackEvent: (event: Telemetry.Event, source: Telemetry.Source, props?: Record<string, any>) => void,
 }
 
 interface DraggingState {
@@ -256,13 +258,13 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             this.onMuteToggle();
             break;
         case RAISE_LOWER_HAND:
-            this.onRaiseHandToggle();
+            this.onRaiseHandToggle(true);
             break;
         case SHARE_UNSHARE_SCREEN:
-            this.onShareScreenToggle();
+            this.onShareScreenToggle(true);
             break;
         case PARTICIPANTS_LIST_TOGGLE:
-            this.onParticipantsButtonClick();
+            this.onParticipantsButtonClick(true);
             break;
         case LEAVE_CALL:
             this.onDisconnectClick();
@@ -422,11 +424,13 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         this.setState({showMenu: false});
     }
 
-    onShareScreenToggle = async () => {
+    onShareScreenToggle = async (fromShortcut?: boolean) => {
         const state = {} as State;
+
         if (this.props.screenSharingID === this.props.currentUserID) {
             window.callsClient.unshareScreen();
             state.screenStream = null;
+            this.props.trackEvent(Telemetry.Event.UnshareScreen, Telemetry.Source.Widget, {initiator: fromShortcut ? 'shortcut' : 'button'});
         } else if (!this.props.screenSharingID) {
             if (window.desktop && compareSemVer(window.desktop.version, '5.1.0') >= 0) {
                 this.props.showScreenSourceModal();
@@ -434,6 +438,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 const stream = await window.callsClient.shareScreen('', hasExperimentalFlag());
                 state.screenStream = stream;
             }
+            this.props.trackEvent(Telemetry.Event.ShareScreen, Telemetry.Source.Widget, {initiator: fromShortcut ? 'shortcut' : 'button'});
         }
 
         this.setState({
@@ -486,7 +491,10 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         });
     }
 
-    onParticipantsButtonClick = () => {
+    onParticipantsButtonClick = (fromShortcut?: boolean) => {
+        const event = this.state.showParticipantsList ? Telemetry.Event.CloseParticipantsList : Telemetry.Event.OpenParticipantsList;
+        this.props.trackEvent(event, Telemetry.Source.Widget, {initiator: fromShortcut ? 'shortcut' : 'button'});
+
         this.setState({
             showParticipantsList: !this.state.showParticipantsList,
             showMenu: false,
@@ -566,7 +574,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                             borderRadius: '4px',
                             fontWeight: 600,
                         }}
-                        onClick={this.onShareScreenToggle}
+                        onClick={() => this.onShareScreenToggle()}
                     >
                         {'Stop sharing'}
                     </button>
@@ -651,7 +659,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     className={`style--none ${!sharingID || isSharing ? 'button-controls' : 'button-controls-disabled'} button-controls--wide`}
                     disabled={sharingID !== '' && !isSharing}
                     style={{background: isSharing ? 'rgba(var(--dnd-indicator-rgb), 0.12)' : ''}}
-                    onClick={this.onShareScreenToggle}
+                    onClick={() => this.onShareScreenToggle()}
                 >
                     <ScreenIcon
                         style={{
@@ -902,7 +910,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                             color: sharingID !== '' && !isSharing ? changeOpacity(this.props.theme.centerChannelColor, 0.34) : '',
                         }}
                         disabled={Boolean(sharingID !== '' && !isSharing)}
-                        onClick={this.onShareScreenToggle}
+                        onClick={() => this.onShareScreenToggle()}
                     >
                         <ScreenIcon
                             style={{width: '16px', height: '16px', marginRight: '8px'}}
@@ -1114,6 +1122,8 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             return;
         }
 
+        this.props.trackEvent(Telemetry.Event.OpenExpandedView, Telemetry.Source.Widget, {initiator: 'button'});
+
         // TODO: remove this as soon as we support opening a window from desktop app.
         if (window.desktop) {
             this.props.showExpandedView();
@@ -1140,20 +1150,23 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         }
     }
 
-    onRaiseHandToggle = () => {
+    onRaiseHandToggle = (fromShortcut?: boolean) => {
         if (!window.callsClient) {
             return;
         }
         if (window.callsClient.isHandRaised) {
             window.callsClient.unraiseHand();
+            this.props.trackEvent(Telemetry.Event.LowerHand, Telemetry.Source.Widget, {initiator: fromShortcut ? 'shortcut' : 'button'});
         } else {
             window.callsClient.raiseHand();
+            this.props.trackEvent(Telemetry.Event.RaiseHand, Telemetry.Source.Widget, {initiator: fromShortcut ? 'shortcut' : 'button'});
         }
     }
 
     onChannelLinkClick = (ev: React.MouseEvent<HTMLElement>) => {
         ev.preventDefault();
         window.postMessage({type: 'browser-history-push-return', message: {pathName: this.props.channelURL}}, window.origin);
+        this.props.trackEvent(Telemetry.Event.OpenChannelLink, Telemetry.Source.Widget);
     }
 
     renderChannelName = (hasTeamSidebar: boolean) => {
@@ -1303,7 +1316,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                                     color: this.state.showParticipantsList ? 'rgba(28, 88, 217, 1)' : '',
                                     background: this.state.showParticipantsList ? 'rgba(28, 88, 217, 0.12)' : '',
                                 }}
-                                onClick={this.onParticipantsButtonClick}
+                                onClick={() => this.onParticipantsButtonClick()}
                             >
                                 <ParticipantsIcon
                                     style={{width: '16px', height: '16px', marginRight: '4px'}}
@@ -1328,7 +1341,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         >
                             <button
                                 className='cursor--pointer style--none button-controls'
-                                onClick={this.onRaiseHandToggle}
+                                onClick={() => this.onRaiseHandToggle()}
                                 style={{background: window.callsClient.isHandRaised ? 'rgba(255, 188, 66, 0.16)' : ''}}
                             >
                                 <HandIcon

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1139,9 +1139,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             });
 
             expandedViewWindow?.addEventListener('beforeunload', () => {
+                this.props.trackEvent(Telemetry.Event.CloseExpandedView, Telemetry.Source.ExpandedView);
                 if (!window.callsClient) {
                     return;
                 }
+
                 const localScreenStream = window.callsClient.getLocalScreenStream();
                 if (localScreenStream && localScreenStream.getVideoTracks()[0].id === expandedViewWindow.screenSharingTrackId) {
                     window.callsClient.unshareScreen();

--- a/webapp/src/components/call_widget/index.ts
+++ b/webapp/src/components/call_widget/index.ts
@@ -17,7 +17,7 @@ import {Client4} from 'mattermost-redux/client';
 
 import {UserState} from '../../types/types';
 
-import {showExpandedView, showScreenSourceModal} from '../../actions';
+import {showExpandedView, showScreenSourceModal, trackEvent} from '../../actions';
 
 import {connectedChannelID, voiceConnectedProfiles, voiceUsersStatuses, voiceChannelCallStartAt, voiceChannelScreenSharingID, expandedView} from '../../selectors';
 
@@ -87,6 +87,7 @@ const mapStateToProps = (state: GlobalState) => {
 const mapDispatchToProps = (dispatch: Dispatch) => bindActionCreators({
     showExpandedView,
     showScreenSourceModal,
+    trackEvent,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(CallWidget);

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -196,6 +196,11 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         });
     }
 
+    onCloseViewClick = () => {
+        this.props.trackEvent(Telemetry.Event.CloseExpandedView, Telemetry.Source.ExpandedView, {initiator: 'button'});
+        this.props.hideExpandedView();
+    }
+
     public componentDidUpdate(prevProps: Props, prevState: State) {
         if (window.opener) {
             if (document.title.indexOf('Call') === -1 && this.props.channel) {
@@ -478,7 +483,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                             <button
                                 className='button-close'
                                 style={style.closeViewButton as CSSProperties}
-                                onClick={this.props.hideExpandedView}
+                                onClick={this.onCloseViewClick}
                             >
                                 <CompassIcon icon='arrow-collapse'/>
                             </button>

--- a/webapp/src/components/expanded_view/index.ts
+++ b/webapp/src/components/expanded_view/index.ts
@@ -11,7 +11,7 @@ import {Client4} from 'mattermost-redux/client';
 import {UserState} from '../../types/types';
 
 import {alphaSortProfiles, stateSortProfiles, isDMChannel, getUserIdFromDM} from '../../utils';
-import {hideExpandedView, showScreenSourceModal} from '../../actions';
+import {hideExpandedView, showScreenSourceModal, trackEvent} from '../../actions';
 import {expandedView, voiceChannelCallStartAt, connectedChannelID, voiceConnectedProfiles, voiceUsersStatuses, voiceChannelScreenSharingID} from '../../selectors';
 
 import ExpandedView from './component';
@@ -54,6 +54,7 @@ const mapStateToProps = (state: GlobalState) => {
 const mapDispatchToProps = (dispatch: Dispatch) => bindActionCreators({
     hideExpandedView,
     showScreenSourceModal,
+    trackEvent,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ExpandedView);

--- a/webapp/src/types/telemetry.ts
+++ b/webapp/src/types/telemetry.ts
@@ -1,0 +1,16 @@
+export enum Event {
+    OpenExpandedView = 'user_open_expanded_view',
+    OpenParticipantsList = 'user_open_participants_list',
+    CloseParticipantsList = 'user_close_participants_list',
+    ShareScreen = 'user_share_screen',
+    UnshareScreen = 'user_unshare_screen',
+    RaiseHand = 'user_raise_hand',
+    LowerHand = 'user_lower_hand',
+    OpenChannelLink = 'user_open_channel_link',
+}
+
+export enum Source {
+    Widget = 'widget',
+    ExpandedView = 'expanded_view',
+}
+

--- a/webapp/src/types/telemetry.ts
+++ b/webapp/src/types/telemetry.ts
@@ -1,5 +1,6 @@
 export enum Event {
     OpenExpandedView = 'user_open_expanded_view',
+    CloseExpandedView = 'user_close_expanded_view',
     OpenParticipantsList = 'user_open_participants_list',
     CloseParticipantsList = 'user_close_participants_list',
     ShareScreen = 'user_share_screen',


### PR DESCRIPTION
#### Summary

PR implements client side telemetry through a new `/telemetry/track` API endpoint. This doesn't instrument any path yet but merely provides the generic functionality to track events. Will send a PR that builds on top of this one for that.

To be used as such:

```js
trackEvent('user_toggle_participants_list', 'widget');
```


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46807
