### PR TITLE
[MM-51405] Fix bad alignment of file recordings icon

### DIFF
--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -70,7 +70,10 @@ const PostType = ({
     const recordingsSubMessage = recordings > 0 ? (
         <>
             <Divider>{untranslatable('•')}</Divider>
-            <CompassIcon icon='file-video-outline'/>
+            <CompassIcon
+                icon='file-video-outline'
+                style={{display: 'inline'}}
+            />
             <span>{formatMessage({defaultMessage: '{count, plural, =1 {# recording} other {# recordings}} available'}, {count: recordings})}</span>
         </>
     ) : null;


### PR DESCRIPTION
#### Summary

Compass icons striking again...this time I couldn't reproduce this outside of Community, even loading the same webapp version so maybe there's something else loading overriding definitions. Either way the problem is that on Community we have a `.CompassIcon` class changing the display to `flex` which causes the element to incorrectly wrap. 

![image](https://user-images.githubusercontent.com/1832946/225141213-014198cc-c9f2-4dca-8f56-9fff23ff638b.png)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51405