### PR TITLE
[MM-42233] Fix widget crash on joining calls

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -50,6 +50,7 @@ import CallDuration from './call_duration';
 import WidgetBanner from './widget_banner';
 import WidgetButton from './widget_button';
 import UnavailableIconWrapper from './unavailable_icon_wrapper';
+import LoadingOverlay from './loading_overlay';
 
 import './component.scss';
 
@@ -112,6 +113,7 @@ interface State {
     audioEls: HTMLAudioElement[],
     alerts: CallAlertStates,
     recDisclaimerDismissedAt: number,
+    connected: boolean,
 }
 
 export default class CallWidget extends React.PureComponent<Props, State> {
@@ -259,6 +261,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             audioEls: [],
             alerts: CallAlertStatesDefault,
             recDisclaimerDismissedAt: 0,
+            connected: false,
         };
         this.node = React.createRef();
         this.menuNode = React.createRef();
@@ -369,6 +372,8 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         });
 
         window.callsClient?.on('connect', () => {
+            this.setState({connected: true});
+
             if (this.props.global) {
                 sendDesktopEvent('calls-joined-call', {
                     callID: window.callsClient?.channelID,
@@ -1481,7 +1486,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 <div style={{display: 'flex', flexDirection: 'column-reverse'}}>
                     {joinedUsers}
                 </div>
-                {this.state.showUsersJoined.includes(this.props.currentUserID) &&
+                {this.state.connected &&
                     <div className='calls-notification-bar calls-slide-top'>
                         {notificationContent}
                     </div>
@@ -1691,6 +1696,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 style={mainStyle}
                 ref={this.node}
             >
+                <LoadingOverlay visible={this.state.connected}/>
 
                 <div
                     ref={this.menuNode}

--- a/webapp/src/components/call_widget/index.ts
+++ b/webapp/src/components/call_widget/index.ts
@@ -70,7 +70,7 @@ const mapStateToProps = (state: GlobalState) => {
         profilesMap,
         picturesMap,
         statuses: voiceUsersStatuses(state) || {},
-        callStartAt: voiceChannelCallStartAt(state, channel?.id) || 0,
+        callStartAt: voiceChannelCallStartAt(state, channel?.id) || Number(window.callsClient?.initTime),
         callHostID: voiceChannelCallHostID(state, channel?.id) || '',
         callHostChangeAt: voiceChannelCallHostChangeAt(state, channel?.id) || 0,
         callRecording: callRecording(state, channel?.id),

--- a/webapp/src/components/call_widget/index.ts
+++ b/webapp/src/components/call_widget/index.ts
@@ -15,7 +15,6 @@ import {UserState} from 'src/types/types';
 import {showExpandedView, showScreenSourceModal, trackEvent} from 'src/actions';
 
 import {
-    connectedChannelID,
     voiceUsersStatuses,
     voiceChannelCallStartAt,
     voiceChannelScreenSharingID,
@@ -33,7 +32,11 @@ import {alphaSortProfiles, stateSortProfiles} from 'src/utils';
 import CallWidget from './component';
 
 const mapStateToProps = (state: GlobalState) => {
-    const channel = getChannel(state, connectedChannelID(state));
+    // Using the channelID from the client since we could connect before
+    // receiving the user connected event and still want to go ahead and show the widget.
+    // Also, it would be possible to lose the event altogether if connecting to
+    // the call while in a ws reconnection handler.
+    const channel = getChannel(state, String(window.callsClient?.channelID));
     const currentUserID = getCurrentUserId(state);
 
     const screenSharingID = voiceChannelScreenSharingID(state, channel?.id) || '';

--- a/webapp/src/components/call_widget/loading_overlay.tsx
+++ b/webapp/src/components/call_widget/loading_overlay.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled, {css} from 'styled-components';
+
+export type Props = {
+    visible: boolean,
+}
+
+export default function LoadingOverlay(props: Props) {
+    return (
+        <Container visible={props.visible}>
+            <Body>
+                <Spinner size={16}/>
+                <Text>{'Connecting to the call...'}</Text>
+            </Body>
+        </Container>
+    );
+}
+
+const Container = styled.div<{visible: boolean}>`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  border-radius: 4px;
+  z-index: 1;
+  background: rgba(var(--center-channel-bg-rgb), 0.7);
+
+  ${({visible}) => visible && css`
+      visibility: hidden;
+      opacity: 0;
+      transition: visibility 0s 0.3s, opacity 0.3s ease-out;
+  `}
+`;
+
+const Body = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Text = styled.span`
+  color: rgba(var(--center-channel-color-rgb), 0.84);
+  font-size: 12px;
+  line-height: 16px;
+  margin-left: 8px;
+  font-weight: 600;
+`;
+
+const Spinner = styled.span<{size: number}>`
+  width: ${({size}) => size}px;
+  height: ${({size}) => size}px;
+  border-radius: 50%;
+  display: inline-block;
+  border-top: 2px solid #166DE0;
+  border-right: 2px solid transparent;
+  box-sizing: border-box;
+  animation: spin 0.8s linear infinite;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;


### PR DESCRIPTION
#### Summary

PR fixes a long lasting bug causing a failure when joining a call. After some inspection I realized the problem wasn't the missing channel but the fact that the client doesn't know if it's connected due to not receiving the ws event for the current user. This could happen when someone tries to connect to a call during a ws reconnection attempt (e.g. just coming back from a laptop sleep). The end result would be very confusing, with the widget not showing while actually being in a call (e.g. hearing everyone but no UI).

The simplest (although not perfect) fix here is to use the channelID from the calls client as source of truth and trust that we are going to connect, eventually.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42233

