### PR TITLE
Clear reaction timeout as soon as possible

### DIFF
--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -66,6 +66,10 @@ export const voiceUsersStatuses = (state: GlobalState) => {
     return getPluginState(state).voiceUsersStatuses[connectedChannelID(state)] || {};
 };
 
+export const voiceUserStatus = (state: GlobalState, channelID: string, userID: string) => {
+    return getPluginState(state).voiceUsersStatuses[channelID]?.[userID] || {};
+};
+
 export const voiceChannelCallStartAt = (state: GlobalState, channelID: string) => {
     return getPluginState(state).voiceChannelCalls[channelID]?.startAt;
 };

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -121,6 +121,7 @@ export type EmojiData = {
 export type Reaction = {
     emoji: EmojiData;
     timestamp: number;
+    timeoutID?: number;
 }
 
 export type ReactionWithUser = Reaction & {


### PR DESCRIPTION
#### Summary
This is a purely performance-focused PR. No behaviour is modified, it only focuses on clearing old timers so that they don't accumulate in the case of a user reacting like crazy.

#### Ticket Link
--