### PR TITLE
[MM-51500] Use correct channelID when setting profile pictures in store

### DIFF
--- a/standalone/src/recording/index.tsx
+++ b/standalone/src/recording/index.tsx
@@ -120,7 +120,7 @@ async function wsHandlerRecording(store: Store, ev: WebSocketMessage<WebsocketEv
         store.dispatch({
             type: RECEIVED_CALL_PROFILE_IMAGES,
             data: {
-                channelID: ev.broadcast.channel_id,
+                channelID: ev.data.channelID,
                 profileImages: await fetchProfileImages(profiles),
             },
         });


### PR DESCRIPTION
#### Summary

Not the first time this hit me. The events sent to the bot are not broadcasted for obvious reasons so the channelID will be sent as part of the data. Profile pictures were failing to get stored properly and the component wouldn't render, causing the weird behaviour.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51500
