### PR TITLE
[MM-49089] Propagate blocking errors to desktop

### DIFF
--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -99,7 +99,7 @@ function connectCall(
     wsURL: string,
     iceConfigs: RTCIceServer[],
     wsEventHandler: (ev: WebSocketMessage<WebsocketEventData>) => void,
-    closeCb?: () => void,
+    closeCb?: (err?: Error) => void,
 ) {
     try {
         if (window.callsClient) {
@@ -113,9 +113,9 @@ function connectCall(
             authToken: getToken(),
         });
 
-        window.callsClient.on('close', () => {
+        window.callsClient.on('close', (err?: Error) => {
             if (closeCb) {
-                closeCb();
+                closeCb(err);
             }
         });
 
@@ -124,7 +124,7 @@ function connectCall(
         }).catch((err: Error) => {
             logErr(err);
             if (closeCb) {
-                closeCb();
+                closeCb(err);
             }
         });
     } catch (err) {

--- a/standalone/src/widget/index.tsx
+++ b/standalone/src/widget/index.tsx
@@ -79,8 +79,16 @@ async function initStoreWidget(store: Store, channelID: string) {
     }
 }
 
-function deinitWidget() {
+function deinitWidget(err?: Error) {
     playSound('leave_self');
+
+    if (err) {
+        sendDesktopEvent('calls-error', {
+            err: 'client-error',
+            callID: window.callsClient?.channelID,
+            errMsg: err.message,
+        });
+    }
 
     // Using setTimeout to give the app enough time to play the sound before
     // closing the widget window.
@@ -93,7 +101,7 @@ function deinitWidget() {
         }
         logDebug('sending leave call message to desktop app');
         sendDesktopEvent('calls-leave-call');
-    }, 200);
+    }, 250);
 }
 
 init({

--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -36,7 +36,5 @@ export const RECEIVED_CALLS_CONFIG = pluginId + '_received_calls_config';
 export const RECEIVED_CHANNEL_STATE = pluginId + 'received_channel_state';
 export const RECEIVED_CALLS_USER_PREFERENCES = pluginId + '_received_calls_user_preferences';
 
-export const RECEIVED_CLIENT_ERROR = pluginId + '_received_client_error';
-
 export const DESKTOP_WIDGET_CONNECTED = pluginId + '_desktop_widget_connected';
 

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -39,7 +39,6 @@ import {
     HIDE_SCREEN_SOURCE_MODAL,
     HIDE_END_CALL_MODAL,
     RECEIVED_CALLS_CONFIG,
-    RECEIVED_CLIENT_ERROR,
     VOICE_CHANNEL_CALL_RECORDING_STATE,
 } from './action_types';
 
@@ -163,24 +162,14 @@ export const endCall = (channelID: string) => {
 };
 
 export const displayCallErrorModal = (channelID: string, err: Error) => (dispatch: Dispatch<GenericAction>) => {
-    dispatch({
-        type: RECEIVED_CLIENT_ERROR,
-        data: {
-            channelID,
-            err,
-        },
-    });
     dispatch(modals.openModal({
         modalId: CallErrorModalID,
         dialogType: CallErrorModal,
+        dialogProps: {
+            channelID,
+            err,
+        },
     }));
-};
-
-export const clearClientError = () => (dispatch: Dispatch<GenericAction>) => {
-    dispatch({
-        type: RECEIVED_CLIENT_ERROR,
-        data: null,
-    });
 };
 
 export const trackEvent = (event: Telemetry.Event, source: Telemetry.Source, props?: Record<string, string>) => {

--- a/webapp/src/components/call_error_modal.tsx
+++ b/webapp/src/components/call_error_modal.tsx
@@ -46,10 +46,18 @@ export const CallErrorModal = (props: Props) => {
         return null;
     };
 
+    const onTroubleShootingClick = (ev: React.MouseEvent) => {
+        ev.preventDefault();
+        window.open('https://docs.mattermost.com/channels/make-calls.html#troubleshooting', '_blank');
+    };
+
     const troubleShootingMsg = (
         <React.Fragment>
             {' Check the '}
-            <a href='https://docs.mattermost.com/channels/make-calls.html#troubleshooting'>{'troubleshooting section'}</a>
+            <a
+                href='https://docs.mattermost.com/channels/make-calls.html#troubleshooting'
+                onClick={onTroubleShootingClick}
+            >{'troubleshooting section'}</a>
             {' if the problem persists.'}
         </React.Fragment>
     );

--- a/webapp/src/components/call_error_modal.tsx
+++ b/webapp/src/components/call_error_modal.tsx
@@ -34,6 +34,9 @@ export const CallErrorModal = (props: Props) => {
     const onRejoinClick = (ev: React.MouseEvent) => {
         ev.preventDefault();
         window.postMessage({type: 'connectCall', channelID: props.channelID}, window.origin);
+        if (props.onHide) {
+            props.onHide();
+        }
     };
 
     const onConfirm = () => {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -599,6 +599,8 @@ export default class Plugin {
                     type: DESKTOP_WIDGET_CONNECTED,
                     data: {channelID: ev.data.message.callID},
                 });
+            } else if (ev.data?.type === 'calls-error' && ev.data.message.err === 'client-error') {
+                store.dispatch(displayCallErrorModal(ev.data.message.channelID, new Error(ev.data.message.errMsg)));
             }
         };
         window.addEventListener('message', windowEventHandler);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -600,7 +600,7 @@ export default class Plugin {
                     data: {channelID: ev.data.message.callID},
                 });
             } else if (ev.data?.type === 'calls-error' && ev.data.message.err === 'client-error') {
-                store.dispatch(displayCallErrorModal(ev.data.message.channelID, new Error(ev.data.message.errMsg)));
+                store.dispatch(displayCallErrorModal(ev.data.message.callID, new Error(ev.data.message.errMsg)));
             }
         };
         window.addEventListener('message', windowEventHandler);

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -47,7 +47,6 @@ import {
     HIDE_END_CALL_MODAL,
     RECEIVED_CHANNEL_STATE,
     RECEIVED_CALLS_USER_PREFERENCES,
-    RECEIVED_CLIENT_ERROR,
     DESKTOP_WIDGET_CONNECTED,
     VOICE_CHANNEL_USER_REACTED,
     VOICE_CHANNEL_USER_REACTED_TIMEOUT,
@@ -681,20 +680,6 @@ const callsUserPreferences = (state = CallsUserPreferencesDefault, action: { typ
     }
 };
 
-type clientError = {
-    channelID: string,
-    err: Error,
-}
-
-const clientErr = (state = null, action: { type: string, data: clientError }) => {
-    switch (action.type) {
-    case RECEIVED_CLIENT_ERROR:
-        return action.data;
-    default:
-        return state;
-    }
-};
-
 export default combineReducers({
     channelState,
     voiceConnectedChannels,
@@ -711,6 +696,5 @@ export default combineReducers({
     voiceChannelRootPost,
     callsConfig,
     callsUserPreferences,
-    clientErr,
     callsRecordings,
 });

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -267,8 +267,6 @@ export const callsUserPreferences = (state: GlobalState): CallsUserPreferences =
 export const shouldPlayJoinUserSound = (state: GlobalState): boolean =>
     numUsersInConnectedChannel(state) < callsUserPreferences(state).joinSoundParticipantsThreshold;
 
-export const getClientError = (state: GlobalState) => pluginState(state).clientErr;
-
 export const isOnPremNotEnterprise = (state: GlobalState): boolean => {
     const license = getLicense(state);
     const enterprise = license.SkuShortName === LicenseSkus.E20 || license.SkuShortName === LicenseSkus.Enterprise;


### PR DESCRIPTION
#### Summary

PR adds some logic to propagate client blocking errors (e.g. connection failures) to the desktop side since the global widget window gets closed immediately but we want to show a modal. I also took the opportunity to simplify a bit. I was originally storing the client error because I was unaware we could pass props to the modal but this is much cleaner.

#### Related PR

https://github.com/mattermost/desktop/pull/2557

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49089
