### PR TITLE
[MM-50990] Fix potential rtcd client leak

### DIFF
--- a/server/rtcd.go
+++ b/server/rtcd.go
@@ -324,7 +324,8 @@ func (m *rtcdClientManager) versionCheck(client *rtcd.Client) error {
 	}
 
 	// Always support dev builds.
-	if info.BuildVersion == "" || strings.HasPrefix(info.BuildVersion, "dev") {
+	if info.BuildVersion == "" || info.BuildVersion == "master" || strings.HasPrefix(info.BuildVersion, "dev") {
+		m.ctx.LogInfo("skipping version compatibility check", "buildVersion", info.BuildVersion)
 		return nil
 	}
 


### PR DESCRIPTION
#### Summary

PR fixes a couple of issues, main one being that failing the min version check didn't properly close the client. This was totally fine if the attempt happened during plugin startup because we would error out on activation and essentially stop the plugin. But if `rtcd` instances were to be updated with a *live* plugin the reconnect logic would go ahead and continuously fail the version check and leak a new client on each attempt. On Community today we reached 750 ws clients due to this "misbehaviour".

And the reason this issue originally triggered was that the build version was not one of the accepted ones. We were testing latest changes which resulted in the build version being `master` but we would only skip the check for either empty strings or those starting with `dev`. 

Finally, the last commit in here improves a bit the case of reconnecting to a flagged/missing host. There's no point in continuing the process if the host is not resolvable any longer so we abort as soon as that happens.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50990
