### PR TITLE
MM-42564 - Audio Output for Airpods shows two outputs

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1004,6 +1004,13 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
         const currentDevice = deviceType === 'input' ? this.state.currentAudioInputDevice : this.state.currentAudioOutputDevice;
 
+        const makeDeviceLabel = (device: MediaDeviceInfo) => {
+            if (device.deviceId.startsWith('default') && !device.label.startsWith('Default')) {
+                return `Default - ${device.label}`;
+            }
+            return device.label;
+        };
+
         const deviceList = devices.map((device) => {
             return (
                 <li
@@ -1022,7 +1029,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                                 width: '100%',
                             }}
                         >
-                            {device.label}
+                            {makeDeviceLabel(device)}
                         </span>
                     </button>
                 </li>

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1004,6 +1004,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
         const currentDevice = deviceType === 'input' ? this.state.currentAudioInputDevice : this.state.currentAudioOutputDevice;
 
+        // Note: this is system default, not the concept of default that we save in local storage in client.ts
         const makeDeviceLabel = (device: MediaDeviceInfo) => {
             if (device.deviceId.startsWith('default') && !device.label.startsWith('Default')) {
                 return `Default - ${device.label}`;


### PR DESCRIPTION
#### Summary
- Chrome is where this problem can happen: it returns default devices as a separate device. I don't think this is a problem, and is probably helpful (so the user knows that that particular device is their usual default). So, instead of deduping (they will have the same `groupId`), let's ensure that the default is labelled as default. In the ticket, this didn't happen, and that's where the confusion came from. But if it was labelled "Default - Airpods" and "Airpods", that would make sense. I think. What do you think?
  - Aside: while testing today, it always had the "Default - " prefix. Maybe that's a recent Chrome change, or I did something to cause the screenshot seen in the ticket. Either way, this will prevent that from happening again.
- Safari won't ever have this trouble, because it's unable to show outputs.
- Firefox requires a flag to be set to see outputs. Even If it's set, Firefox shouldn't have this problem because it doesn't distinguish between default and non-default in the enumeration, so there won't be a double counting.

- Added notes for our documentation: https://community.mattermost.com/private-core/pl/ekwjh8dmu3rtbg9ajtpmd79ygh

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-42564
