### PR TITLE
MM-51226 - Mobile: Emojis not showing in reaction stream

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -153,6 +153,7 @@ type EmojiData struct {
 	Name    string `json:"name"`
 	Skin    string `json:"skin,omitempty"`
 	Unified string `json:"unified"`
+	Literal string `json:"literal,omitempty"`
 }
 
 func (ed EmojiData) toMap() map[string]interface{} {
@@ -160,6 +161,7 @@ func (ed EmojiData) toMap() map[string]interface{} {
 		"name":    ed.Name,
 		"skin":    ed.Skin,
 		"unified": ed.Unified,
+		"literal": ed.Literal,
 	}
 }
 

--- a/webapp/src/components/expanded_view/reaction_button.tsx
+++ b/webapp/src/components/expanded_view/reaction_button.tsx
@@ -52,8 +52,9 @@ export const ReactionButton = forwardRef(({trackEvent}: Props, ref) => {
     const addReactionText = showBar ? 'Close Reactions' : 'Add Reaction';
 
     const handleUserPicksEmoji = (ecd: EmojiClickData) => {
+        const name = ecd.names.length > 0 ? ecd.names[0] : '';
         const emojiData: EmojiData = {
-            name: ecd.names[0].replaceAll(' ', '_'),
+            name: name.replaceAll(' ', '_'),
             skin: ecd.activeSkinTone,
             unified: ecd.unified.toLowerCase(),
             literal: ecd.emoji || '',

--- a/webapp/src/components/expanded_view/reaction_button.tsx
+++ b/webapp/src/components/expanded_view/reaction_button.tsx
@@ -53,9 +53,10 @@ export const ReactionButton = forwardRef(({trackEvent}: Props, ref) => {
 
     const handleUserPicksEmoji = (ecd: EmojiClickData) => {
         const emojiData: EmojiData = {
-            name: ecd.emoji,
+            name: ecd.names[0].replaceAll(' ', '_'),
             skin: ecd.activeSkinTone,
-            unified: ecd.unified.toUpperCase(),
+            unified: ecd.unified.toLowerCase(),
+            literal: ecd.emoji || '',
         };
         callsClient?.sendUserReaction(emojiData);
     };
@@ -182,7 +183,7 @@ interface QuickSelectProps {
 
 const QuickSelect = ({emoji, handleClick}: QuickSelectProps) => {
     const onClick = () => {
-        handleClick({emoji: emoji.name, unified: emoji.unified} as EmojiClickData);
+        handleClick({names: [emoji.name], unified: emoji.unified} as EmojiClickData);
     };
 
     return (

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -51,8 +51,9 @@ export type UserRaiseUnraiseHandData = {
 
 export type EmojiData = {
     name: string;
-    skin?: string;
     unified: string;
+    skin?: string;
+    literal?: string;
 } & BaseData
 
 export type UserReactionData = {


### PR DESCRIPTION
#### Summary
- The change to `emoji-picker-react` changed the emoji names a bit, and some emojis are not in the emoji name map on the mobile side. So, replace spaces in the names with underscores, and send the emoji literal string in case the map doesn't have the emoji name.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51226
