### PR TITLE
[MM-49022] Implement minimum supported version compatibility check for `rtcd`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mattermost/calls-offloader v0.1.0
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.1.1
-	github.com/mattermost/rtcd v0.7.1-0.20221220234917-bbe400d74d73
+	github.com/mattermost/rtcd v0.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/vmihailenco/msgpack/v5 v5.3.5

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,11 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/mattermost/calls-offloader v0.1.0
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.1.1
-	github.com/mattermost/rtcd v0.7.1-0.20221124183223-25eed58b22d2
+	github.com/mattermost/rtcd v0.7.1-0.20221220234917-bbe400d74d73
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/vmihailenco/msgpack/v5 v5.3.5

--- a/go.sum
+++ b/go.sum
@@ -564,8 +564,8 @@ github.com/mattermost/mattermost-plugin-api v0.1.1 h1:bNnPbWCLWZpT/k2kjUxNnzCfUg
 github.com/mattermost/mattermost-plugin-api v0.1.1/go.mod h1:9yZhtg0bBj3kqSTjXnjYBMZoTsWbe3ajdFMdl9/Jz34=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221122212622-0509e78744bf h1:a61ZNxW8zYZjNSbH4Y3agqkWcw7AAo7XxXU4i722Ozs=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221122212622-0509e78744bf/go.mod h1:B9ntfVMlYp1gsCnEKRuM4nMN02l2LQG0+JEPJoSA3mk=
-github.com/mattermost/rtcd v0.7.1-0.20221220234917-bbe400d74d73 h1:M6EFVg+lJxwjLnh1YMPwVPYfHfo1w7qRzC7oMXjOM/c=
-github.com/mattermost/rtcd v0.7.1-0.20221220234917-bbe400d74d73/go.mod h1:obJtR9gnk6jOk6GC1YyOuq7z1DIaIrvwkyPGvYta0tE=
+github.com/mattermost/rtcd v0.8.0 h1:aFacLwfuLhyxGFZrL12uhm1DBrGaa1Ytj8ynKMXdY0k=
+github.com/mattermost/rtcd v0.8.0/go.mod h1:obJtR9gnk6jOk6GC1YyOuq7z1DIaIrvwkyPGvYta0tE=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -562,8 +564,8 @@ github.com/mattermost/mattermost-plugin-api v0.1.1 h1:bNnPbWCLWZpT/k2kjUxNnzCfUg
 github.com/mattermost/mattermost-plugin-api v0.1.1/go.mod h1:9yZhtg0bBj3kqSTjXnjYBMZoTsWbe3ajdFMdl9/Jz34=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221122212622-0509e78744bf h1:a61ZNxW8zYZjNSbH4Y3agqkWcw7AAo7XxXU4i722Ozs=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221122212622-0509e78744bf/go.mod h1:B9ntfVMlYp1gsCnEKRuM4nMN02l2LQG0+JEPJoSA3mk=
-github.com/mattermost/rtcd v0.7.1-0.20221124183223-25eed58b22d2 h1:D+W/TvZVR9TrpMfKpRVOEtKjA2cEmJqncQMrBPhC7rg=
-github.com/mattermost/rtcd v0.7.1-0.20221124183223-25eed58b22d2/go.mod h1:obJtR9gnk6jOk6GC1YyOuq7z1DIaIrvwkyPGvYta0tE=
+github.com/mattermost/rtcd v0.7.1-0.20221220234917-bbe400d74d73 h1:M6EFVg+lJxwjLnh1YMPwVPYfHfo1w7qRzC7oMXjOM/c=
+github.com/mattermost/rtcd v0.7.1-0.20221220234917-bbe400d74d73/go.mod h1:obJtR9gnk6jOk6GC1YyOuq7z1DIaIrvwkyPGvYta0tE=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/plugin.json
+++ b/plugin.json
@@ -115,5 +115,8 @@
                 "help_text": "The maximum duration (in minutes) for call recordings. Value must be in the range [15, 180]."
             }
         ]
+    },
+    "props": {
+        "min_rtcd_version": "v0.8.0"
     }
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/semver"
 )
 
 const (
@@ -131,4 +133,22 @@ func isMobilePostGA(r *http.Request) (mobile, postGA bool) {
 		return true, false
 	}
 	return true, minor >= 441
+}
+
+func checkMinVersion(minVersion, currVersion string) error {
+	minV, err := semver.NewVersion(minVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse minVersion: %w", err)
+	}
+
+	currV, err := semver.NewVersion(currVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse currVersion: %w", err)
+	}
+
+	if cmp := currV.Compare(minV); cmp < 0 {
+		return fmt.Errorf("current version (%s) is lower than minimum supported version (%s)", currVersion, minVersion)
+	}
+
+	return nil
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_isMobilePostGA(t *testing.T) {
@@ -54,6 +55,86 @@ func Test_isMobilePostGA(t *testing.T) {
 			gotMobile, gotPostGA := isMobilePostGA(r)
 			assert.Equal(t, tt.wantMobile, gotMobile)
 			assert.Equal(t, tt.wantPostGA, gotPostGA)
+		})
+	}
+}
+
+func TestCheckMinVersion(t *testing.T) {
+	tcs := []struct {
+		name        string
+		minVersion  string
+		currVersion string
+		err         string
+	}{
+		{
+			name:        "empty minVersion",
+			minVersion:  "",
+			currVersion: "",
+			err:         "failed to parse minVersion: Invalid Semantic Version",
+		},
+		{
+			name:        "empty currVersion",
+			minVersion:  "0.1.0",
+			currVersion: "",
+			err:         "failed to parse currVersion: Invalid Semantic Version",
+		},
+		{
+			name:        "invalid minVersion",
+			minVersion:  "not.a.version",
+			currVersion: "not.a.version",
+			err:         "failed to parse minVersion: Invalid Semantic Version",
+		},
+		{
+			name:        "invalid currVersion",
+			minVersion:  "0.1.0",
+			currVersion: "not.a.version",
+			err:         "failed to parse currVersion: Invalid Semantic Version",
+		},
+		{
+			name:        "not supported, minor",
+			minVersion:  "0.2.0",
+			currVersion: "0.1.0",
+			err:         "current version (0.1.0) is lower than minimum supported version (0.2.0)",
+		},
+		{
+			name:        "not supported, patch",
+			minVersion:  "0.2.1",
+			currVersion: "0.2.0",
+			err:         "current version (0.2.0) is lower than minimum supported version (0.2.1)",
+		},
+		{
+			name:        "supported, equal",
+			minVersion:  "0.2.1",
+			currVersion: "0.2.1",
+			err:         "",
+		},
+		{
+			name:        "supported, greater",
+			minVersion:  "0.2.1",
+			currVersion: "0.2.2",
+			err:         "",
+		},
+		{
+			name:        "supported, minVersion prefix",
+			minVersion:  "v0.2.1",
+			currVersion: "0.2.2",
+			err:         "",
+		},
+		{
+			name:        "supported, currVersion prefix",
+			minVersion:  "0.2.1",
+			currVersion: "v0.2.2",
+			err:         "",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkMinVersion(tc.minVersion, tc.currVersion)
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### Summary

PR implements a minimum supported version compatibility check for `rtcd` that will prevent the plugin from starting if the configured (in manifest) minimum version is not respected. Such error will be surfaced to the admin through the admin console (see screenshot).

#### Screenshot

![image](https://user-images.githubusercontent.com/1832946/208787221-d180d4eb-7ace-4d98-86e0-dff939f5336e.png)

#### Related PR

https://github.com/mattermost/rtcd/pull/84

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49022

