### PR TITLE
MM-51985 - Fix for: Rudder keys are missing from prod builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,8 +13,8 @@ permissions:
 
 jobs:
   plugin-cd:
+    uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main
     secrets: inherit
     env:
       RUDDER_DATAPLANE_URL: ${{ secrets.MM_RUDDER_DATAPLANE_URL }}
       RUDDER_WRITE_KEY: ${{ secrets.MM_RUDDER_CALLS_PROD }}
-    uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main


### PR DESCRIPTION
#### Summary
- Trying to fix the broken cd pipeline

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51985

