### PR TITLE
[MM-46918] Fallback to using telemetry ID as rtcd's client ID

### DIFF
--- a/server/rtcd.go
+++ b/server/rtcd.go
@@ -420,6 +420,11 @@ func (m *rtcdClientManager) getRTCDClientConfig(rtcdURL string, dialFn rtcd.Dial
 		return cfg, fmt.Errorf("rtcd URL is missing")
 	}
 
+	// Use the telemetry ID if none is explicitly given.
+	if cfg.ClientID == "" {
+		cfg.ClientID = m.ctx.API.GetDiagnosticId()
+	}
+
 	// If no client id has been provided until now we fail with error.
 	if cfg.ClientID == "" {
 		return cfg, fmt.Errorf("client id is missing")


### PR DESCRIPTION
#### Summary

This is one bit of confusing syntax I wanted to get rid of. Using the telemetry ID as a fallback seems to be a good choice as it's saved in DB already and unique across the cluster.

This means the `RTCD service URL` setting can be now configured simply using the `http://hostname:port` form.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46918

