### PR TITLE
[MM-49924] Fix Desktop version comparison

### DIFF
--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -1,5 +1,6 @@
 import {
     getWSConnectionURL,
+    shouldRenderDesktopWidget,
 } from './utils';
 
 describe('utils', () => {
@@ -24,6 +25,54 @@ describe('utils', () => {
 
         testCases.forEach((testCase) => it(testCase.description, () => {
             expect(getWSConnectionURL(testCase.config)).toEqual(testCase.expected);
+        }));
+    });
+
+    describe('shouldRenderDesktopWidget', () => {
+        const testCases = [
+            {
+                description: 'equals',
+                actual: '5.3.0',
+                expected: true,
+            },
+            {
+                description: 'greater',
+                actual: '5.3.1',
+                expected: true,
+            },
+            {
+                description: 'lesser',
+                actual: '5.2.9',
+                expected: false,
+            },
+            {
+                description: 'nightly build',
+                actual: '5.3.0-nightly.20230124',
+                expected: true,
+            },
+            {
+                description: 'patch version',
+                actual: '5.3.1',
+                expected: true,
+            },
+            {
+                description: 'major version',
+                actual: '6.0.0',
+                expected: true,
+            },
+            {
+                description: 'complex',
+                actual: '5.3.0-alpha.something+meta-data',
+                expected: true,
+            },
+        ];
+
+        testCases.forEach((testCase) => it(testCase.description, () => {
+            window.desktop = {
+                version: testCase.actual,
+            };
+            expect(shouldRenderDesktopWidget()).toEqual(testCase.expected);
+            delete window.desktop;
         }));
     });
 });

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -1,4 +1,4 @@
-import {compareSemVer} from 'semver-parser';
+import {parseSemVer} from 'semver-parser';
 
 import {
     getCurrentRelativeTeamUrl,
@@ -342,7 +342,17 @@ export async function followThread(store: Store, channelID: string, teamID: stri
 
 export function shouldRenderDesktopWidget() {
     const win = window.opener ? window.opener : window;
-    return win.desktop && compareSemVer(win.desktop.version, '5.3.0') >= 0;
+    if (!win.desktop) {
+        return false;
+    }
+
+    const version = parseSemVer(win.desktop.version);
+
+    if (version.major < 5) {
+        return false;
+    }
+
+    return version.major > 5 || version.minor >= 3;
 }
 
 export function sendDesktopEvent(event: string, data?: any) {


### PR DESCRIPTION
#### Summary

Apparently `compareSemVer()` was considering `5.3.0-nightly.20230124` to be lesser than `5.3.0` :confused:, messing things up for Desktop builds.

Fixes https://github.com/mattermost/desktop/issues/2512

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49924
