### PR TITLE
Reaction websocket broadcast

### DIFF
--- a/server/client_message.go
+++ b/server/client_message.go
@@ -26,6 +26,7 @@ const (
 	clientMessageTypeScreenOff   = "screen_off"
 	clientMessageTypeRaiseHand   = "raise_hand"
 	clientMessageTypeUnraiseHand = "unraise_hand"
+	clientMessageTypeReaction    = "reaction"
 )
 
 func (m *clientMessage) ToJSON() ([]byte, error) {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -256,17 +256,19 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 	case clientMessageTypeReaction:
 		evType := wsEventUserReact
 
-		var data struct {
-			Emoji string `json:"emoji"`
+		var emoji struct {
+			Name string `json:"name"`
+			Skin int    `json:"skin"`
 		}
-		if err := json.Unmarshal(msg.Data, &data); err != nil {
+		if err := json.Unmarshal(msg.Data, &emoji); err != nil {
 			p.LogError(err.Error())
 		}
 
 		p.API.PublishWebSocketEvent(evType, map[string]interface{}{
-			"userID":    us.userID,
-			"emoji":     data.Emoji,
-			"timestamp": time.Now().UnixMilli(),
+			"userID":     us.userID,
+			"emoji_name": emoji.Name,
+			"emoji_skin": emoji.Skin,
+			"timestamp":  time.Now().UnixMilli(),
 		}, &model.WebsocketBroadcast{ChannelId: us.channelID})
 	default:
 		p.LogError("invalid client message", "type", msg.Type)

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -257,18 +257,20 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 		evType := wsEventUserReact
 
 		var emoji struct {
-			Name string `json:"name"`
-			Skin int    `json:"skin"`
+			Name    string `json:"name"`
+			Skin    string `json:"skin"`
+			Unified string `json:"unified"`
 		}
 		if err := json.Unmarshal(msg.Data, &emoji); err != nil {
 			p.LogError(err.Error())
 		}
 
 		p.API.PublishWebSocketEvent(evType, map[string]interface{}{
-			"userID":     us.userID,
-			"emoji_name": emoji.Name,
-			"emoji_skin": emoji.Skin,
-			"timestamp":  time.Now().UnixMilli(),
+			"userID":        us.userID,
+			"emoji_name":    emoji.Name,
+			"emoji_skin":    emoji.Skin,
+			"emoji_unified": emoji.Unified,
+			"timestamp":     time.Now().UnixMilli(),
 		}, &model.WebsocketBroadcast{ChannelId: us.channelID})
 	default:
 		p.LogError("invalid client message", "type", msg.Type)

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -30,6 +30,7 @@ const (
 	wsEventCallEnd          = "call_end"
 	wsEventUserRaiseHand    = "user_raise_hand"
 	wsEventUserUnraiseHand  = "user_unraise_hand"
+	wsEventUserReact        = "user_reaction"
 	wsEventJoin             = "join"
 	wsEventError            = "error"
 	wsReconnectionTimeout   = 10 * time.Second
@@ -252,6 +253,21 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 			"userID":      us.userID,
 			"raised_hand": ts,
 		}, &model.WebsocketBroadcast{ChannelId: us.channelID, ReliableClusterSend: true})
+	case clientMessageTypeReaction:
+		evType := wsEventUserReact
+
+		var data struct {
+			Emoji string `json:"emoji"`
+		}
+		if err := json.Unmarshal(msg.Data, &data); err != nil {
+			p.LogError(err.Error())
+		}
+
+		p.API.PublishWebSocketEvent(evType, map[string]interface{}{
+			"userID":    us.userID,
+			"emoji":     data.Emoji,
+			"timestamp": time.Now().UnixMilli(),
+		}, &model.WebsocketBroadcast{ChannelId: us.channelID})
 	default:
 		p.LogError("invalid client message", "type", msg.Type)
 		return
@@ -688,6 +704,14 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 			return
 		}
 		msg.Data = []byte(msgData)
+	case clientMessageTypeReaction:
+		msgData, ok := req.Data["data"].(string)
+		if !ok {
+			p.LogError("invalid or missing data")
+			return
+		}
+		msg.Data = []byte(msgData)
+
 	}
 
 	select {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -271,7 +271,8 @@ export default class CallsClient extends EventEmitter {
             this.intervalID = window.setInterval(() => {
                 this.ws?.send('reaction', {
                     data: JSON.stringify({
-                        emoji: emojis[count],
+                        name: emojis[count],
+                        skin: count,
                     }),
                 });
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -34,6 +34,7 @@ export default class CallsClient extends EventEmitter {
     private onBeforeUnload: () => void;
     private closed = false;
     private initTime = Date.now();
+    private intervalID = 0; // TODO: Remove the following block when the actual events are being sent by the emoji picker
 
     constructor(config: CallsClientConfig) {
         super();
@@ -263,6 +264,24 @@ export default class CallsClient extends EventEmitter {
             }
         });
 
+        // TODO: Remove the following block when the actual events are being sent by the emoji picker
+        {
+            let count = 0;
+            const emojis = ['thumbsup', 'thumbsdown', 'heart', 'heart_eyes', 'see_no_evil', 'parrot', 'screwdriver'];
+            this.intervalID = window.setInterval(() => {
+                this.ws?.send('reaction', {
+                    data: JSON.stringify({
+                        emoji: emojis[count],
+                    }),
+                });
+
+                count++;
+                if (count >= emojis.length) {
+                    count = 0;
+                }
+            }, 500);
+        }
+
         return this;
     }
 
@@ -274,6 +293,7 @@ export default class CallsClient extends EventEmitter {
         this.removeAllListeners('devicechange');
         window.removeEventListener('beforeunload', this.onBeforeUnload);
         navigator.mediaDevices.removeEventListener('devicechange', this.onDeviceChange);
+        clearInterval(this.intervalID);
     }
 
     public async setAudioInputDevice(device: MediaDeviceInfo) {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -34,7 +34,6 @@ export default class CallsClient extends EventEmitter {
     private onBeforeUnload: () => void;
     private closed = false;
     private initTime = Date.now();
-    private intervalID = 0; // TODO: Remove the following block when the actual events are being sent by the emoji picker
 
     constructor(config: CallsClientConfig) {
         super();
@@ -264,26 +263,6 @@ export default class CallsClient extends EventEmitter {
             }
         });
 
-        // TODO: Remove the following block when the actual events are being sent by the emoji picker
-        {
-            let count = 0;
-            const emojis = ['thumbsup', 'thumbsdown', 'heart', 'heart_eyes', 'see_no_evil', 'parrot', 'screwdriver'];
-            this.intervalID = window.setInterval(() => {
-                this.ws?.send('reaction', {
-                    data: JSON.stringify({
-                        name: emojis[count],
-                        skin: '1F3BF',
-                        unified: '14CBD-1F3BF',
-                    }),
-                });
-
-                count++;
-                if (count >= emojis.length) {
-                    count = 0;
-                }
-            }, 500);
-        }
-
         return this;
     }
 
@@ -295,7 +274,6 @@ export default class CallsClient extends EventEmitter {
         this.removeAllListeners('devicechange');
         window.removeEventListener('beforeunload', this.onBeforeUnload);
         navigator.mediaDevices.removeEventListener('devicechange', this.onDeviceChange);
-        clearInterval(this.intervalID);
     }
 
     public async setAudioInputDevice(device: MediaDeviceInfo) {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -272,7 +272,8 @@ export default class CallsClient extends EventEmitter {
                 this.ws?.send('reaction', {
                     data: JSON.stringify({
                         name: emojis[count],
-                        skin: count,
+                        skin: '1F3BF',
+                        unified: '14CBD-1F3BF',
                     }),
                 });
 


### PR DESCRIPTION
#### Summary
This PR adds the minimum logic to listen for reaction events sent by the client and broadcast them to the users in the call.

I also added a second commit (sorry for the force-push, I had to fix some typing there :nerd_face:) with an endless loop of emoji reactions sent by every client that joins the call. This will be removed as soon as the emoji picker is in place.

#### Ticket Link
--
