### PR TITLE
Bump `rtcd` dependency to v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 require (
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.0.27
-	github.com/mattermost/rtcd v0.6.10
+	github.com/mattermost/rtcd v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.2+incompatible
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.sum
+++ b/go.sum
@@ -977,8 +977,8 @@ github.com/mattermost/mattermost-server/v6 v6.6.0 h1:47XbXSJu9fdbhZWG5bQ5dj3ySrI
 github.com/mattermost/mattermost-server/v6 v6.6.0/go.mod h1:oR6UCRo+SEvnfN2FEOdzHs1UljrskyCKU8tWeKlxgMo=
 github.com/mattermost/morph v0.0.0-20220401091636-39f834798da8/go.mod h1:jxM3g1bx+k2Thz7jofcHguBS8TZn5Pc+o5MGmORObhw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
-github.com/mattermost/rtcd v0.6.10 h1:C4L6m7oFz+4ugUmr9aSID0wYczzV4dmCdJxnWyziPtQ=
-github.com/mattermost/rtcd v0.6.10/go.mod h1:cwe9aU2yJTXW5L9zKhm/B+rM4VlR9Bqvj8khrn191+M=
+github.com/mattermost/rtcd v0.7.0 h1:5K5u8wYrkFzOAbY3lOlrDQdlnTXcZ9dp2Crp2xKRhro=
+github.com/mattermost/rtcd v0.7.0/go.mod h1:Qh9B0B0hZfwhFsGbtfDGX+mh+/pixCONHtcOk3Ky3xw=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -1908,7 +1908,6 @@ golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/webapp/src/rtc_stats.ts
+++ b/webapp/src/rtc_stats.ts
@@ -17,23 +17,29 @@ export function parseRTCStats(reports: RTCStatsReport): RTCStats {
         switch (report.type) {
         case 'inbound-rtp':
             stats[report.ssrc].local.in = {
+                mid: report.mid,
                 kind: report.kind,
+                trackIdentifier: report.trackIdentifier,
                 packetsReceived: report.packetsReceived,
-                bytesReceived: report.bytesReceived,
                 packetsLost: report.packetsLost,
                 packetsDiscarded: report.packetsDiscarded,
+                bytesReceived: report.bytesReceived,
+                nackCount: report.nackCount,
+                pliCount: report.pliCount,
                 jitter: report.jitter,
                 jitterBufferDelay: report.jitterBufferDelay,
             };
             break;
         case 'outbound-rtp':
             stats[report.ssrc].local.out = {
+                mid: report.mid,
                 kind: report.kind,
                 packetsSent: report.packetsSent,
                 bytesSent: report.bytesSent,
                 retransmittedPacketsSent: report.retransmittedPacketsSent,
                 retransmittedBytesSent: report.retransmittedBytesSent,
                 nackCount: report.nackCount,
+                pliCount: report.pliCount,
                 targetBitrate: report.targetBitrate,
             };
             break;

--- a/webapp/src/rtc_stats.ts
+++ b/webapp/src/rtc_stats.ts
@@ -17,6 +17,8 @@ export function parseRTCStats(reports: RTCStatsReport): RTCStats {
         switch (report.type) {
         case 'inbound-rtp':
             stats[report.ssrc].local.in = {
+
+                // @ts-ignore: mid is missing current version, we need bump some dependencies to fix this.
                 mid: report.mid,
                 kind: report.kind,
                 trackIdentifier: report.trackIdentifier,
@@ -32,6 +34,8 @@ export function parseRTCStats(reports: RTCStatsReport): RTCStats {
             break;
         case 'outbound-rtp':
             stats[report.ssrc].local.out = {
+
+                // @ts-ignore: mid is missing in current version, we need bump some dependencies to fix this.
                 mid: report.mid,
                 kind: report.kind,
                 packetsSent: report.packetsSent,


### PR DESCRIPTION
#### Summary

Forgot to do this as part of https://github.com/mattermost/mattermost-plugin-calls/pull/231. While I was testing locally I also added a couple of useful stats to the report.