### PR TITLE
MM-49613 - Emoji picker crash

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5,8 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@emoji-mart/data": "1.0.6",
-        "@emoji-mart/react": "1.0.1",
         "@mattermost/compass-icons": "0.1.32",
         "@mattermost/types": "6.7.0-0",
         "@msgpack/msgpack": "2.7.1",
@@ -14,7 +12,7 @@
         "axios": "0.21.4",
         "core-js": "3.21.1",
         "css-vars-ponyfill": "2.4.8",
-        "emoji-mart": "5.3.3",
+        "emoji-picker-react": "4.4.7",
         "highlight.js": "11.6.0",
         "media-chrome": "0.16.0",
         "pako": "2.0.4",
@@ -1856,20 +1854,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@emoji-mart/data": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.0.6.tgz",
-      "integrity": "sha512-8wu3ec/kLCB0Y3K+pOKyY6Ob+xtQu3XhZvntdrpOTUQZ/PO6FW5PpFw7RE1kQ/up1fsVSJBl5mZ8Gs4SPwTYeg=="
-    },
-    "node_modules/@emoji-mart/react": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.0.1.tgz",
-      "integrity": "sha512-ALhLD96BOL5w+a4NI5NpmfqfF1aVjjj2qJE0dLst/OhjBfVmpteWNgn/h8LZy9ulU6AnbeS+13KnPFzDjCvRRw==",
-      "peerDependencies": {
-        "emoji-mart": "^5.2",
-        "react": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@emotion/babel-utils": {
@@ -5405,7 +5389,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6395,10 +6378,19 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/emoji-mart": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.3.3.tgz",
-      "integrity": "sha512-rr3wXUimYFQ5Mf50P/5UOsRibr5JSJE3Nj4zw0aDglb3GSHzn/wGKBoXoSkjtWaji8UcmXcYn3cdilD2Eix6iQ=="
+    "node_modules/emoji-picker-react": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.4.7.tgz",
+      "integrity": "sha512-HcB1Fr57W6M+gLLm/W4YhbAnUQqYBUAhZBOHmPlSQODLtsDI8vecyqNIF9RrStZHfZwzUSLlpZMfY07AA6gxmA==",
+      "dependencies": {
+        "clsx": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -19871,17 +19863,6 @@
       "version": "0.5.5",
       "dev": true
     },
-    "@emoji-mart/data": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.0.6.tgz",
-      "integrity": "sha512-8wu3ec/kLCB0Y3K+pOKyY6Ob+xtQu3XhZvntdrpOTUQZ/PO6FW5PpFw7RE1kQ/up1fsVSJBl5mZ8Gs4SPwTYeg=="
-    },
-    "@emoji-mart/react": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.0.1.tgz",
-      "integrity": "sha512-ALhLD96BOL5w+a4NI5NpmfqfF1aVjjj2qJE0dLst/OhjBfVmpteWNgn/h8LZy9ulU6AnbeS+13KnPFzDjCvRRw==",
-      "requires": {}
-    },
     "@emotion/babel-utils": {
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
@@ -22673,8 +22654,7 @@
     "clsx": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "dev": true
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "co": {
       "version": "4.6.0",
@@ -23480,10 +23460,13 @@
       "version": "6.0.1",
       "dev": true
     },
-    "emoji-mart": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.3.3.tgz",
-      "integrity": "sha512-rr3wXUimYFQ5Mf50P/5UOsRibr5JSJE3Nj4zw0aDglb3GSHzn/wGKBoXoSkjtWaji8UcmXcYn3cdilD2Eix6iQ=="
+    "emoji-picker-react": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.4.7.tgz",
+      "integrity": "sha512-HcB1Fr57W6M+gLLm/W4YhbAnUQqYBUAhZBOHmPlSQODLtsDI8vecyqNIF9RrStZHfZwzUSLlpZMfY07AA6gxmA==",
+      "requires": {
+        "clsx": "^1.2.1"
+      }
     },
     "emoji-regex": {
       "version": "9.2.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -66,8 +66,6 @@
     "webpack-cli": "4.7.2"
   },
   "dependencies": {
-    "@emoji-mart/data": "1.0.6",
-    "@emoji-mart/react": "1.0.1",
     "@mattermost/compass-icons": "0.1.32",
     "@mattermost/types": "6.7.0-0",
     "@msgpack/msgpack": "2.7.1",
@@ -75,7 +73,7 @@
     "axios": "0.21.4",
     "core-js": "3.21.1",
     "css-vars-ponyfill": "2.4.8",
-    "emoji-mart": "5.3.3",
+    "emoji-picker-react": "4.4.7",
     "highlight.js": "11.6.0",
     "media-chrome": "0.16.0",
     "pako": "2.0.4",

--- a/webapp/src/components/expanded_view/reaction_button.tsx
+++ b/webapp/src/components/expanded_view/reaction_button.tsx
@@ -53,12 +53,6 @@ export const ReactionButton = forwardRef(({trackEvent}: Props, ref) => {
     const [showPicker, setShowPicker] = useState(false);
     const [showBar, setShowBar] = useState(false);
 
-    // Note: this is such a hack. Emoji-mart seems be mounted and then receives the onClickOutside immediately after.
-    //  (it's not really that emoji-mart/react doesn't trigger the cleanup function when it's unmounted, see:
-    //  https://github.com/missive/emoji-mart/issues/635, because clicking once it's unmounted doesn't fire the onClickOutside event.)
-    //  e.preventDefault() doesn't stop the click from propogating to the newly mounted picker.
-    const [pickerHack, setPickerHack] = useState(true);
-
     useImperativeHandle(ref, () => ({
         toggle() {
             toggleReactions();
@@ -96,34 +90,7 @@ export const ReactionButton = forwardRef(({trackEvent}: Props, ref) => {
     ) : <HandRightOutlineIcon size={18}/>;
 
     const toggleShowPicker = () => {
-        setShowPicker((showing) => {
-            if (showing) {
-                // We are showing, and clicking the emoji icon sends an event here (but not to onClickOutside because
-                // it's closed before it has a chance to handle it). So reset the pickerHack to false for the next time.
-                setPickerHack(false);
-            }
-            return !showing;
-        });
-    };
-    const clickedOutsidePicker = () => {
-        if (!pickerHack) {
-            // Here's the hack: don't trigger the showPicker if we received this click immediately after mounting.
-            setPickerHack(true);
-            return;
-        }
-
-        // We have set pickerHack in the past, so this is a regular clickedOutsidePicker event.
-        setShowPicker((showing) => {
-            if (showing) {
-                // Reset the hack and close the picker.
-                setPickerHack(false);
-                return false;
-            }
-
-            // show the picker? (this should never happen--if the picker is not showing, it shouldn't receive the outsideClick.)
-            // But just in case:
-            return true;
-        });
+        setShowPicker((showing) => !showing);
     };
 
     const toggleReactions = () => setShowBar((prev) => {

--- a/webapp/src/components/expanded_view/reaction_button.tsx
+++ b/webapp/src/components/expanded_view/reaction_button.tsx
@@ -46,7 +46,6 @@ interface Props {
 }
 
 export const ReactionButton = forwardRef(({trackEvent}: Props, ref) => {
-    const barRef: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
     const [showPicker, setShowPicker] = useState(false);
     const [showBar, setShowBar] = useState(false);
 
@@ -145,7 +144,7 @@ export const ReactionButton = forwardRef(({trackEvent}: Props, ref) => {
                 </PickerContainer>
             }
             {showBar &&
-                <Bar ref={barRef}>
+                <Bar>
                     <OverlayTrigger
                         key={'calls-popout-raisehand-button'}
                         placement='top'


### PR DESCRIPTION
#### Summary
- It appears that, because of all the fancy features (shadow-doming? custom elements? IntersectionObserver?),  emoji-mart does not work if you try to instantiate it twice on the same page (see: https://github.com/missive/emoji-mart/issues/755). Somehow we were running into that. Or maybe into something completely different, but with the same `illegal-constructor` effect.
- Because I couldn't figure it out, propose to swap it out with `emoji-picker-react`. It has a few fewer customizations, and seems to lag a bit on load (I'm seeing a few failed fetches to a cdn for apple emojis). But otherwise it works.
- We lose the "on click outside" closing behavior, too. 

<img width="468" alt="image" src="https://user-images.githubusercontent.com/1490756/211917607-b0127dff-6b39-4887-b1cb-7c164e2e61b9.png">

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-49613
