### PR TITLE
Fix horizontal shift when adding reactions

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -567,7 +567,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                         }
                     </div>
                     { !this.props.screenSharingID &&
-                        <div style={{flex: 1, display: 'flex', flexDirection: 'row'}}>
+                        <div style={{flex: 1, display: 'flex'}}>
                             <ReactionStream
                                 reactions={this.props.reactions}
                                 currentUserID={this.props.currentUserID}

--- a/webapp/src/components/reaction_stream/reaction_stream.tsx
+++ b/webapp/src/components/reaction_stream/reaction_stream.tsx
@@ -18,6 +18,7 @@ type Props = {
 };
 
 const ReactionStreamList = styled.div`
+    position: absolute;
     align-self: flex-end;
     height: 75vh;
     display: flex;


### PR DESCRIPTION
#### Summary

Absolutely position the reaction list inside the parent div so that it does not shift the placement of any other siblings. The `flex-direction` is no longer needed in the parent, so I removed it.

https://user-images.githubusercontent.com/3924815/192263536-f1017d92-a58f-4a66-9ec3-e09aebd1385a.mp4

#### Ticket Link
--