### PR TITLE
[MM-51322] Add fallback logic for disconnected presenter

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -286,6 +286,12 @@ func (p *Plugin) removeSession(us *session) error {
 		p.publishWebSocketEvent(wsEventUserDisconnected, map[string]interface{}{
 			"userID": us.userID,
 		}, &model.WebsocketBroadcast{ChannelId: us.channelID, ReliableClusterSend: true})
+
+		// If the removed user was sharing we should send out a screen off event.
+		if prevState.Call.ScreenSharingID != "" && (currState.Call == nil || currState.Call.ScreenSharingID == "") {
+			p.LogDebug("removed session was sharing, sending screen off event", "userID", us.userID, "connID", us.connID)
+			p.publishWebSocketEvent(wsEventUserScreenOff, map[string]interface{}{}, &model.WebsocketBroadcast{ChannelId: us.channelID, ReliableClusterSend: true})
+		}
 	}
 
 	// Checking if the host has changed.

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -427,8 +427,6 @@ func (p *Plugin) handleLeave(us *session, userID, connID, channelID string) erro
 	state, err := p.kvGetChannelState(channelID)
 	if err != nil {
 		return err
-	} else if state != nil && state.Call != nil && state.Call.ScreenSharingID == userID {
-		p.publishWebSocketEvent(wsEventUserScreenOff, map[string]interface{}{}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
 	}
 
 	handlerID, err := p.getHandlerID()

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -596,6 +596,14 @@ const voiceChannelScreenSharingID = (state: { [channelID: string]: string } = {}
             ...state,
             [action.data.channelID]: action.data.userID,
         };
+    case VOICE_CHANNEL_USER_DISCONNECTED: {
+        // If the user who disconnected matches the one sharing we
+        // want to fallthrough and clear the state.
+        if (action.data.userID !== state[action.data.channelID]) {
+            return state;
+        }
+    }
+    // eslint-disable-next-line no-fallthrough
     case VOICE_CHANNEL_CALL_END:
     case VOICE_CHANNEL_USER_SCREEN_OFF:
         return {


### PR DESCRIPTION
#### Summary

@cpoile I looked at logs and there's nothing suggesting the event wasn't sent so I must assume it either got lost somehow or your client didn't receive it for some unrelated reason. I moved the server side logic to a better place but other than that nothing has changed on that side.

I am opting for adding a fallback on the client since we can safely assume that a disconnection means the screen sharing state should be cleared. That said, if websocket events are failing to get to clients, we clearly have more serious problems to deal with.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51322
