### PR TITLE
[MM-48900] Display available recording files in call thread root post

### DIFF
--- a/server/bot_api.go
+++ b/server/bot_api.go
@@ -196,9 +196,10 @@ func (p *Plugin) handleBotPostRecordings(w http.ResponseWriter, r *http.Request,
 		res.Code = http.StatusInternalServerError
 		return
 	}
-	recordings, ok := post.GetProp("recording_files").([]string)
+
+	recordings, ok := post.GetProp("recording_files").([]interface{})
 	if !ok {
-		recordings = []string{
+		recordings = []interface{}{
 			fileID,
 		}
 	} else {

--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -12,6 +12,7 @@ type recordingState struct {
 	ID        string `json:"id"`
 	CreatorID string `json:"creator_id"`
 	JobID     string `json:"job_id"`
+	BotConnID string `json:"bot_conn_id"`
 	RecordingStateClient
 }
 

--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -274,7 +274,7 @@ func (p *Plugin) cleanUpState() error {
 				continue
 			}
 
-			if len(k) < 26 {
+			if len(k) != 26 {
 				continue
 			}
 

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -7,6 +7,7 @@ import {Post} from '@mattermost/types/posts';
 
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
+import CompassIcon from 'src/components/icons/compassIcon';
 import ActiveCallIcon from 'src/components/icons/active_call_icon';
 import CallIcon from 'src/components/icons/call_icon';
 import LeaveCallIcon from 'src/components/icons/leave_call_icon';
@@ -53,15 +54,26 @@ const PostType = ({
         }
     };
 
+    const recordings = post.props.recording_files?.length || 0;
+
+    const recordingsSubMessage = recordings > 0 ? (
+        <>
+            <Divider>{'•'}</Divider>
+            <CompassIcon icon='file-video-outline'/>
+            <span>{`${recordings} recording${recordings > 1 ? 's' : ''} available`}</span>
+        </>
+    ) : null;
+
     const subMessage = post.props.end_at ? (
         <>
             <Duration>
                 {`Ended at ${moment(post.props.end_at).format('h:mm A')}`}
             </Duration>
-            <span style={{margin: '0 4px'}}>{'•'}</span>
+            <Divider>{'•'}</Divider>
             <Duration>
                 {`Lasted ${moment.duration(post.props.end_at - post.props.start_at).humanize(false)}`}
             </Duration>
+            { recordingsSubMessage }
         </>
     ) : (
         <Duration>{moment(post.props.start_at).fromNow()}</Duration>
@@ -255,6 +267,10 @@ const DisabledButton = styled(Button)`
     color: rgba(var(--center-channel-color-rgb), 0.32);
     background: rgba(var(--center-channel-color-rgb), 0.08);
     cursor: not-allowed;
+`;
+
+const Divider = styled.span`
+    margin: 0 4px;
 `;
 
 export default PostType;


### PR DESCRIPTION
#### Summary

I found a couple of issues while implementing this:

1. Multiple recording files were not saved correctly in post props due to a type mismatch.
2. There was a potential race condition in a rapid sequence of stop recording -> start recording that would lead to an invalid state with the host and users thinking a seeing the new recording as ended while ongoing.
3. Fixed a potential state parsing bug due to improper key length check.

As far as UX changes so far I only implemented a simple indicator of available recordings, no extra behaviour as there are some inconsistencies with the design so anything more will require further input.

#### Screenshot

![image](https://user-images.githubusercontent.com/1832946/211677025-ff9daff0-27a8-4437-90c3-e8553c650d73.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48900