### PR TITLE
[MM-49739] Send focus desktop event

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1465,7 +1465,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
     onExpandClick = () => {
         if (this.state.expandedViewWindow && !this.state.expandedViewWindow.closed) {
-            this.state.expandedViewWindow.focus();
+            if (this.props.global) {
+                sendDesktopEvent('calls-popout-focus');
+            } else {
+                this.state.expandedViewWindow.focus();
+            }
             return;
         }
 


### PR DESCRIPTION
#### Summary

Sending a focus event to the desktop side since the window is not focused automatically when opened from the global widget.

#### Related PR

https://github.com/mattermost/desktop/pull/2539

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49739

