### PR TITLE
MM-49079 - Fix desktop links

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -167,7 +167,8 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             callsClient?.on('close', () => window.close());
 
             // don't allow navigation in expanded window e.g. permalinks in rhs
-            this.#unlockNavigation = props.history.block(() => {
+            this.#unlockNavigation = props.history.block((tx) => {
+                sendDesktopEvent('calls-link-click', {link: tx.pathname});
                 return false;
             });
         } else if (window.desktop) {


### PR DESCRIPTION
#### Summary
- Previously, clicking links in the RHS of the desktop popout did two things:
  - For internal links, nothing happened.
  - For external links, a new electron window would open:

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/1490756/219688522-2dde743f-bf31-4978-babc-1b01ba143f52.png">

- Now (with https://github.com/mattermost/desktop/pull/2558) the links are handled completely by the Desktop app.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-49079
