### PR TITLE
[MM-46048] Implement glare-free negotiation

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -381,14 +381,9 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             }
 
             if (isDirectChannel(this.props.channel) || isGroupChannel(this.props.channel)) {
-                // FIXME (MM-46048) - HACK
-                // There's a race condition between unmuting and receiving existing tracks from other participants.
-                // Fixing this properly requires extensive and potentially breaking changes.
-                // Waiting for a second before unmuting is a decent workaround that should work in most cases.
-                setTimeout(() => {
-                    window.callsClient?.unmute();
-                }, 1000);
+                window.callsClient?.unmute();
             }
+
             this.setState({currentAudioInputDevice: window.callsClient.currentAudioInputDevice});
             this.setState({currentAudioOutputDevice: window.callsClient.currentAudioOutputDevice});
         });


### PR DESCRIPTION
#### Summary

PR implements glare-free negotiation using the proposed scheme in https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation (polite peer case).

In practical terms this avoids a whole set of issues involving clients receiving tracks while trying to send theirs. The most glaring example we have in product would be joining calls unmuted, which led to the unfortunate "sleep a few seconds" hack.

I've load tested a bit to cover a few scenarios and it seems like working as expected. I am still not entirely sure whether this covers all potential racing issues with signaling but it definitely improves the most common ones.

#### Related PRs

https://github.com/mattermost/rtcd/pull/80

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46048

