### PR TITLE
MM-50533 - Prioritize raised hand when ordering participants

### DIFF
--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -1,37 +1,31 @@
-import {parseSemVer} from 'semver-parser';
-
-import {
-    getCurrentRelativeTeamUrl,
-    getCurrentTeamId,
-    getTeam,
-} from 'mattermost-redux/selectors/entities/teams';
-
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {Client4} from 'mattermost-redux/client';
-import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
-import {setThreadFollow} from 'mattermost-redux/actions/threads';
-
-import {Team} from '@mattermost/types/teams';
+import {UserState} from '@calls/common/lib/types';
 import {Channel} from '@mattermost/types/channels';
-import {UserProfile} from '@mattermost/types/users';
-
-import {GlobalState} from '@mattermost/types/store';
 import {ClientConfig} from '@mattermost/types/config';
 
-import {UserState} from '@calls/common/lib/types';
+import {GlobalState} from '@mattermost/types/store';
+
+import {Team} from '@mattermost/types/teams';
+import {UserProfile} from '@mattermost/types/users';
+import {setThreadFollow} from 'mattermost-redux/actions/threads';
+import {Client4} from 'mattermost-redux/client';
+import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
+
+import {getCurrentRelativeTeamUrl, getCurrentTeamId, getTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {parseSemVer} from 'semver-parser';
+
+import {logDebug, logErr, logWarn} from './log';
 
 import {pluginId} from './manifest';
-import {logErr, logWarn, logDebug} from './log';
 
-import {
-    voiceChannelRootPost,
-} from './selectors';
-
-import {Store} from './types/mattermost-webapp';
+import {voiceChannelRootPost} from './selectors';
+import JoinSelfSound from './sounds/join_self.mp3';
+import JoinUserSound from './sounds/join_user.mp3';
 
 import LeaveSelfSound from './sounds/leave_self.mp3';
-import JoinUserSound from './sounds/join_user.mp3';
-import JoinSelfSound from './sounds/join_self.mp3';
+
+import {Store} from './types/mattermost-webapp';
 
 export function getPluginStaticPath() {
     return `${window.basename || ''}/static/plugins/${pluginId}`;

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -162,18 +162,18 @@ export function stateSortProfiles(profiles: UserProfile[], statuses: { [key: str
             };
         }
 
-        if (stateA.unmuted && !stateB.unmuted) {
-            return -1;
-        } else if (stateB.unmuted && !stateA.unmuted) {
-            return 1;
-        }
-
         if (stateA.raised_hand && !stateB.raised_hand) {
             return -1;
         } else if (stateB.raised_hand && !stateA.raised_hand) {
             return 1;
         } else if (stateA.raised_hand && stateB.raised_hand) {
             return stateA.raised_hand - stateB.raised_hand;
+        }
+
+        if (stateA.unmuted && !stateB.unmuted) {
+            return -1;
+        } else if (stateB.unmuted && !stateA.unmuted) {
+            return 1;
         }
 
         if (considerReaction) {


### PR DESCRIPTION
#### Summary
- Participants who raised their hands first will always be ordered first, maintaining the raised hand order regardless of other states (e.g., voice on).
- Mobile: https://github.com/mattermost/mattermost-mobile/pull/7229

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-50533