### PR TITLE
Fix nil dereference crash

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -48,6 +48,9 @@ func (p *Plugin) publishWebSocketEvent(ev string, data map[string]interface{}, b
 	// If broadcasting to a channel we need to also send to the bot since they
 	// won't be in the channel.
 	if botID != "" && broadcast != nil && broadcast.ChannelId != "" {
+		if data == nil {
+			data = map[string]interface{}{}
+		}
 		data["channelID"] = broadcast.ChannelId
 		p.metrics.IncWebSocketEvent("out", ev)
 		p.API.PublishWebSocketEvent(ev, data, &model.WebsocketBroadcast{


### PR DESCRIPTION
#### Summary

PR fixes a crash if the WS data passed was nil, such as in:

https://github.com/mattermost/mattermost-plugin-calls/blob/c28001e91b83d69ecd34c6651c373f9d6921082d/server/api.go#L356

I suppose we could add a smarter check since it's unlikely the bot will need some of these events but for now let's keep it simple.
