### PR TITLE
[MM-50541] Limit screen thumbnail height

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -775,7 +775,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     style={this.style.screenSharingPanel as CSSProperties}
                 >
                     <div
-                        style={{position: 'relative', width: '80%', background: '#C4C4C4'}}
+                        style={{position: 'relative', width: '80%', maxHeight: '188px', background: '#C4C4C4'}}
                     >
                         <video
                             id='screen-player'


### PR DESCRIPTION
#### Summary

It doesn't make sense to let the thumbnail grow indefinitely in height as it ends up covering more of Mattermost.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50541