### PR TITLE
MM-46947 - Fix: Manifest parsing won't allow placeholders for custom pluginSettingType

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -90,7 +90,7 @@
         {
           "key": "RTCDServiceURL",
           "display_name": "RTCD service URL",
-          "type": "custom",
+          "type": "text",
           "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
           "placeholder": "https://rtcd.example.com"
         }


### PR DESCRIPTION
#### Summary
- change custom to text
- tested, works

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46947