### PR TITLE
[MM-50413] Fix addIceCandidate error due to potential race

### DIFF
--- a/webapp/src/rtcpeer/index.ts
+++ b/webapp/src/rtcpeer/index.ts
@@ -1,6 +1,6 @@
 import {EventEmitter} from 'events';
 
-import {logDebug} from '../log';
+import {logDebug, logErr} from '../log';
 
 import {
     RTCPeerConfig,
@@ -12,6 +12,7 @@ export default class RTCPeer extends EventEmitter {
     private pc: RTCPeerConnection | null;
     private senders: {[key: string]: RTCRtpSender};
     private makingOffer = false;
+    private candidates: RTCIceCandidate[] = [];
 
     constructor(config: RTCPeerConfig) {
         super();
@@ -95,7 +96,17 @@ export default class RTCPeer extends EventEmitter {
 
         switch (msg.type) {
         case 'candidate':
-            await this.pc.addIceCandidate(msg.candidate);
+            // It's possible that ICE candidates are received moments before
+            // we set the initial remote description which would cause an
+            // error. In such case we queue them up to be added later.
+            if (this.pc.remoteDescription && this.pc.remoteDescription.type) {
+                this.pc.addIceCandidate(msg.candidate).catch((err) => {
+                    logErr('failed to add candidate', err);
+                });
+            } else {
+                logDebug('received ice candidate before remote description, queuing...');
+                this.candidates.push(msg.candidate);
+            }
             break;
         case 'offer':
             await this.pc.setRemoteDescription(msg);
@@ -104,6 +115,12 @@ export default class RTCPeer extends EventEmitter {
             break;
         case 'answer':
             await this.pc.setRemoteDescription(msg);
+            for (const candidate of this.candidates) {
+                logDebug('adding queued ice candidate');
+                this.pc.addIceCandidate(candidate).catch((err) => {
+                    logErr('failed to add candidate', err);
+                });
+            }
             break;
         default:
             throw new Error('invalid signaling data received');


### PR DESCRIPTION
#### Summary

PR fixes a potential issue when ice candidates are received before a remote description is set. The workaround is to queue them up until we set the description.

@cpoile I believe the mobile side is potentially affected as well but thought that we may wait to share `RTCPeer` so we can stop duplicating every little fix. But let me know if you think that's too far in the future and if so I will create a PR on the other side.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50413