### PR TITLE
Qol no experimental

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -242,6 +242,8 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                     skinTonePosition='search'
                     onEmojiSelect={this.handleUserPicksEmoji}
                     onClickOutside={this.toggleEmojiPicker}
+                    autoFocus={true}
+                    perLine={12}
                 />
             </div>
         ) : null;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -319,7 +319,7 @@ export default class Plugin {
                         reaction,
                     },
                 });
-            }, 5000); // TODO: This time was randomly chosen; see if it should be configurable or at least a little better informed
+            }, 10000); // TODO: This time was randomly chosen; see if it should be configurable or at least a little better informed
         });
     }
 


### PR DESCRIPTION
#### Summary
- increased timer for reaction disappearance to 10 secs
- emoji picker focus on search bar on opening
- emojis per line 9 -> 12

no longer requiring `/calls experimental on` as in https://github.com/mattermost/mattermost-plugin-calls/pull/214
