### PR TITLE
Remove unnecessary mount

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -391,10 +391,21 @@ export default class Plugin {
                     iceServers: iceConfigs,
                 });
                 const globalComponentID = registry.registerGlobalComponent(CallWidget);
-                const rootComponentID = registry.registerRootComponent(injectIntl(ExpandedView));
+
+                // DEPRECATED
+                let rootComponentID: string;
+
+                // This is only needed to support desktop versions < 5.3 that
+                // didn't implement the global widget and mounted the expanded view
+                // on top of the center channel view.
+                if (window.desktop) {
+                    rootComponentID = registry.registerRootComponent(injectIntl(ExpandedView));
+                }
                 window.callsClient.on('close', (err?: Error) => {
                     registry.unregisterComponent(globalComponentID);
-                    registry.unregisterComponent(rootComponentID);
+                    if (window.desktop) {
+                        registry.unregisterComponent(rootComponentID);
+                    }
                     if (window.callsClient) {
                         if (err) {
                             store.dispatch(displayCallErrorModal(window.callsClient.channelID, err));


### PR DESCRIPTION
#### Summary

We were still registering and mounting the `ExpandedView` every time we joined a call even if it was never going to be rendered, with the exception of Desktop < 5.3. Adding some checks to make sure it's mounted only in such case.

