### PR TITLE
[MM-47364] Disable crash on hovering disabled button

### DIFF
--- a/webapp/src/components/call_widget/widget_button.tsx
+++ b/webapp/src/components/call_widget/widget_button.tsx
@@ -26,8 +26,10 @@ export default function WidgetButton(props: Props) {
             key={props.id}
             placement='top'
             overlay={
-                props.disabled ||
-                <Tooltip id={`tooltip-${props.id}`}>
+                <StyledTooltip
+                    id={`tooltip-${props.id}`}
+                    isDisabled={props.disabled}
+                >
                     <div>{props.tooltipText}</div>
                     {props.tooltipSubtext &&
                     <TooltipSubtext>
@@ -37,7 +39,7 @@ export default function WidgetButton(props: Props) {
                     { props.shortcut &&
                     <Shortcut shortcut={props.shortcut}/>
                     }
-                </Tooltip>
+                </StyledTooltip>
             }
         >
             <Button
@@ -73,4 +75,10 @@ const Button = styled.button<{bgColor: string, isDisabled?: boolean, isUnavailab
 
 const TooltipSubtext = styled.div`
   opacity: 0.56;
+`;
+
+const StyledTooltip = styled(Tooltip)<{isDisabled?: boolean}>`
+  ${({isDisabled}) => isDisabled && css`
+      display: none;
+  `}
 `;

--- a/webapp/src/components/call_widget/widget_button.tsx
+++ b/webapp/src/components/call_widget/widget_button.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {OverlayTrigger} from 'react-bootstrap';
 import styled, {css} from 'styled-components';
 
 import CompassIcon from 'src/components/icons/compassIcon';
 import Shortcut from 'src/components/shortcut';
+import {StyledTooltip} from 'src/components/shared';
 
 import UnavailableIconWrapper from './unavailable_icon_wrapper';
 
@@ -28,7 +29,7 @@ export default function WidgetButton(props: Props) {
             overlay={
                 <StyledTooltip
                     id={`tooltip-${props.id}`}
-                    isDisabled={props.disabled}
+                    $isDisabled={props.disabled}
                 >
                     <div>{props.tooltipText}</div>
                     {props.tooltipSubtext &&
@@ -75,10 +76,4 @@ const Button = styled.button<{bgColor: string, isDisabled?: boolean, isUnavailab
 
 const TooltipSubtext = styled.div`
   opacity: 0.56;
-`;
-
-const StyledTooltip = styled(Tooltip)<{isDisabled?: boolean}>`
-  ${({isDisabled}) => isDisabled && css`
-      display: none;
-  `}
 `;

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -684,6 +684,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                                     />
                                 }
                                 unavailable={noScreenPermissions}
+                                disabled={sharingID !== '' && !isSharing}
                             />
 
                             <ControlsButton

--- a/webapp/src/components/expanded_view/controls_button.tsx
+++ b/webapp/src/components/expanded_view/controls_button.tsx
@@ -26,8 +26,10 @@ export default function ControlsButton(props: Props) {
             key={props.id}
             placement='top'
             overlay={
-                props.disabled ||
-                <Tooltip id={`tooltip-${props.id}`}>
+                <StyledTooltip
+                    id={`tooltip-${props.id}`}
+                    isDisabled={props.disabled}
+                >
                     <div>{props.tooltipText}</div>
                     {props.tooltipSubtext &&
                     <TooltipSubtext>
@@ -37,7 +39,7 @@ export default function ControlsButton(props: Props) {
                     { props.shortcut &&
                     <Shortcut shortcut={props.shortcut}/>
                     }
-                </Tooltip>
+                </StyledTooltip>
             }
         >
             <ButtonContainer
@@ -124,4 +126,10 @@ const UnavailableIcon = styled.div`
 
 const TooltipSubtext = styled.div`
   opacity: 0.56;
+`;
+
+const StyledTooltip = styled(Tooltip)<{isDisabled?: boolean}>`
+  ${({isDisabled}) => isDisabled && css`
+      display: none;
+  `}
 `;

--- a/webapp/src/components/expanded_view/controls_button.tsx
+++ b/webapp/src/components/expanded_view/controls_button.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {OverlayTrigger} from 'react-bootstrap';
 import styled, {css} from 'styled-components';
 
 import CompassIcon from 'src/components/icons/compassIcon';
 import Shortcut from 'src/components/shortcut';
+import {StyledTooltip} from 'src/components/shared';
 
 export type Props = {
     id: string,
@@ -28,7 +29,7 @@ export default function ControlsButton(props: Props) {
             overlay={
                 <StyledTooltip
                     id={`tooltip-${props.id}`}
-                    isDisabled={props.disabled}
+                    $isDisabled={props.disabled}
                 >
                     <div>{props.tooltipText}</div>
                     {props.tooltipSubtext &&
@@ -126,10 +127,4 @@ const UnavailableIcon = styled.div`
 
 const TooltipSubtext = styled.div`
   opacity: 0.56;
-`;
-
-const StyledTooltip = styled(Tooltip)<{isDisabled?: boolean}>`
-  ${({isDisabled}) => isDisabled && css`
-      display: none;
-  `}
 `;

--- a/webapp/src/components/shared.tsx
+++ b/webapp/src/components/shared.tsx
@@ -1,4 +1,5 @@
-import styled from 'styled-components';
+import {Tooltip} from 'react-bootstrap';
+import styled, {css} from 'styled-components';
 
 export const Header = styled.div`
     font-weight: 600;
@@ -16,4 +17,10 @@ export const HorizontalSpacer = styled.div<{ size: number }>`
 
 export const VerticalSpacer = styled.div<{ size: number }>`
     margin-top: ${(props) => props.size}px;
+`;
+
+export const StyledTooltip = styled(Tooltip)<{$isDisabled?: boolean}>`
+  ${({$isDisabled}) => $isDisabled && css`
+      display: none;
+  `}
 `;


### PR DESCRIPTION
#### Summary

There doesn't seem to be a clean way to prevent the `OverlayTrigger` from rendering so I am using css to avoid doing some weird code duplication or more complex stuff (wrapping the element).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-47364
