### PR TITLE
[MM-49588] Fix audio devices list overflow

### DIFF
--- a/webapp/src/components/call_widget/component.scss
+++ b/webapp/src/components/call_widget/component.scss
@@ -135,6 +135,8 @@ a.calls-channel-link {
 
 #calls-widget .Menu {
   position: static;
+  border: none;
+  box-shadow: none;
 }
 
 #calls-widget button {

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -235,7 +235,9 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             },
             audioInputsOutputsMenu: {
                 left: 'calc(100% + 4px)',
-                top: 'auto',
+                overflow: 'auto',
+                top: 0,
+                maxHeight: 'calc(100% + 90px)',
             },
             expandButton: {
                 position: 'absolute',
@@ -905,13 +907,13 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
         if (el) {
             this.audioMenuResizeObserver = new ResizeObserver((entries) => {
-                if (entries.length === 0) {
+                if (entries.length === 0 || entries[0].borderBoxSize.length === 0) {
                     return;
                 }
                 sendDesktopEvent('calls-widget-resize', {
                     element: 'calls-widget-audio-menu',
-                    width: Math.round(entries[0].contentRect.width),
-                    height: Math.round(entries[0].contentRect.height),
+                    height: Math.round(entries[0].borderBoxSize[0].blockSize),
+                    width: Math.round(entries[0].borderBoxSize[0].inlineSize),
                 });
             });
             this.audioMenuResizeObserver.observe(el);
@@ -1000,6 +1002,16 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             this.state.devices.outputs?.filter((device: any) => device.deviceId && device.label);
         const isDisabled = devices.length === 0;
 
+        const buttonStyle: CSSProperties = {
+            display: 'flex',
+            flexDirection: 'column',
+            color: isDisabled ? changeOpacity(this.props.theme.centerChannelColor, 0.32) : '',
+        };
+
+        if ((deviceType === 'input' && this.state.showAudioInputDevicesMenu) || (deviceType === 'output' && this.state.showAudioOutputDevicesMenu)) {
+            buttonStyle.background = 'rgba(var(--center-channel-color-rgb), 0.1)';
+        }
+
         return (
             <React.Fragment>
                 {devices.length > 0 && this.renderAudioDevicesList(deviceType, devices)}
@@ -1009,11 +1021,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     <button
                         id={`calls-widget-audio-${deviceType}-button`}
                         className='style--none'
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            color: isDisabled ? changeOpacity(this.props.theme.centerChannelColor, 0.32) : '',
-                        }}
+                        style={buttonStyle}
                         onClick={onClickHandler}
                         disabled={isDisabled}
                     >


### PR DESCRIPTION
#### Summary

PR fixes especially long audio devices lists from overflowing outside the viewport. To achieve this we are doing two things:

1. Setting a `max-height` to be the height of widget + height of menu.
2. Making the submenus always start from the top.

Originally I tried to make them grow upwards but that would break the global widget logic and required even more complex calculations. I think this approach is simple enough since it doesn't make sense to grow indefinitely anyway.

Since I was touching the code I opted to add a background to help the user identify what list they currently have open.

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/1832946/211943688-106e4779-fff3-4a3b-ab1e-d53cc21d0032.png)

![image](https://user-images.githubusercontent.com/1832946/211943368-a3cbde18-4bb4-4274-9c97-f33a79ed4700.png)

After

![image](https://user-images.githubusercontent.com/1832946/211943002-848493fa-bce8-4163-b897-f38155932987.png)

![image](https://user-images.githubusercontent.com/1832946/211943217-91b60b8c-729a-453e-a846-1d88877f5d51.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49588

