### PR TITLE
[MM-51592] Add logic to cover reconnect edge case

### DIFF
--- a/e2e/tests/start_call.spec.ts
+++ b/e2e/tests/start_call.spec.ts
@@ -135,6 +135,28 @@ test.describe('start new call', () => {
 
         await devPage.leaveCall();
     });
+
+    test('ws reconnect', async ({page}) => {
+        const devPage = new PlaywrightDevPage(page);
+        await devPage.startCall();
+        await devPage.wait(1000);
+
+        const reconnected = await page.evaluate(() => {
+            return new Promise((resolve) => {
+                window.callsClient.ws.on('open', (connID: string, originalConnID: string, isReconnect: boolean) => {
+                    resolve(isReconnect);
+                });
+                window.callsClient.ws.ws.close();
+            });
+        });
+
+        expect(reconnected).toBe(true);
+
+        // Waiting a bit to make extra sure connection won't close after a timeout.
+        await devPage.wait(15000);
+
+        await devPage.leaveCall();
+    });
 });
 
 test.describe('desktop', () => {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -454,6 +454,16 @@ func (p *Plugin) isSingleHandler() bool {
 	return !isHA || (isHA && hasEnvVar)
 }
 
+func (p *Plugin) isHA() bool {
+	cfg := p.API.GetConfig()
+
+	if cfg == nil {
+		return false
+	}
+
+	return cfg.ClusterSettings.Enable != nil && *cfg.ClusterSettings.Enable
+}
+
 func (c *configuration) getICEServers(forClient bool) ICEServersConfigs {
 	var iceServers ICEServersConfigs
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -414,6 +414,15 @@ func (p *Plugin) handleLeave(us *session, userID, connID, channelID string) erro
 	select {
 	case <-us.wsReconnectCh:
 		p.LogDebug("reconnected, returning", "userID", userID, "connID", connID, "channelID", channelID)
+
+		// Clearing the previous session since it gets copied over after
+		// successful reconnect.
+		p.mut.Lock()
+		if p.sessions[connID] == us {
+			p.LogDebug("clearing session after reconnect", "userID", userID, "connID", connID, "channelID", channelID)
+			delete(p.sessions, connID)
+		}
+		p.mut.Unlock()
 		return nil
 	case <-us.leaveCh:
 		p.LogDebug("user left call", "userID", userID, "connID", connID, "channelID", us.channelID)
@@ -649,6 +658,14 @@ func (p *Plugin) handleReconnect(userID, connID, channelID, originalConnID, prev
 	var rtc bool
 	p.mut.Lock()
 	us := p.sessions[connID]
+
+	// Covering the edge case of a client getting a new connection ID even if reconnecting
+	// to the same instance/node. In such case we need to use the previous connection ID
+	// to find the existing session.
+	if us == nil {
+		us = p.sessions[prevConnID]
+	}
+
 	if us != nil {
 		rtc = us.rtc
 		if atomic.CompareAndSwapInt32(&us.wsReconnected, 0, 1) {
@@ -660,7 +677,17 @@ func (p *Plugin) handleReconnect(userID, connID, channelID, originalConnID, prev
 			return fmt.Errorf("session already reconnected")
 		}
 	} else {
-		p.LogDebug("session not found", "connID", connID)
+		if p.isHA() {
+			// If we are running in HA this case can be expected as it's likely the
+			// reconnect happened on a different node which is not storing the
+			// original session.
+			p.LogDebug("session not found", "userID", userID, "connID", connID, "channelID", channelID,
+				"originalConnID", originalConnID)
+		} else {
+			// If not running in HA, this should not happen.
+			p.LogError("session not found", "userID", userID, "connID", connID, "channelID", channelID,
+				"originalConnID", originalConnID)
+		}
 	}
 
 	us = newUserSession(userID, channelID, connID, rtc)


### PR DESCRIPTION
#### Summary

PR fixes some interesting issues that have been spotted on Community in the last few days. Participants get kicked out of a call almost randomly after successfully reconnecting to the websocket channel. Today our dev meeting recording was cut short due to the calls bot suffering this unfortunate fate.

The problem is that one assumption was made when implementing the reconnection logic. I assumed that a client should always get back the same connection ID if reconnecting to the same instance (or HA node) due to the reliable websocket implementation allowing to re-use the same connection object. For some reasons, yet to be understood, this is not happening consistently.

I still think there's something suspect on the server side which I'll be investigating separately but still it makes sense to cover for such case just to be on the safe side.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51592
