### PR TITLE
[MM-48928] Outstanding UX for recordings

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -82,6 +82,7 @@ interface Props {
     },
     callStartAt: number,
     callHostID: string,
+    callHostChangeAt: number,
     callRecording?: CallRecordingState,
     screenSharingID: string,
     show: boolean,
@@ -1190,13 +1191,13 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         // This component should render if all of the following conditions apply:
         // - Recording has started.
         // - Recording has not ended.
-        // - Diclaimer has not been dismissed already.
+        // - Diclaimer has not been dismissed after either call start or last host change.
 
         if (!this.props.callRecording?.start_at || this.props.callRecording?.end_at) {
             return null;
         }
 
-        if (this.state.recDisclaimerDismissedAt > this.props.callRecording?.start_at) {
+        if (this.state.recDisclaimerDismissedAt > this.props.callRecording?.start_at && this.state.recDisclaimerDismissedAt > this.props.callHostChangeAt) {
             return null;
         }
 

--- a/webapp/src/components/call_widget/index.ts
+++ b/webapp/src/components/call_widget/index.ts
@@ -25,6 +25,7 @@ import {
     voiceConnectedProfiles,
     voiceChannelCallHostID,
     callRecording,
+    voiceChannelCallHostChangeAt,
 } from 'src/selectors';
 
 import {alphaSortProfiles, stateSortProfiles} from 'src/utils';
@@ -68,6 +69,7 @@ const mapStateToProps = (state: GlobalState) => {
         statuses: voiceUsersStatuses(state) || {},
         callStartAt: voiceChannelCallStartAt(state, channel?.id) || 0,
         callHostID: voiceChannelCallHostID(state, channel?.id) || '',
+        callHostChangeAt: voiceChannelCallHostChangeAt(state, channel?.id) || 0,
         callRecording: callRecording(state, channel?.id),
         screenSharingID,
         allowScreenSharing: allowScreenSharing(state),

--- a/webapp/src/components/call_widget/widget_banner.tsx
+++ b/webapp/src/components/call_widget/widget_banner.tsx
@@ -131,6 +131,7 @@ const Banner = styled.div<{color: string, bgColor: string, fadeIn: boolean}>`
   align-items: flex-start;
   width: 100%;
   background-color: ${({bgColor}) => bgColor};
+  box-shadow: 0px 8px 24px rgba(var(--center-channel-color-rgb), 0.12);
   padding: 5px 8px;
   border-radius: 4px;
   color: ${({color}) => color};

--- a/webapp/src/components/call_widget/widget_banner.tsx
+++ b/webapp/src/components/call_widget/widget_banner.tsx
@@ -205,7 +205,6 @@ const DeclineButton = styled.button`
 
 const Icon = styled.div<{fill?: string, color?: string}>`
   font-size: 12px;
-  line-height: 12px;
   fill: ${({fill}) => (fill || 'currentColor')};
   color: ${({color}) => (color || 'currentColor')};
   margin-top: 4px;

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -93,6 +93,7 @@ interface Props extends RouteComponentProps {
     },
     callStartAt: number,
     callHostID: string,
+    callHostChangeAt: number,
     callRecording?: CallRecordingState,
     hideExpandedView: () => void,
     showScreenSourceModal: () => void,
@@ -970,6 +971,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
 
                 <RecordingInfoPrompt
                     isHost={this.props.callHostID === this.props.currentUserID}
+                    hostChangeAt={this.props.callHostChangeAt}
                     recording={this.props.callRecording}
                     recordingMaxDuration={this.props.recordingMaxDuration}
                     onDecline={this.onDisconnectClick}

--- a/webapp/src/components/expanded_view/controls_button.tsx
+++ b/webapp/src/components/expanded_view/controls_button.tsx
@@ -94,7 +94,7 @@ const ButtonContainer = styled.div<{ margin?: string }>`
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin: ${({margin}) => margin || '0 16px'};
+    margin: ${({margin}) => margin || '0 8px'};
 `;
 
 const Button = styled.button<{bgColor: string, isDisabled?: boolean, isUnavailable?: boolean, fill?: string}>`

--- a/webapp/src/components/expanded_view/in_call_prompt.tsx
+++ b/webapp/src/components/expanded_view/in_call_prompt.tsx
@@ -79,7 +79,7 @@ const Prompt = styled.div`
   position: absolute;
   bottom: 100px;
   margin: 0 24px;
-  background: rgba(221, 223, 228, 0.08);
+  background: #2D2D2E;
   border: 1px solid rgba(61, 60, 64, 0.16);
   box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12);
   border-radius: 4px;

--- a/webapp/src/components/expanded_view/in_call_prompt.tsx
+++ b/webapp/src/components/expanded_view/in_call_prompt.tsx
@@ -133,7 +133,6 @@ const DeclineButton = styled.button`
 
 const Icon = styled.div<{fill?: string, color?: string}>`
   font-size: 18px;
-  line-height: 18px;
   fill: ${({fill}) => (fill || 'currentColor')};
   color: ${({color}) => (color || 'currentColor')};
 `;

--- a/webapp/src/components/expanded_view/index.ts
+++ b/webapp/src/components/expanded_view/index.ts
@@ -42,6 +42,7 @@ import {
     callRecording,
     recordingsEnabled,
     recordingMaxDuration,
+    voiceChannelCallHostChangeAt,
 } from 'src/selectors';
 
 import ExpandedView from './component';
@@ -85,6 +86,7 @@ const mapStateToProps = (state: GlobalState) => {
         statuses,
         callStartAt: voiceChannelCallStartAt(state, channel?.id) || 0,
         callHostID: voiceChannelCallHostID(state, channel?.id) || '',
+        callHostChangeAt: voiceChannelCallHostChangeAt(state, channel?.id) || 0,
         callRecording: callRecording(state, channel?.id),
         screenSharingID,
         channel,

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -74,7 +74,7 @@ export default function RecordingInfoPrompt(props: Props) {
                 iconFill='rgb(var(--dnd-indicator-rgb))'
                 iconColor='rgb(var(--dnd-indicator-rgb))'
                 header={`Your recording will end in ${getMinutesLeftBeforeEnd()} minutes`}
-                body={`Calls can be recorded for up to ${props.recordingMaxDuration} minutes.`}
+                body={`Calls can only be recorded for up to ${props.recordingMaxDuration} minutes after which the recording will automatically stop.`}
                 confirmText={'Dismiss'}
                 onClose={() => updateDismissedAt(Date.now())}
             />

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -21,6 +21,7 @@ import InCallPrompt from './in_call_prompt';
 
 type Props = {
     isHost: boolean,
+    hostChangeAt: number,
     recording?: CallRecordingState,
     recordingMaxDuration: number,
     onDecline: () => void;
@@ -93,9 +94,9 @@ export default function RecordingInfoPrompt(props: Props) {
         return null;
     }
 
-    // If the prompt was dismissed after the call has started then we
-    // don't show this again.
-    if (!hasRecEnded && dismissedAt > props.recording?.start_at) {
+    // If the prompt was dismissed after the call has started and after the last host change
+    // we don't show this again.
+    if (!hasRecEnded && dismissedAt > props.recording?.start_at && dismissedAt > props.hostChangeAt) {
         return null;
     }
 

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -539,6 +539,7 @@ interface callState {
     startAt?: number,
     ownerID?: string,
     hostID: string,
+    hostChangeAt?: number,
 }
 
 interface callStateAction {
@@ -556,6 +557,7 @@ const voiceChannelCalls = (state: {[channelID: string]: callState} = {}, action:
             [action.data.channelID]: {
                 ...state[action.data.channelID],
                 hostID: action.data.hostID,
+                hostChangeAt: Date.now(),
             },
         };
     case VOICE_CHANNEL_CALL_START:
@@ -566,6 +568,7 @@ const voiceChannelCalls = (state: {[channelID: string]: callState} = {}, action:
                 startAt: action.data.startAt,
                 ownerID: action.data.ownerID,
                 hostID: action.data.hostID,
+                hostChangeAt: action.data.startAt,
             },
         };
     default:

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -109,6 +109,10 @@ export const voiceChannelCallHostID = (state: GlobalState, channelID: string) =>
     return pluginState(state).voiceChannelCalls[channelID]?.hostID;
 };
 
+export const voiceChannelCallHostChangeAt = (state: GlobalState, channelID: string) => {
+    return pluginState(state).voiceChannelCalls[channelID]?.hostChangeAt;
+};
+
 export const voiceChannelScreenSharingID = (state: GlobalState, channelID: string) => {
     return pluginState(state).voiceChannelScreenSharingID[channelID];
 };


### PR DESCRIPTION
#### Summary

PR addresses some outstanding UX feedback (see https://www.figma.com/file/9HL2HADCQ0lLmn1RBOBGGV/Calls%3A-Recording?node-id=298%3A120956&t=0Aq13EORRxvt3YoH-0 for details).

In addition we are at least partially addressing the issue of a user not being aware of becoming the host. We are showing the "you are recording this call" banner again upon host change even if the banner was dismissed prior (as non-host user). Ideally we should consider a custom message for this but we didn't get time to design further so happy to have something rather than nothing.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48928
