### PR TITLE
[MM-49996] Add `/call recording` slash command

### DIFF
--- a/webapp/src/components/badge.tsx
+++ b/webapp/src/components/badge.tsx
@@ -70,7 +70,7 @@ const Spinner = styled.span<{size: number}>`
   height: ${({size}) => size}px;
   border-radius: 50%;
   display: inline-block;
-  border-top: 2px solid #FFF;
+  border-top: 2px solid currentColor;
   border-right: 2px solid transparent;
   box-sizing: border-box;
   animation: spin 1s linear infinite;

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -93,13 +93,13 @@ export default function RecordingInfoPrompt(props: Props) {
         return null;
     }
 
-    // If the prompt was dismissed after the call has started and after the last host change
+    // If the prompt was dismissed after the recording has started and after the last host change
     // we don't show this again.
     if (!hasRecEnded && dismissedAt > props.recording?.start_at && dismissedAt > props.hostChangeAt) {
         return null;
     }
 
-    // If the prompt was dismissed after the call has ended then we
+    // If the prompt was dismissed after the recording has ended then we
     // don't show this again.
     if (hasRecEnded && dismissedAt > props.recording?.end_at) {
         return null;


### PR DESCRIPTION
#### Summary

PR adds support for using `/call recording [start|stop]` to handle call recordings.
For these to make sense I also added a couple of missing flows from the widget, such as async error handling and loading spinner when starting a recording.

#### Related PR

https://github.com/mattermost/mattermost-mobile/pull/7062

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49996
