### PR TITLE
[MM-49004] Allow for listening address to be specified in configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mattermost/calls-offloader v0.1.3
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.1.1
-	github.com/mattermost/rtcd v0.8.0
+	github.com/mattermost/rtcd v0.8.1-0.20230111181530-c10fe17a5a1a
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible
 	github.com/vmihailenco/msgpack/v5 v5.3.5

--- a/go.sum
+++ b/go.sum
@@ -564,8 +564,8 @@ github.com/mattermost/mattermost-plugin-api v0.1.1 h1:bNnPbWCLWZpT/k2kjUxNnzCfUg
 github.com/mattermost/mattermost-plugin-api v0.1.1/go.mod h1:9yZhtg0bBj3kqSTjXnjYBMZoTsWbe3ajdFMdl9/Jz34=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221122212622-0509e78744bf h1:a61ZNxW8zYZjNSbH4Y3agqkWcw7AAo7XxXU4i722Ozs=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221122212622-0509e78744bf/go.mod h1:B9ntfVMlYp1gsCnEKRuM4nMN02l2LQG0+JEPJoSA3mk=
-github.com/mattermost/rtcd v0.8.0 h1:aFacLwfuLhyxGFZrL12uhm1DBrGaa1Ytj8ynKMXdY0k=
-github.com/mattermost/rtcd v0.8.0/go.mod h1:obJtR9gnk6jOk6GC1YyOuq7z1DIaIrvwkyPGvYta0tE=
+github.com/mattermost/rtcd v0.8.1-0.20230111181530-c10fe17a5a1a h1:NlPgFusABHdocIGlmK6PHwiiUhtC+oHrRbIymClfbHY=
+github.com/mattermost/rtcd v0.8.1-0.20230111181530-c10fe17a5a1a/go.mod h1:obJtR9gnk6jOk6GC1YyOuq7z1DIaIrvwkyPGvYta0tE=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=

--- a/plugin.json
+++ b/plugin.json
@@ -30,6 +30,15 @@
                 "hosting": "on-prem"
             },
             {
+                "key": "UDPServerAddress",
+                "display_name": "RTC Server Address",
+                "type": "text",
+                "help_text": "The IP address used by the RTC server to listen on.",
+                "default": "",
+                "placeholder": "127.0.0.1",
+                "hosting": "on-prem"
+            },
+            {
                 "key": "UDPServerPort",
                 "display_name": "RTC Server Port",
                 "type": "number",

--- a/server/activate.go
+++ b/server/activate.go
@@ -164,6 +164,7 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	rtcServerConfig := rtc.ServerConfig{
+		ICEAddressUDP:   cfg.UDPServerAddress,
 		ICEPortUDP:      *cfg.UDPServerPort,
 		ICEHostOverride: cfg.ICEHostOverride,
 		ICEServers:      rtc.ICEServers(cfg.getICEServers(false)),

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"reflect"
 	"strconv"
@@ -31,6 +32,8 @@ import (
 type configuration struct {
 	// The IP (or hostname) to be used as the host ICE candidate.
 	ICEHostOverride string
+	// The IP address used by the RTC server to listen on.
+	UDPServerAddress string
 	// UDP port used by the RTC server to listen to.
 	UDPServerPort *int
 	// The URL to a running RTCD service instance that should host the calls.
@@ -208,6 +211,10 @@ func (c *configuration) SetDefaults() {
 }
 
 func (c *configuration) IsValid() error {
+	if c.UDPServerAddress != "" && net.ParseIP(c.UDPServerAddress) == nil {
+		return fmt.Errorf("UDPServerAddress parsing failed")
+	}
+
 	if c.UDPServerPort == nil {
 		return fmt.Errorf("UDPServerPort should not be nil")
 	}
@@ -235,6 +242,7 @@ func (c *configuration) IsValid() error {
 func (c *configuration) Clone() *configuration {
 	var cfg configuration
 
+	cfg.UDPServerAddress = c.UDPServerAddress
 	cfg.ICEHostOverride = c.ICEHostOverride
 	cfg.RTCDServiceURL = c.RTCDServiceURL
 	cfg.JobServiceURL = c.JobServiceURL

--- a/webapp/src/components/admin_console_settings/ice_host_override.tsx
+++ b/webapp/src/components/admin_console_settings/ice_host_override.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {ChangeEvent, useState} from 'react';
+import {CustomComponentProps} from 'src/types/mattermost-webapp';
+import {getConfig} from 'mattermost-redux/selectors/entities/admin';
+import {useSelector} from 'react-redux';
+
+import manifest from 'src/manifest';
+
+import {
+    LabelRow,
+} from 'src/components/admin_console_settings/common';
+
+const ICEHostOverride = (props: CustomComponentProps) => {
+    const config = useSelector(getConfig);
+
+    // If RTCD is configured then this setting doesn't apply and should be hidden.
+    if (config.PluginSettings?.Plugins[manifest.id].rtcdserviceurl?.length > 0) {
+        return null;
+    }
+
+    const leftCol = 'col-sm-4';
+    const rightCol = 'col-sm-8';
+
+    // Webapp doesn't pass the placeholder setting.
+    const placeholder = manifest.settings_schema?.settings.find((e) => e.key === 'ICEHostOverride')?.placeholder || '';
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        props.onChange(props.id, e.target.value);
+    };
+
+    return (
+        <div
+            data-testid={props.id}
+            className='form-group'
+        >
+            <div className={'control-label ' + leftCol}>
+                <LabelRow>
+                    <label
+                        data-testid={props.id + 'label'}
+                        htmlFor={props.id}
+                    >
+                        {props.label}
+                    </label>
+                </LabelRow>
+            </div>
+            <div className={rightCol}>
+                <input
+                    data-testid={props.id + 'input'}
+                    id={props.id}
+                    className='form-control'
+                    type={'input'}
+                    placeholder={placeholder}
+                    value={props.value}
+                    onChange={handleChange}
+                    disabled={props.disabled}
+                />
+                <div
+                    data-testid={props.id + 'help-text'}
+                    className='help-text'
+                >
+                    {props.helpText}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ICEHostOverride;

--- a/webapp/src/components/admin_console_settings/udp_server_address.tsx
+++ b/webapp/src/components/admin_console_settings/udp_server_address.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {ChangeEvent, useState} from 'react';
+import {CustomComponentProps} from 'src/types/mattermost-webapp';
+import {getConfig} from 'mattermost-redux/selectors/entities/admin';
+import {useSelector} from 'react-redux';
+
+import manifest from 'src/manifest';
+
+import {
+    LabelRow,
+} from 'src/components/admin_console_settings/common';
+
+const UDPServerAddress = (props: CustomComponentProps) => {
+    const config = useSelector(getConfig);
+
+    // If RTCD is configured then this setting doesn't apply and should be hidden.
+    if (config.PluginSettings?.Plugins[manifest.id].rtcdserviceurl?.length > 0) {
+        return null;
+    }
+
+    const leftCol = 'col-sm-4';
+    const rightCol = 'col-sm-8';
+
+    // Webapp doesn't pass the placeholder setting.
+    const placeholder = manifest.settings_schema?.settings.find((e) => e.key === 'UDPServerAddress')?.placeholder || '';
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        props.onChange(props.id, e.target.value);
+    };
+
+    return (
+        <div
+            data-testid={props.id}
+            className='form-group'
+        >
+            <div className={'control-label ' + leftCol}>
+                <LabelRow>
+                    <label
+                        data-testid={props.id + 'label'}
+                        htmlFor={props.id}
+                    >
+                        {props.label}
+                    </label>
+                </LabelRow>
+            </div>
+            <div className={rightCol}>
+                <input
+                    data-testid={props.id + 'input'}
+                    id={props.id}
+                    className='form-control'
+                    type={'input'}
+                    placeholder={placeholder}
+                    value={props.value}
+                    onChange={handleChange}
+                    disabled={props.disabled}
+                />
+                <div
+                    data-testid={props.id + 'help-text'}
+                    className='help-text'
+                >
+                    {props.helpText}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default UDPServerAddress;

--- a/webapp/src/components/admin_console_settings/udp_server_port.tsx
+++ b/webapp/src/components/admin_console_settings/udp_server_port.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {ChangeEvent, useState} from 'react';
+import {CustomComponentProps} from 'src/types/mattermost-webapp';
+import {getConfig} from 'mattermost-redux/selectors/entities/admin';
+import {useSelector} from 'react-redux';
+
+import manifest from 'src/manifest';
+
+import {
+    LabelRow,
+} from 'src/components/admin_console_settings/common';
+
+const UDPServerPort = (props: CustomComponentProps) => {
+    const config = useSelector(getConfig);
+
+    // If RTCD is configured then this setting doesn't apply and should be hidden.
+    if (config.PluginSettings?.Plugins[manifest.id].rtcdserviceurl?.length > 0) {
+        return null;
+    }
+
+    const leftCol = 'col-sm-4';
+    const rightCol = 'col-sm-8';
+
+    // Webapp doesn't pass the placeholder setting.
+    const placeholder = manifest.settings_schema?.settings.find((e) => e.key === 'UDPServerPort')?.placeholder || '';
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        props.onChange(props.id, parseInt(e.target.value, 10));
+    };
+
+    return (
+        <div
+            data-testid={props.id}
+            className='form-group'
+        >
+            <div className={'control-label ' + leftCol}>
+                <LabelRow>
+                    <label
+                        data-testid={props.id + 'label'}
+                        htmlFor={props.id}
+                    >
+                        {props.label}
+                    </label>
+                </LabelRow>
+            </div>
+            <div className={rightCol}>
+                <input
+                    data-testid={props.id + 'number'}
+                    id={props.id}
+                    className='form-control'
+                    type={'number'}
+                    placeholder={placeholder}
+                    value={props.value}
+                    onChange={handleChange}
+                    disabled={props.disabled}
+                />
+                <div
+                    data-testid={props.id + 'help-text'}
+                    className='help-text'
+                >
+                    {props.helpText}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default UDPServerPort;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -16,13 +16,16 @@ import {
     showScreenSourceModal,
     displayCallsTestModeUser,
 } from 'src/actions';
+
 import {PostTypeCloudTrialRequest} from 'src/components/custom_post_types/post_type_cloud_trial_request';
 import RTCDServiceUrl from 'src/components/admin_console_settings/rtcd_service_url';
 import EnableRecordings from 'src/components/admin_console_settings/recordings/enable_recordings';
 import MaxRecordingDuration from 'src/components/admin_console_settings/recordings/max_recording_duration';
 import JobServiceURL from 'src/components/admin_console_settings/recordings/job_service_url';
-
 import TestMode from 'src/components/admin_console_settings/test_mode';
+import UDPServerPort from 'src/components/admin_console_settings/udp_server_port';
+import UDPServerAddress from 'src/components/admin_console_settings/udp_server_address';
+import ICEHostOverride from 'src/components/admin_console_settings/ice_host_override';
 
 import {
     handleUserConnected,
@@ -419,6 +422,9 @@ export default class Plugin {
         registry.registerAdminConsoleCustomSetting('MaxRecordingDuration', MaxRecordingDuration);
         registry.registerAdminConsoleCustomSetting('JobServiceURL', JobServiceURL);
         registry.registerAdminConsoleCustomSetting('DefaultEnabled', TestMode);
+        registry.registerAdminConsoleCustomSetting('UDPServerAddress', UDPServerAddress);
+        registry.registerAdminConsoleCustomSetting('UDPServerPort', UDPServerPort);
+        registry.registerAdminConsoleCustomSetting('ICEHostOverride', ICEHostOverride);
 
         const connectCall = async (channelID: string, title?: string) => {
             if (shouldRenderDesktopWidget()) {


### PR DESCRIPTION
#### Summary

PR adds a new `UDPServerAddress` setting to potentially configure the address/interface to be used by the RTC server (receiving/sending UDP packets).

In addition we customize those settings that don't make sense when RTCD is used so that they don't get displayed and cause confusion.

#### Related PR

https://github.com/mattermost/rtcd/pull/85

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49004

