### PR TITLE
[MM-48746] Implement basic error surfacing

### DIFF
--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -67,9 +67,10 @@ type CallStateClient struct {
 }
 
 type RecordingStateClient struct {
-	InitAt  int64 `json:"init_at"`
-	StartAt int64 `json:"start_at"`
-	EndAt   int64 `json:"end_at"`
+	InitAt  int64  `json:"init_at"`
+	StartAt int64  `json:"start_at"`
+	EndAt   int64  `json:"end_at"`
+	Err     string `json:"err,omitempty"`
 }
 
 type ChannelStateClient struct {
@@ -86,6 +87,7 @@ func (rs *RecordingStateClient) toMap() map[string]interface{} {
 		"init_at":  rs.InitAt,
 		"start_at": rs.StartAt,
 		"end_at":   rs.EndAt,
+		"err":      rs.Err,
 	}
 }
 
@@ -124,6 +126,19 @@ func (cs *callState) Clone() *callState {
 	}
 
 	return &newState
+}
+
+func (cs *channelState) getRecording() (*recordingState, error) {
+	if cs == nil {
+		return nil, fmt.Errorf("channel state is missing from store")
+	}
+	if cs.Call == nil {
+		return nil, fmt.Errorf("no call ongoing")
+	}
+	if cs.Call.Recording == nil {
+		return nil, fmt.Errorf("no recording ongoing")
+	}
+	return cs.Call.Recording, nil
 }
 
 func (cs *channelState) Clone() *channelState {

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -520,8 +520,8 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
 
         let error = '';
         if (this.props.callRecording?.err) {
-            header = 'Something went wrong with the recording!';
-            body = 'Please try to record again. If the error persists please ask your system administrator.';
+            header = 'Something went wrong with the recording';
+            body = 'Please try to record again. You can also contact your system admin for troubleshooting help.';
             error = capitalize(this.props.callRecording?.err);
 
             icon = (

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -518,9 +518,12 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             body = 'You can find the recording in this call\'s chat thread once it\'s finished processing.';
         }
 
+        let error = '';
         if (this.props.callRecording?.err) {
             header = 'Something went wrong with the recording!';
-            body = `${capitalize(this.props.callRecording?.err)}. Please try to record again. If the problem persists, reach out to a system admin.`;
+            body = 'Please try to record again. If the error persists please ask your system administrator.';
+            error = capitalize(this.props.callRecording?.err);
+
             icon = (
                 <CompassIcon
                     icon='alert-outline'
@@ -538,6 +541,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                 iconColor='rgb(var(--dnd-indicator-rgb))'
                 header={header}
                 body={body}
+                error={error}
                 confirmText={confirmText}
                 onClose={() => this.setState({promptDismissedAt: Date.now()})}
             />

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -25,6 +25,7 @@ import {
     hasExperimentalFlag,
     sendDesktopEvent,
     shouldRenderDesktopWidget,
+    capitalize,
 } from 'src/utils';
 import {applyOnyx} from 'src/css_utils';
 import {
@@ -480,8 +481,9 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         const isHost = this.props.callHostID === this.props.currentUserID;
         const hasRecEnded = this.props.callRecording?.end_at;
 
-        // Nothing to show if the recording hasn't started yet.
-        if (!this.props.callRecording?.start_at) {
+        // Nothing to show if the recording hasn't started yet, unless there
+        // was an error.
+        if (!this.props.callRecording?.start_at && !this.props.callRecording?.err) {
             return null;
         }
 
@@ -506,18 +508,32 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         let header = CallRecordingDisclaimerStrings[isHost ? 'host' : 'participant'].header;
         let body = CallRecordingDisclaimerStrings[isHost ? 'host' : 'participant'].body;
         const confirmText = isHost ? 'Dismiss' : 'Understood';
+        let icon = (
+            <RecordCircleOutlineIcon
+                size={18}
+            />);
 
         if (hasRecEnded) {
             header = 'Recording has stopped. Processing...';
             body = 'You can find the recording in this call\'s chat thread once it\'s finished processing.';
         }
 
+        if (this.props.callRecording?.err) {
+            header = 'Something went wrong with the recording!';
+            body = `${capitalize(this.props.callRecording?.err)}. Please try to record again. If the problem persists, reach out to a system admin.`;
+            icon = (
+                <CompassIcon
+                    icon='alert-outline'
+                    style={{
+                        fontSize: 18,
+                    }}
+                />
+            );
+        }
+
         return (
             <InCallPrompt
-                icon={(
-                    <RecordCircleOutlineIcon
-                        size={18}
-                    />)}
+                icon={icon}
                 iconFill='rgb(var(--dnd-indicator-rgb))'
                 iconColor='rgb(var(--dnd-indicator-rgb))'
                 header={header}
@@ -743,6 +759,10 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             return null;
         }
 
+        if (this.props.callRecording?.err) {
+            return null;
+        }
+
         return (
             <Badge
                 text={'REC'}
@@ -808,7 +828,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         const isChatUnread = Boolean(this.props.threadUnreadReplies);
 
         const isHost = this.props.callHostID === this.props.currentUserID;
-        const isRecording = isHost && this.props.callRecording && this.props.callRecording.init_at > 0 && !this.props.callRecording.end_at;
+        const isRecording = isHost && this.props.callRecording && this.props.callRecording.init_at > 0 && !this.props.callRecording.end_at && !this.props.callRecording.err;
         const recordTooltipText = isRecording ? 'Stop recording' : 'Record call';
         const RecordIcon = isRecording ? RecordSquareOutlineIcon : RecordCircleOutlineIcon;
 

--- a/webapp/src/components/expanded_view/in_call_prompt.tsx
+++ b/webapp/src/components/expanded_view/in_call_prompt.tsx
@@ -8,6 +8,7 @@ export type Props = {
     iconFill?: string,
     iconColor?: string,
     body: string,
+    error?: string,
     header: string,
     confirmText?: string,
     onClose?: () => void,
@@ -35,6 +36,9 @@ export default function InCallPrompt(props: Props) {
                 </Header>
                 <Body>
                     {props.body}
+                    { props.error &&
+                    <ErrorMsg>{props.error}</ErrorMsg>
+                    }
                 </Body>
                 <Footer>
                     { props.confirmText && props.onClose &&
@@ -87,6 +91,8 @@ const Header = styled.div`
 const Body = styled.div`
   margin-top: 8px;
   margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
 `;
 
 const Footer = styled.div`
@@ -115,4 +121,8 @@ const CloseButton = styled(Icon)`
   :hover {
     background: rgba(var(--center-channel-color-rgb), 0.08);
   }
+`;
+
+const ErrorMsg = styled.i`
+  color: rgba(var(--center-channel-color-rgb), 0.72);
 `;

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -172,5 +172,6 @@ export type CallRecordingState = {
     init_at: number,
     start_at: number,
     end_at: number,
+    err?: string,
 }
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -367,3 +367,7 @@ export function sendDesktopEvent(event: string, data?: any) {
         win.location.origin,
     );
 }
+
+export function capitalize(input: string) {
+    return input.charAt(0).toUpperCase() + input.slice(1);
+}


### PR DESCRIPTION
#### Summary

PR adds some basic error handling to cover for the following failure cases:

1. Recording fails to start immediately (e.g. job service returns an error).
2. Recording job times out (e.g. recording bot fails to join the call).
3. Recording fails to stop.

@tanmay-des I opted to actually relay the server side error to the client in the hope it will give them more information but I also acknowledge it's not really actionable on their part as they likely need a system/infrastructure admin to intervene. Please let me know if you'd like it reverted to the generic "something has failed".

/cc @itao 

#### Screenshots

![image](https://user-images.githubusercontent.com/1832946/204907437-3bde5b03-58aa-46ea-853f-8f01b95afa3b.png)

![image](https://user-images.githubusercontent.com/1832946/204907465-47c4c522-e085-4477-bcf1-dd51bb80b28c.png)


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48746
