### PR TITLE
Handle screen permissions error to hide component

### DIFF
--- a/webapp/src/components/screen_source_modal/component.tsx
+++ b/webapp/src/components/screen_source_modal/component.tsx
@@ -167,14 +167,14 @@ export default class ScreenSourceModal extends React.PureComponent<Props, State>
         document.addEventListener('keyup', this.keyboardClose, true);
         document.addEventListener('click', this.closeOnBlur, true);
 
-        window.addEventListener('message', this.handleDesktopCapturerMessage);
+        window.addEventListener('message', this.handleDesktopEvents);
     }
 
     componentWillUnmount() {
         document.removeEventListener('keyup', this.keyboardClose, true);
         document.removeEventListener('click', this.closeOnBlur, true);
 
-        window.removeEventListener('message', this.handleDesktopCapturerMessage);
+        window.removeEventListener('message', this.handleDesktopEvents);
     }
 
     componentDidUpdate(prevProps: Props) {
@@ -190,18 +190,18 @@ export default class ScreenSourceModal extends React.PureComponent<Props, State>
         }
     }
 
-    handleDesktopCapturerMessage = (event: MessageEvent) => {
-        if (event.origin !== window.origin) {
+    handleDesktopEvents = (ev: MessageEvent) => {
+        if (ev.origin !== window.origin) {
             return;
         }
 
-        if (event.data.type === 'desktop-sources-result') {
-            const sources = event.data.message;
+        if (ev.data.type === 'desktop-sources-result') {
+            const sources = ev.data.message;
             this.setState({
                 sources,
                 selected: sources[0]?.id || '',
             });
-        } else if (event.data.type === 'calls-error' && event.data.message.err === 'screen-permissions') {
+        } else if (ev.data.type === 'calls-error' && ev.data.message.err === 'screen-permissions') {
             this.props.hideScreenSourceModal();
         }
     };

--- a/webapp/src/components/screen_source_modal/component.tsx
+++ b/webapp/src/components/screen_source_modal/component.tsx
@@ -195,15 +195,15 @@ export default class ScreenSourceModal extends React.PureComponent<Props, State>
             return;
         }
 
-        if (event.data.type !== 'desktop-sources-result') {
-            return;
+        if (event.data.type === 'desktop-sources-result') {
+            const sources = event.data.message;
+            this.setState({
+                sources,
+                selected: sources[0]?.id || '',
+            });
+        } else if (event.data.type === 'calls-error' && event.data.message.err === 'screen-permissions') {
+            this.props.hideScreenSourceModal();
         }
-
-        const sources = event.data.message;
-        this.setState({
-            sources,
-            selected: sources[0]?.id || '',
-        });
     };
 
     render() {


### PR DESCRIPTION
#### Summary

There was an issue in handling the request from the desktop side in the `ScreenSourceModal` component since in case of an error we wouldn't show the modal but its state would still be open. Handling the error fixes this so that if users hide the "no permissions" banner and try again to share they will get it again, as expected.

To note, I think we should be changing the error message if we are on desktop since the "cancelled" part doesn't apply there. 

#### Related PR

https://github.com/mattermost/desktop/pull/2556


