### PR TITLE
[MM-50751] Fix race condition attaching media tracks on join

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -321,7 +321,43 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         }
     }
 
+    private attachVoiceTracks(tracks: MediaStreamTrack[]) {
+        const audioEls = [];
+        for (const track of tracks) {
+            const audioEl = document.createElement('audio');
+            audioEl.srcObject = new MediaStream([track]);
+            audioEl.controls = false;
+            audioEl.autoplay = true;
+            audioEl.style.display = 'none';
+            audioEl.onerror = (err) => logErr(err);
+            audioEl.id = track.id;
+
+            const deviceID = window.callsClient?.currentAudioOutputDevice?.deviceId;
+            if (deviceID) {
+                // @ts-ignore - setSinkId is an experimental feature
+                audioEl.setSinkId(deviceID);
+            }
+
+            document.body.appendChild(audioEl);
+            track.onended = () => {
+                audioEl.srcObject = null;
+                audioEl.remove();
+            };
+
+            audioEls.push(audioEl);
+        }
+
+        this.setState({
+            audioEls: [...this.state.audioEls, ...audioEls],
+        });
+    }
+
     public componentDidMount() {
+        if (!window.callsClient) {
+            logErr('callsClient should be defined');
+            return;
+        }
+
         if (this.props.global) {
             window.visualViewport.addEventListener('resize', this.onViewportResize);
             this.menuResizeObserver = new ResizeObserver(this.sendGlobalWidgetBounds);
@@ -349,40 +385,22 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             });
         }, 5000);
 
-        window.callsClient?.on('remoteVoiceStream', (stream: MediaStream) => {
-            const voiceTrack = stream.getAudioTracks()[0];
-            const audioEl = document.createElement('audio');
-            audioEl.srcObject = stream;
-            audioEl.controls = false;
-            audioEl.autoplay = true;
-            audioEl.style.display = 'none';
-            audioEl.onerror = (err) => logErr(err);
-            audioEl.id = voiceTrack.id;
-
-            const deviceID = window.callsClient?.currentAudioOutputDevice?.deviceId;
-            if (deviceID) {
-                // @ts-ignore - setSinkId is an experimental feature
-                audioEl.setSinkId(deviceID);
-            }
-
-            this.setState({
-                audioEls: [...this.state.audioEls, audioEl],
-            });
-
-            document.body.appendChild(audioEl);
-            voiceTrack.onended = () => {
-                audioEl.srcObject = null;
-                audioEl.remove();
-            };
+        this.attachVoiceTracks(window.callsClient.getRemoteVoiceTracks());
+        window.callsClient.on('remoteVoiceStream', (stream: MediaStream) => {
+            this.attachVoiceTracks(stream.getAudioTracks());
         });
 
-        window.callsClient?.on('remoteScreenStream', (stream: MediaStream) => {
+        // eslint-disable-next-line react/no-did-mount-set-state
+        this.setState({
+            screenStream: window.callsClient.getRemoteScreenStream(),
+        });
+        window.callsClient.on('remoteScreenStream', (stream: MediaStream) => {
             this.setState({
                 screenStream: stream,
             });
         });
 
-        window.callsClient?.on('devicechange', (devices: AudioDevices) => {
+        window.callsClient.on('devicechange', (devices: AudioDevices) => {
             this.setState({
                 devices,
                 alerts: {
@@ -396,7 +414,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             });
         });
 
-        window.callsClient?.on('connect', () => {
+        window.callsClient.on('connect', () => {
             this.setState({connecting: false});
 
             if (this.props.global) {
@@ -413,7 +431,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             this.setState({currentAudioOutputDevice: window.callsClient?.currentAudioOutputDevice});
         });
 
-        window.callsClient?.on('error', (err: Error) => {
+        window.callsClient.on('error', (err: Error) => {
             if (err === AudioInputPermissionsError) {
                 this.setState({
                     alerts: {
@@ -427,7 +445,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             }
         });
 
-        window.callsClient?.on('initaudio', () => {
+        window.callsClient.on('initaudio', () => {
             this.setState({
                 alerts: {
                     ...this.state.alerts,


### PR DESCRIPTION
#### Summary

This was an interesting one given I could never reproduce the issue on my end, neither locally nor when connecting on remote instances.

The bug has been there for a long time as I remember first encountering this on a Community recording a few months ago. Something in the recorder setup made it more likely to reproduce. In fact, I was finally able to do this earlier today through a quick load-test on Community.

The problem was that we are registering the media track events handler(s) when mounting the component (both widget and recording view) but any delay in doing so could mean events firing before we get a chance to listen and tracks getting "lost", or better, never attached to the document, hence never played. To fix this, before listening on the track events we also check for existing available tracks and attach them accordingly.

Thanks to @hanzei for raising this issue. I was almost convinced it was a Chromium bug after the previous failed attempts at reproducing this but indeed, as often is the case, it was an issue on our end.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50751