### PR TITLE
[MM-42429] Implement basic connecting animation

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -50,6 +50,7 @@ import CallDuration from './call_duration';
 import WidgetBanner from './widget_banner';
 import WidgetButton from './widget_button';
 import UnavailableIconWrapper from './unavailable_icon_wrapper';
+import LoadingOverlay from './loading_overlay';
 
 import './component.scss';
 
@@ -112,6 +113,7 @@ interface State {
     audioEls: HTMLAudioElement[],
     alerts: CallAlertStates,
     recDisclaimerDismissedAt: number,
+    connected: boolean,
 }
 
 export default class CallWidget extends React.PureComponent<Props, State> {
@@ -259,6 +261,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             audioEls: [],
             alerts: CallAlertStatesDefault,
             recDisclaimerDismissedAt: 0,
+            connected: false,
         };
         this.node = React.createRef();
         this.menuNode = React.createRef();
@@ -369,6 +372,8 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         });
 
         window.callsClient?.on('connect', () => {
+            this.setState({connected: true});
+
             if (this.props.global) {
                 sendDesktopEvent('calls-joined-call', {
                     callID: window.callsClient?.channelID,
@@ -1481,7 +1486,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 <div style={{display: 'flex', flexDirection: 'column-reverse'}}>
                     {joinedUsers}
                 </div>
-                {this.state.showUsersJoined.includes(this.props.currentUserID) &&
+                {this.state.connected &&
                     <div className='calls-notification-bar calls-slide-top'>
                         {notificationContent}
                     </div>
@@ -1691,6 +1696,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 style={mainStyle}
                 ref={this.node}
             >
+                <LoadingOverlay visible={this.state.connected}/>
 
                 <div
                     ref={this.menuNode}

--- a/webapp/src/components/call_widget/index.ts
+++ b/webapp/src/components/call_widget/index.ts
@@ -70,7 +70,7 @@ const mapStateToProps = (state: GlobalState) => {
         profilesMap,
         picturesMap,
         statuses: voiceUsersStatuses(state) || {},
-        callStartAt: voiceChannelCallStartAt(state, channel?.id) || 0,
+        callStartAt: voiceChannelCallStartAt(state, channel?.id) || Number(window.callsClient?.initTime),
         callHostID: voiceChannelCallHostID(state, channel?.id) || '',
         callHostChangeAt: voiceChannelCallHostChangeAt(state, channel?.id) || 0,
         callRecording: callRecording(state, channel?.id),

--- a/webapp/src/components/call_widget/loading_overlay.tsx
+++ b/webapp/src/components/call_widget/loading_overlay.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled, {css} from 'styled-components';
+
+export type Props = {
+    visible: boolean,
+}
+
+export default function LoadingOverlay(props: Props) {
+    return (
+        <Container visible={props.visible}>
+            <Body>
+                <Spinner size={16}/>
+                <Text>{'Connecting to the call...'}</Text>
+            </Body>
+        </Container>
+    );
+}
+
+const Container = styled.div<{visible: boolean}>`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  border-radius: 4px;
+  z-index: 1;
+  background: rgba(var(--center-channel-bg-rgb), 0.7);
+
+  ${({visible}) => visible && css`
+      visibility: hidden;
+      opacity: 0;
+      transition: visibility 0s 0.3s, opacity 0.3s ease-out;
+  `}
+`;
+
+const Body = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Text = styled.span`
+  color: rgba(var(--center-channel-color-rgb), 0.84);
+  font-size: 12px;
+  line-height: 16px;
+  margin-left: 8px;
+  font-weight: 600;
+`;
+
+const Spinner = styled.span<{size: number}>`
+  width: ${({size}) => size}px;
+  height: ${({size}) => size}px;
+  border-radius: 50%;
+  display: inline-block;
+  border-top: 2px solid #166DE0;
+  border-right: 2px solid transparent;
+  box-sizing: border-box;
+  animation: spin 0.8s linear infinite;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;


### PR DESCRIPTION
#### Summary

To address some of the concerns in https://github.com/mattermost/mattermost-plugin-calls/pull/326 I thought of implementing a very basic connecting overlay to give the user some sort of feedback on the state of the call. 

This is not exactly as designed but the designs were not really updated and were considering showing a skeleton which I am not sure we need to since we are able to show the widget just fine. Here opting for a simple overlay on top with some opacity so that the widget is essentially unusable until connected (see video below). 

@tanmay-des Happy to review any of this of course, consider this an experimentation at this point.

#### Video

https://user-images.githubusercontent.com/1832946/217644923-cbab433e-0602-4949-a786-f5d6b9787a4b.mp4

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42429