### PR TITLE
Fix missing ws events

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -284,7 +284,7 @@ func (p *Plugin) removeSession(us *session) error {
 	// multiple times but we should send out the ws event only once.
 	if prevState.Call != nil && prevState.Call.Users[us.userID] != nil && (currState.Call == nil || currState.Call.Users[us.userID] == nil) {
 		p.LogDebug("session was removed from state", "userID", us.userID, "connID", us.connID, "originalConnID", us.originalConnID)
-		p.API.PublishWebSocketEvent(wsEventUserDisconnected, map[string]interface{}{
+		p.publishWebSocketEvent(wsEventUserDisconnected, map[string]interface{}{
 			"userID": us.userID,
 		}, &model.WebsocketBroadcast{ChannelId: us.channelID, ReliableClusterSend: true})
 	}

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -314,7 +314,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 			p.LogError(err.Error())
 		}
 
-		p.API.PublishWebSocketEvent(evType, map[string]interface{}{
+		p.publishWebSocketEvent(evType, map[string]interface{}{
 			"user_id":   us.userID,
 			"emoji":     emoji.toMap(),
 			"timestamp": time.Now().UnixMilli(),


### PR DESCRIPTION
#### Summary

Almost randomly spotted this while testing recordings. Users were leaving calls but it was not reflected in the recording view and in the output file as a result. 

We need to make extra sure to always use the provided `publishWebSocketEvent` wrapping method so that the call bot receives the ws events.

