### PR TITLE
Update calls-recorder

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -136,6 +136,7 @@
         ]
     },
     "props": {
-        "min_rtcd_version": "v0.9.0"
+        "min_rtcd_version": "v0.9.0",
+        "calls_recorder_version": "v0.2.3"
     }
 }

--- a/server/activate.go
+++ b/server/activate.go
@@ -104,6 +104,14 @@ func (p *Plugin) OnActivate() error {
 			return err
 		}
 
+		recorderVersion, ok := manifest.Props["calls_recorder_version"].(string)
+		if !ok {
+			err = fmt.Errorf("failed to get recorder version from manifest")
+			p.LogError(err.Error())
+			return err
+		}
+		recordingJobRunner = "mattermost/calls-recorder:" + recorderVersion
+
 		go func() {
 			p.LogDebug("updating job runner")
 

--- a/server/job_service.go
+++ b/server/job_service.go
@@ -19,8 +19,9 @@ import (
 )
 
 const jobServiceConfigKey = "jobservice_config"
-const recordingJobRunner = "mattermost/calls-recorder:v0.2.2"
 const runnerUpdateLockTimeout = 2 * time.Minute
+
+var recordingJobRunner = ""
 
 type jobService struct {
 	ctx    *Plugin


### PR DESCRIPTION
#### Summary

PR updates the `calls-recorder` image to latest version (unreleased yet but working on it) `0.2.3`. To keep things cleaner I moved it to the manifest for a little easier updating.

