### PR TITLE
Fix load-test client from sending PLIs for voice tracks

### DIFF
--- a/lt/client.go
+++ b/lt/client.go
@@ -316,9 +316,11 @@ func (u *user) initRTC() error {
 	})
 
 	pc.OnTrack(func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
-		rtcpSendErr := pc.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(track.SSRC())}})
-		if rtcpSendErr != nil {
-			log.Printf(rtcpSendErr.Error())
+		if track.Kind() == webrtc.RTPCodecTypeVideo {
+			rtcpSendErr := pc.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(track.SSRC())}})
+			if rtcpSendErr != nil {
+				log.Printf(rtcpSendErr.Error())
+			}
 		}
 
 		codecName := strings.Split(track.Codec().RTPCodecCapability.MimeType, "/")[1]


### PR DESCRIPTION
#### Summary

As part of improving the simulation I added some code to send a picture-loss-indication when receiving a track, similarly to what a real client (e.g. browser) would do. However I forgot to add a check on the track type so now we are sending them out for audio tracks as well which doesn't make sense and also causes an error spam on the server side.