### PR TITLE
MM-49663 - Prevent race condition between starting and joining

### DIFF
--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -43,6 +43,7 @@ type callState struct {
 	RTCDHost        string                `json:"rtcd_host"`
 	HostID          string                `json:"host_id"`
 	Recording       *recordingState       `json:"recording,omitempty"`
+	StartComplete   bool                  `json:"start_complete"`
 }
 
 type channelState struct {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -533,6 +533,10 @@ func (p *Plugin) handleJoin(userID, connID, channelID, title, threadID string) e
 			"owner_id":  state.Call.OwnerID,
 			"host_id":   state.Call.HostID,
 		}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
+
+		if err := p.callStartComplete(channelID); err != nil {
+			return err
+		}
 	}
 
 	handlerID, err := p.getHandlerID()


### PR DESCRIPTION
#### Summary
- Every so often on mobile you can make one of the clients fail to set it's UI correctly by pressing the `Join Call` at the same time on two devices. Turns out, this was finding a race on the server where:
  - User A joins call
  - User A creates a call
  - User B joins call
  - User B sends `user_connected` event
  - User A sends `call_started` event
- Which messes up the logic on the mobile side. I could have fixed it on the client side, but this is much more robust I think.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-49663