### PR TITLE
MM-48922 - Handle cloud upgrade event

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -425,22 +425,8 @@ func (p *Plugin) handleGetTURNCredentials(w http.ResponseWriter, r *http.Request
 // handleConfig returns the client configuration, and cloud license information
 // that isn't exposed to clients yet on the webapp
 func (p *Plugin) handleConfig(w http.ResponseWriter) error {
-	skuShortName := "starter"
-	license := p.pluginAPI.System.GetLicense()
-	if license != nil {
-		skuShortName = license.SkuShortName
-	}
-
-	type config struct {
-		clientConfig
-		SkuShortName string `json:"sku_short_name"`
-	}
-	ret := config{
-		clientConfig: p.getConfiguration().getClientConfig(),
-		SkuShortName: skuShortName,
-	}
-
 	w.Header().Set("Content-Type", "application/json")
+	ret := p.getClientConfiguration()
 	if err := json.NewEncoder(w).Encode(ret); err != nil {
 		return fmt.Errorf("error encoding config: %w", err)
 	}
@@ -563,6 +549,13 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 
 		if matches := callRecordingActionRE.FindStringSubmatch(r.URL.Path); len(matches) == 3 {
 			p.handleRecordingAction(w, r, matches[1], matches[2])
+			return
+		}
+
+		if r.URL.Path == "/cloud-license-changed" {
+			if err := p.handleCloudLicenseChanged(w); err != nil {
+				p.handleError(w, err)
+			}
 			return
 		}
 	}

--- a/server/cloud_limits.go
+++ b/server/cloud_limits.go
@@ -102,6 +102,15 @@ func (p *Plugin) handleCloudNotifyAdmins(w http.ResponseWriter, r *http.Request)
 	return nil
 }
 
+func (p *Plugin) handleCloudLicenseChanged(w http.ResponseWriter) error {
+	// Set the overrides and update the server side's configuration
+	if err := p.OnConfigurationChange(); err != nil {
+		p.pluginAPI.Log.Warn("tried to set new configuration", "error", err)
+	}
+
+	return p.handleConfig(w)
+}
+
 func (p *Plugin) getSystemBotID() (string, error) {
 	botID, err := p.pluginAPI.Bot.EnsureBot(&model.Bot{
 		Username:    model.BotSystemBotUsername,

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"github.com/mattermost/mattermost-server/v6/model"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -72,22 +71,4 @@ func TestPortsRangeIsValid(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGetClientConfig(t *testing.T) {
-	cfg := &configuration{}
-	cfg.SetDefaults()
-	clientCfg := cfg.getClientConfig()
-
-	// defaults
-	require.Equal(t, model.NewBool(true), clientCfg.AllowEnableCalls)
-	require.Equal(t, cfg.AllowEnableCalls, clientCfg.AllowEnableCalls)
-	require.Equal(t, model.NewBool(false), clientCfg.DefaultEnabled)
-	require.Equal(t, cfg.DefaultEnabled, clientCfg.DefaultEnabled)
-
-	*cfg.AllowEnableCalls = false
-	*cfg.DefaultEnabled = true
-	clientCfg = cfg.getClientConfig()
-	require.Equal(t, true, *clientCfg.AllowEnableCalls)
-	require.Equal(t, cfg.DefaultEnabled, clientCfg.DefaultEnabled)
 }

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -98,6 +98,16 @@ export const getCallsConfig = (): ActionFunc => {
     });
 };
 
+export const postLicenseChanged = (): ActionFunc => {
+    return bindClientFunc({
+        clientFunc: () => Client4.doFetch<CallsConfig>(
+            `${getPluginPath()}/cloud-license-changed`,
+            {method: 'post'},
+        ),
+        onSuccess: [RECEIVED_CALLS_CONFIG],
+    });
+};
+
 export const notifyAdminCloudFreeTrial = async () => {
     return Client4.doFetch(
         `${getPluginPath()}/cloud-notify-admins`,

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -11,6 +11,7 @@ import {getCurrentUserId, getUser, isCurrentUserSystemAdmin} from 'mattermost-re
 import {getChannel as getChannelAction} from 'mattermost-redux/actions/channels';
 import {getProfilesByIds as getProfilesByIdsAction} from 'mattermost-redux/actions/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import WebsocketEvents from 'mattermost-redux/constants/websocket';
 
 import {
     displayFreeTrial,
@@ -53,6 +54,7 @@ import {
     handleUserReaction,
     handleCallHostChanged,
     handleCallRecordingState,
+    handleLicenseChanged,
 } from './websocket_handlers';
 
 import {
@@ -214,6 +216,10 @@ export default class Plugin {
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_call_recording_state`, (ev) => {
             handleCallRecordingState(store, ev);
+        });
+
+        registry.registerWebSocketEventHandler(WebsocketEvents.LICENSE_CHANGED, () => {
+            handleLicenseChanged(store);
         });
     }
 

--- a/webapp/src/websocket_handlers.ts
+++ b/webapp/src/websocket_handlers.ts
@@ -13,6 +13,8 @@ import {
 } from 'src/types/types';
 import {REACTION_TIMEOUT_IN_REACTION_STREAM} from 'src/constants';
 
+import {postLicenseChanged} from 'src/actions';
+
 import {Store} from './types/mattermost-webapp';
 import {
     VOICE_CHANNEL_USER_MUTED,
@@ -287,4 +289,8 @@ export function handleCallRecordingState(store: Store, ev: WebSocketMessage<Call
             recState: ev.data.recState,
         },
     });
+}
+
+export function handleLicenseChanged(store: Store) {
+    store.dispatch(postLicenseChanged());
 }


### PR DESCRIPTION
#### Summary
- Refactored the client config
- Send a websocket event to all clients when the cloud limits are changed (very rare event)
- This will update the cloud limits on both the client and server

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-48922
