### PR TITLE
[MM-48142] Fix remaining call state issues on parent window

### DIFF
--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -34,3 +34,5 @@ export const RECEIVED_CALLS_USER_PREFERENCES = pluginId + '_received_calls_user_
 
 export const RECEIVED_CLIENT_ERROR = pluginId + '_received_client_error';
 
+export const DESKTOP_WIDGET_CONNECTED = pluginId + '_desktop_widget_connected';
+

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -363,6 +363,12 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         });
 
         window.callsClient.on('connect', () => {
+            if (this.props.global) {
+                sendDesktopEvent('calls-joined-call', {
+                    callID: window.callsClient?.channelID,
+                });
+            }
+
             if (isDirectChannel(this.props.channel) || isGroupChannel(this.props.channel)) {
                 // FIXME (MM-46048) - HACK
                 // There's a race condition between unmuting and receiving existing tracks from other participants.

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -13,6 +13,11 @@ import LeaveCallIcon from 'src/components/icons/leave_call_icon';
 import ConnectedProfiles from 'src/components/connected_profiles';
 import {Header, SubHeader} from 'src/components/shared';
 
+import {
+    shouldRenderDesktopWidget,
+    sendDesktopEvent,
+} from 'src/utils';
+
 interface Props {
     post: Post,
     connectedID: string,
@@ -43,6 +48,8 @@ const PostType = ({
     const onLeaveButtonClick = () => {
         if (window.callsClient) {
             window.callsClient.disconnect();
+        } else if (shouldRenderDesktopWidget()) {
+            sendDesktopEvent('calls-leave-call', {callID: post.channel_id});
         }
     };
 

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -41,6 +41,7 @@ import {
     RECEIVED_CHANNEL_STATE,
     RECEIVED_CALLS_USER_PREFERENCES,
     RECEIVED_CLIENT_ERROR,
+    DESKTOP_WIDGET_CONNECTED,
 } from './action_types';
 
 interface channelState {
@@ -178,6 +179,8 @@ const connectedChannelID = (state: string | null = null, action: { type: string,
     switch (action.type) {
     case VOICE_CHANNEL_UNINIT:
         return null;
+    case DESKTOP_WIDGET_CONNECTED:
+        return action.data.channelID;
     case VOICE_CHANNEL_USER_CONNECTED: {
         const callsClient = window.callsClient || window.opener?.callsClient;
         if (action.data.currentUserID === action.data.userID && callsClient?.channelID === action.data.channelID) {


### PR DESCRIPTION
#### Summary

PR fixes a couple of state related issues in the main window when using the global widget, namely:

- Channel toast should not show after joining the call.
- Leave button should render in the post card.
- Leaving the call from the post card should be allowed, as well as through slash command.
- Switching calls from the post card should work as in web.

#### Related PR

https://github.com/mattermost/desktop/pull/2349

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48142