### PR TITLE
 Make consistent order of hands up 

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -527,17 +527,16 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         const currentID = this.props.currentUserID;
         const isSharing = sharingID === currentID;
 
+        const handsup: string[] = [];
+
         // building the list here causes a bug tht if a user leaves and recently reacted it will show as blank
         const profileMap: {[key: string]: UserProfile;} = {};
         this.props.profiles.forEach((profile) => {
             profileMap[profile.id] = profile;
-        });
-        const handsup: string[] = [];
-        for (const [id, member] of Object.entries(this.props.statuses)) {
-            if (member.raised_hand) {
-                handsup.push(id);
+            if (this.props.statuses[profile.id]?.raised_hand) {
+                handsup.push(profile.id);
             }
-        }
+        });
 
         return (
             <div

--- a/webapp/src/components/reaction_stream/reaction_stream.tsx
+++ b/webapp/src/components/reaction_stream/reaction_stream.tsx
@@ -45,7 +45,7 @@ const ReactionChip = styled.div<chipProps>`
     width: fit-content;
 
     ${(props) => props.highlight && `
-        background: #FFBC1F;
+        background: #FFFFFF;
         color: #090A0B;
   `}
 `;


### PR DESCRIPTION
#### Summary

Create the hands up array in the same order as the participants list RHS, so hands up are shown in the order that they were raised. Also changed the background colour to white. 

<img width="1512" alt="Screen Shot 2022-09-30 at 10 57 24 AM" src="https://user-images.githubusercontent.com/112951043/193298717-86d4fe6f-6f07-400d-b6bf-84f9b5f0d92c.png">
