### PR TITLE
MM-51985 - Fix for: Rudder keys are missing from prod builds - 3

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,10 +11,11 @@ on:
 permissions:
   contents: read
 
+env:
+  RUDDER_DATAPLANE_URL: ${{ secrets.MM_RUDDER_DATAPLANE_URL }}
+  RUDDER_WRITE_KEY: ${{ secrets.MM_RUDDER_CALLS_PROD }}
+
 jobs:
   plugin-cd:
     uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main
     secrets: inherit
-    env:
-      RUDDER_DATAPLANE_URL: ${{ secrets.MM_RUDDER_DATAPLANE_URL }}
-      RUDDER_WRITE_KEY: ${{ secrets.MM_RUDDER_CALLS_PROD }}


### PR DESCRIPTION
#### Summary
- Third try to get env vars working

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51985
