### PR TITLE
[MM-46696] Surface screen permissions error coming from global widget desktop window

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
     workers: 4,
     timeout: 30 * 1000,
     expect: {
-        timeout: 10 * 1000,
+        timeout: 20 * 1000,
         toMatchSnapshot: {
             maxDiffPixelRatio: 0.05,
         },

--- a/standalone/src/widget/index.tsx
+++ b/standalone/src/widget/index.tsx
@@ -47,9 +47,6 @@ async function initWidget(store: Store, theme: Theme, channelID: string) {
         case 'register-desktop':
             window.desktop = ev.data.message;
             break;
-        case 'calls-widget-share-screen':
-            window.callsClient?.shareScreen(ev.data.message.sourceID, ev.data.message.withAudio);
-            break;
         }
     });
     sendDesktopEvent('get-app-version');

--- a/webapp/src/components/screen_source_modal/component.tsx
+++ b/webapp/src/components/screen_source_modal/component.tsx
@@ -191,6 +191,10 @@ export default class ScreenSourceModal extends React.PureComponent<Props, State>
     }
 
     handleDesktopCapturerMessage = (event: MessageEvent) => {
+        if (event.origin !== window.origin) {
+            return;
+        }
+
         if (event.data.type !== 'desktop-sources-result') {
             return;
         }


### PR DESCRIPTION
#### Summary

PR adds some logic to handle screen permissions error coming from the desktop side so that they get surfaced to the user same as on web.

#### Related PR

https://github.com/mattermost/desktop/pull/2554

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46696
