### PR TITLE
Fix trailing slash in services URLs

### DIFF
--- a/server/job_service.go
+++ b/server/job_service.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mattermost/mattermost-plugin-api/cluster"
 
@@ -46,7 +47,8 @@ func (p *Plugin) getJobServiceClientConfig(serviceURL string) (offloader.ClientC
 	// Give precedence to environment to override everything else.
 	cfg.ClientID = os.Getenv("MM_CALLS_JOB_SERVICE_CLIENT_ID")
 	cfg.AuthKey = os.Getenv("MM_CALLS_JOB_SERVICE_AUTH_KEY")
-	cfg.URL = os.Getenv("MM_CALLS_JOB_SERVICE_URL")
+	cfg.URL = strings.TrimSuffix(os.Getenv("MM_CALLS_JOB_SERVICE_URL"), "/")
+
 	if cfg.URL == "" {
 		cfg.URL = serviceURL
 	}
@@ -153,6 +155,9 @@ func (p *Plugin) newJobService(serviceURL string) (*jobService, error) {
 	if serviceURL == "" {
 		return nil, fmt.Errorf("serviceURL should not be empty")
 	}
+
+	// Remove trailing slash if present.
+	serviceURL = strings.TrimSuffix(serviceURL, "/")
 
 	cfg, err := p.getJobServiceClientConfig(serviceURL)
 	if err != nil {

--- a/server/rtcd.go
+++ b/server/rtcd.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -299,6 +300,9 @@ func resolveURL(u string, timeout time.Duration) ([]net.IP, string, error) {
 }
 
 func (m *rtcdClientManager) newRTCDClient(rtcdURL, host string, dialFn rtcd.DialContextFn) (*rtcd.Client, error) {
+	// Remove trailing slash if present.
+	rtcdURL = strings.TrimSuffix(rtcdURL, "/")
+
 	clientCfg, err := m.getRTCDClientConfig(rtcdURL, dialFn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rtcd client config: %w", err)


### PR DESCRIPTION
#### Summary

PR fixes an issue causing the plugin to fail to start if the provided URL (either `rtcd` or `calls-offloader`) has a trailing slash.

Thanks @oh6hay for spotting this :100: 