### PR TITLE
[MM-47001] Fix accessibility conflict

### DIFF
--- a/e2e/tests/shortcuts.spec.ts
+++ b/e2e/tests/shortcuts.spec.ts
@@ -123,4 +123,43 @@ test.describe('keyboard shortcuts', () => {
 
         await devPage.leaveCall();
     });
+
+    test('accessibility conflict', async ({page}) => {
+        const devPage = new PlaywrightDevPage(page);
+        await devPage.startCall();
+        await devPage.wait(1000);
+
+        // unmute
+        const muteButton = page.locator('#voice-mute-unmute');
+        await expect(muteButton).toBeVisible();
+        await muteButton.click();
+
+        // open participants list
+        await page.keyboard.press('Alt+P');
+
+        const participantsList = page.locator('#calls-widget-participants-list');
+        await expect(participantsList).toBeVisible();
+
+        // should not mute
+        await page.keyboard.press('Space');
+        await expect(participantsList).toBeVisible();
+        let isMuted = await page.evaluate(() => {
+            return window.callsClient.isMuted();
+        });
+        if (isMuted) {
+            test.fail();
+            return;
+        }
+
+        // mute
+        await page.keyboard.press('Control+Shift+Space');
+
+        isMuted = await page.evaluate(() => {
+            return window.callsClient.isMuted();
+        });
+        if (!isMuted) {
+            test.fail();
+            return;
+        }
+    });
 });

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -452,6 +452,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             return;
         }
 
+        // This is needed to prevent a conflict with the accessibility controller on buttons.
+        if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur();
+        }
+
         const isMuted = window.callsClient.isMuted();
         if (isMuted) {
             window.callsClient.unmute();
@@ -494,6 +499,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
     onParticipantsButtonClick = (fromShortcut?: boolean) => {
         const event = this.state.showParticipantsList ? Telemetry.Event.CloseParticipantsList : Telemetry.Event.OpenParticipantsList;
         this.props.trackEvent(event, Telemetry.Source.Widget, {initiator: fromShortcut ? 'shortcut' : 'button'});
+
+        // This is needed to prevent a conflict with the accessibility controller on buttons.
+        if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur();
+        }
 
         this.setState({
             showParticipantsList: !this.state.showParticipantsList,
@@ -1156,6 +1166,12 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         if (!window.callsClient) {
             return;
         }
+
+        // This is needed to prevent a conflict with the accessibility controller on buttons.
+        if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur();
+        }
+
         if (window.callsClient.isHandRaised) {
             window.callsClient.unraiseHand();
             this.props.trackEvent(Telemetry.Event.LowerHand, Telemetry.Source.Widget, {initiator: fromShortcut ? 'shortcut' : 'button'});


### PR DESCRIPTION
#### Summary

Keyboard shortcut to mute/unmute is causing a conflict with the accessibility controller since the [recommended behaviour](https://www.w3.org/WAI/ARIA/apg/patterns/button/) is that `Space` toggles a button in focus.

Given we are providing specific shortcuts I am thinking accessibility is retained hence preventing this behaviour by unfocusing the button element on click and let the in-product shortcut do its thing. But I am happy to revisit, just let me know your thoughts.

More context can be found in the original discussion at https://community.mattermost.com/core/pl/r9rktsydz3ndmmdqyjkicb8i6o

#### Ticket Link

https://mattermost.atlassian.net/browse/
