### PR TITLE
[MM-49674] Add undefined checks to keyboard shortcuts handler

### DIFF
--- a/webapp/src/shortcuts.ts
+++ b/webapp/src/shortcuts.ts
@@ -58,6 +58,10 @@ export const reverseKeyMappings = (() => {
 })();
 
 export function keyToAction(scope: string, ev: KeyboardEvent) {
+    if (!ev.key || !ev.code) {
+        return null;
+    }
+
     const key = ev.key.toLowerCase();
     const code = ev.code.replace('Key', '').toLowerCase();
 


### PR DESCRIPTION
#### Summary

This happened to me before but I wasn't quite sure how to reproduce. Apparently, selecting one of browser's saved suggestions on a text input generates a keydown event with no key nor code. PR adds some extra checks to make sure we don't try to read from undefined.

![image](https://user-images.githubusercontent.com/1832946/212722692-0caa6a21-4363-45b5-824f-53559cfa3762.png)


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49674

