### PR TITLE
[MM-51288] Surface recording errors if happening after first dismissal

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -220,6 +220,7 @@ export const startCallRecording = (callID: string) => (dispatch: Dispatch<Generi
                     start_at: 0,
                     end_at: 0,
                     err: err.message,
+                    error_at: Date.now(),
                 },
             },
         });

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1372,9 +1372,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         }
 
         // If the prompt was dismissed after the recording has started and after the last host change
-        // we don't show this again.
+        // we don't show this again, unless there was a more recent error.
         if (!hasRecEnded && dismissedAt > recording?.start_at && dismissedAt > this.props.callHostChangeAt) {
-            return null;
+            if (!recording?.error_at || dismissedAt > recording.error_at) {
+                return null;
+            }
         }
 
         // If the prompt was dismissed after the recording has ended then we

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -94,9 +94,11 @@ export default function RecordingInfoPrompt(props: Props) {
     }
 
     // If the prompt was dismissed after the recording has started and after the last host change
-    // we don't show this again.
+    // we don't show this again, unless there was a more recent error.
     if (!hasRecEnded && dismissedAt > props.recording?.start_at && dismissedAt > props.hostChangeAt) {
-        return null;
+        if (!props.recording?.error_at || dismissedAt > props.recording.error_at) {
+            return null;
+        }
     }
 
     // If the prompt was dismissed after the recording has ended then we

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -521,6 +521,7 @@ type callRecordingStateAction = {
 const callsRecordings = (state: {[callID: string]: CallRecordingState} = {}, action: callRecordingStateAction) => {
     switch (action.type) {
     case VOICE_CHANNEL_UNINIT:
+    case VOICE_CHANNEL_USER_DISCONNECTED:
         return {};
     case VOICE_CHANNEL_CALL_RECORDING_STATE:
         return {

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -70,6 +70,7 @@ export type CallRecordingState = {
     start_at: number,
     end_at: number,
     err?: string,
+    error_at?: number,
 } & BaseData
 
 export type CallRecordingStateData = {

--- a/webapp/src/websocket_handlers.ts
+++ b/webapp/src/websocket_handlers.ts
@@ -280,6 +280,10 @@ export function handleCallHostChanged(store: Store, ev: WebSocketMessage<CallHos
 }
 
 export function handleCallRecordingState(store: Store, ev: WebSocketMessage<CallRecordingStateData>) {
+    if (ev.data.recState.err) {
+        ev.data.recState.error_at = Date.now();
+    }
+
     store.dispatch({
         type: VOICE_CHANNEL_CALL_RECORDING_STATE,
         data: {


### PR DESCRIPTION
#### Summary

PR fixes a couple of issues with recordings info prompts:

1. In case of error starting the call, if the banner was dismissed once, any successive attempt to start a call would not show anything in case of error.
2. Not clearing the recording state on disconnect made it so that if a prompt was shown before leaving a call it would briefly reappear (almost like a flicker) on joining a new call. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51288
