### PR TITLE
[MM-49944] Dispatch missing call start event

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -590,65 +590,83 @@ export default class Plugin {
                     type: RECEIVED_CHANNEL_STATE,
                     data: {id: channelID, enabled: resp.data.enabled},
                 });
+
+                const call = resp.data.call;
+                if (!call) {
+                    return;
+                }
+
+                store.dispatch({
+                    type: VOICE_CHANNEL_CALL_START,
+                    data: {
+                        channelID,
+                        startAt: call.start_at,
+                        ownerID: call.owner_id,
+                        hostID: call.host_id,
+                    },
+                });
+
                 store.dispatch({
                     type: VOICE_CHANNEL_USERS_CONNECTED,
                     data: {
-                        users: resp.data.call?.users,
+                        users: call.users || [],
                         channelID,
                     },
                 });
-                if (resp.data.call?.thread_id) {
+
+                if (call.thread_id) {
                     store.dispatch({
                         type: VOICE_CHANNEL_ROOT_POST,
                         data: {
                             channelID,
-                            rootPost: resp.data.call?.thread_id,
+                            rootPost: call.thread_id,
                         },
                     });
                 }
-                if (resp.data.call?.host_id) {
+
+                if (call.host_id) {
                     store.dispatch({
                         type: VOICE_CHANNEL_CALL_HOST,
                         data: {
                             channelID,
-                            hostID: resp.data.call?.host_id,
+                            hostID: call.host_id,
                         },
                     });
                 }
 
-                if (resp.data.call?.users && resp.data.call?.users.length > 0) {
+                if (call.users && call.users.length > 0) {
                     store.dispatch({
                         type: VOICE_CHANNEL_PROFILES_CONNECTED,
                         data: {
-                            profiles: await getProfilesByIds(store.getState(), resp.data.call?.users),
+                            profiles: await getProfilesByIds(store.getState(), call.users),
                             channelID,
                         },
                     });
                 }
 
-                if (resp.data.call?.recording) {
+                if (call.recording) {
                     store.dispatch({
                         type: VOICE_CHANNEL_CALL_RECORDING_STATE,
                         data: {
                             callID: channelID,
-                            recState: resp.data.call?.recording,
+                            recState: call.recording,
                         },
                     });
                 }
 
-                if (resp.data.call?.screen_sharing_id) {
+                if (call.screen_sharing_id) {
                     store.dispatch({
                         type: VOICE_CHANNEL_USER_SCREEN_ON,
                         data: {
                             channelID,
-                            userID: resp.data.call?.screen_sharing_id,
+                            userID: call.screen_sharing_id,
                         },
                     });
                 }
 
                 const userStates: Record<string, UserState> = {};
-                const users = resp.data.call?.users || [];
-                const states = resp.data.call?.states || [];
+                const users = call.users || [];
+                const states = call.states || [];
                 for (let i = 0; i < users.length; i++) {
                     userStates[users[i]] = {...states[i], id: users[i]};
                 }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -614,25 +614,21 @@ export default class Plugin {
                     },
                 });
 
-                if (call.thread_id) {
-                    store.dispatch({
-                        type: VOICE_CHANNEL_ROOT_POST,
-                        data: {
-                            channelID,
-                            rootPost: call.thread_id,
-                        },
-                    });
-                }
+                store.dispatch({
+                    type: VOICE_CHANNEL_ROOT_POST,
+                    data: {
+                        channelID,
+                        rootPost: call.thread_id,
+                    },
+                });
 
-                if (call.host_id) {
-                    store.dispatch({
-                        type: VOICE_CHANNEL_CALL_HOST,
-                        data: {
-                            channelID,
-                            hostID: call.host_id,
-                        },
-                    });
-                }
+                store.dispatch({
+                    type: VOICE_CHANNEL_CALL_HOST,
+                    data: {
+                        channelID,
+                        hostID: call.host_id,
+                    },
+                });
 
                 if (call.users && call.users.length > 0) {
                     store.dispatch({
@@ -644,25 +640,21 @@ export default class Plugin {
                     });
                 }
 
-                if (call.recording) {
-                    store.dispatch({
-                        type: VOICE_CHANNEL_CALL_RECORDING_STATE,
-                        data: {
-                            callID: channelID,
-                            recState: call.recording,
-                        },
-                    });
-                }
+                store.dispatch({
+                    type: VOICE_CHANNEL_CALL_RECORDING_STATE,
+                    data: {
+                        callID: channelID,
+                        recState: call.recording,
+                    },
+                });
 
-                if (call.screen_sharing_id) {
-                    store.dispatch({
-                        type: VOICE_CHANNEL_USER_SCREEN_ON,
-                        data: {
-                            channelID,
-                            userID: call.screen_sharing_id,
-                        },
-                    });
-                }
+                store.dispatch({
+                    type: VOICE_CHANNEL_USER_SCREEN_ON,
+                    data: {
+                        channelID,
+                        userID: call.screen_sharing_id,
+                    },
+                });
 
                 const userStates: Record<string, UserState> = {};
                 const users = call.users || [];


### PR DESCRIPTION
#### Summary

We were failing to dispatch the call start event when fetching call (and channel) data. This bug was easily reproducible by logging out and back in with an ongoing call. I cannot guarantee that's what happened to all the reporting users but these changes should likely fix most instances of the issue.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49944
