### PR TITLE
Fix potential edge case

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -128,8 +128,14 @@ func (p *Plugin) addUserSession(userID, connID string, channel *model.Channel) (
 		}
 
 		// When the bot joins the call it means the recording has started.
-		if state.Call.Recording != nil && userID == botID {
-			state.Call.Recording.StartAt = time.Now().UnixMilli()
+		if userID == botID {
+			if state.Call.Recording != nil && state.Call.Recording.StartAt == 0 {
+				state.Call.Recording.StartAt = time.Now().UnixMilli()
+			} else if state.Call.Recording == nil || state.Call.Recording.StartAt > 0 {
+				// In this case we should fail to prevent the bot from recording
+				// without consent.
+				return nil, fmt.Errorf("recording not in progress or already started")
+			}
 		}
 
 		if state.Call.HostID == "" && userID != botID {


### PR DESCRIPTION
#### Summary

Fixing a potential edge case where in case of a timeout (or other unexpected error) while making the start job request, the recording job process could still run and the bot start recording without anyone noticing. So we add an explicit check to make sure the bot is only allowed in if a recording has been requested but not started yet.
