### PR TITLE
Fix participant screen overflow

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -569,7 +569,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                         }
                     </div>
                     { !this.props.screenSharingID &&
-                        <div style={{flex: 1, display: 'flex'}}>
+                        <div style={{flex: 1, display: 'flex', overflow: 'auto'}}>
                             <ReactionStream/>
                             <ul
                                 id='calls-expanded-view-participants-grid'


### PR DESCRIPTION
#### Summary
Controls were disappearing when there are many users on a call
##### Screenshots
Before
----
https://community.mattermost.com/core/pl/gsm1s4ubc38m5py4q3zf4pw5py

After
----
<img width="1792" alt="Screenshot 2022-10-14 at 16 29 17" src="https://user-images.githubusercontent.com/28563179/195859691-9cb419be-0cbe-41e7-a851-e5edfa88dee1.png">


