### PR TITLE
MM-51007 - Fix: CSS raise hand z-index incorrect

### DIFF
--- a/webapp/src/components/reaction_stream/reaction_stream.tsx
+++ b/webapp/src/components/reaction_stream/reaction_stream.tsx
@@ -105,6 +105,7 @@ const ReactionStreamList = styled.div<streamListStyleProps>`
     height: 75vh;
     display: flex;
     flex-direction: column-reverse;
+    z-index: 1;
     margin-left: 10px;
     -webkit-mask: -webkit-gradient(#0000, #000);
     mask: linear-gradient(#0000, #0003, #000f);


### PR DESCRIPTION
#### Summary
- Simple fix

<img width="612" alt="image" src="https://user-images.githubusercontent.com/1490756/224137057-67e78580-ab59-43b7-9a8c-5b015b448664.png">

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51007
