### PR TITLE
[MM-49635] Improve recordings security

### DIFF
--- a/server/job_service.go
+++ b/server/job_service.go
@@ -19,7 +19,7 @@ import (
 )
 
 const jobServiceConfigKey = "jobservice_config"
-const recordingJobRunner = "mattermost/calls-recorder:v0.2.1"
+const recordingJobRunner = "mattermost/calls-recorder:v0.2.2"
 const runnerUpdateLockTimeout = 2 * time.Minute
 
 type jobService struct {

--- a/standalone/src/common.ts
+++ b/standalone/src/common.ts
@@ -14,8 +14,9 @@ export function getToken() {
     }
 
     const encoded = window.location.hash.substr(1);
+
     // Performing URL safe base64 decoding.
-    const data = JSON.parse(atob(encoded.replace(/_/g, '/').replace(/-/g, '+')))
+    const data = JSON.parse(atob(encoded.replace(/_/g, '/').replace(/-/g, '+')));
 
     return data.token || '';
 }

--- a/standalone/src/common.ts
+++ b/standalone/src/common.ts
@@ -9,6 +9,13 @@ export function getCallTitle() {
 }
 
 export function getToken() {
-    const params = new URLSearchParams(window.location.search);
-    return params.get('token') || '';
+    if (!window.location.hash) {
+        return '';
+    }
+
+    const encoded = window.location.hash.substr(1);
+    // Performing URL safe base64 decoding.
+    const data = JSON.parse(atob(encoded.replace(/_/g, '/').replace(/-/g, '+')))
+
+    return data.token || '';
 }


### PR DESCRIPTION
#### Summary

Two main things happening here:

1. Passing the bot token used to record through URI fragment instead of query. I am doing a bit more to try and keep it extensible so we are actually passing a base64 encoded json object with the token inside.
2. We bump the recorder image to `v0.2.2` (still to be released, pending a couple of review on that side). 

#### Related PR

https://github.com/mattermost/calls-recorder/pull/13

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49635
