### PR TITLE
Mitigate some glare in load-test client

### DIFF
--- a/lt/client.go
+++ b/lt/client.go
@@ -416,6 +416,17 @@ func (u *user) handleSignal(ev *model.WebSocketEvent) {
 
 	} else if t == "offer" {
 		log.Printf("%s: sdp offer", u.cfg.username)
+
+		if u.pc.SignalingState() != webrtc.SignalingStateStable {
+			log.Printf("%s: signaling conflict on offer, queuing", u.cfg.username)
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				log.Printf("%s: applying previously queued offer", u.cfg.username)
+				u.handleSignal(ev)
+			}()
+			return
+		}
+
 		if err := u.pc.SetRemoteDescription(webrtc.SessionDescription{
 			Type: webrtc.SDPTypeOffer,
 			SDP:  data["sdp"].(string),


### PR DESCRIPTION
#### Summary

`pion` doesn't yet support the updated API that allows for perfect negotiation so we have to resort to some hack to mitigate the issue.

To fix the `SetRemoteDescription failed: InvalidModificationError: invalid proposed signaling state transition: have-local-offer->SetRemote(offer)->have-remote-offer` error we detect the conflict and queue the offer for later on.
