### PR TITLE
MM-47358 - Fix: Cancelling screen sharing results in "system preferences" client side error

### DIFF
--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -24,7 +24,7 @@ export const CallAlertConfigs: {[key: string]: CallAlertConfig} = {
     missingScreenPermissions: {
         type: CallAlertType.Error,
         icon: 'monitor',
-        bannerText: 'Allow screen recording access to Mattermost in your system preferences.',
+        bannerText: 'Screen recording access is not currently allowed or was cancelled.',
         tooltipText: 'No screen sharing permissions',
         tooltipSubtext: 'Allow screen recording access to Mattermost.',
     },


### PR DESCRIPTION
#### Summary
- Change the error message so it's not so frightening if they just pressed 'cancel'

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-47358

