### PR TITLE
MM-51985 - Fix: Rudder keys are missing from prod builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,10 +11,6 @@ on:
 permissions:
   contents: read
 
-env:
-  RUDDER_DATAPLANE_URL: ${{ secrets.MM_RUDDER_DATAPLANE_URL }}
-  RUDDER_WRITE_KEY: ${{ secrets.MM_RUDDER_CALLS_PROD }}
-
 jobs:
   plugin-cd:
     uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ DEFAULT_GOARCH := $(shell go env GOARCH)
 BUILD_HASH = $(shell git rev-parse HEAD)
 LDFLAGS += -X "main.buildHash=$(BUILD_HASH)"
 LDFLAGS+= -X "main.isDebug=$(MM_DEBUG)"
-LDFLAGS += -X "main.rudderWriteKey=$(RUDDER_WRITE_KEY)"
-LDFLAGS += -X "main.rudderDataplaneURL=$(RUDDER_DATAPLANE_URL)"
+LDFLAGS += -X "main.rudderWriteKey=$(MM_RUDDER_CALLS_PROD)"
+LDFLAGS += -X "main.rudderDataplaneURL=$(MM_RUDDER_DATAPLANE_URL)"
 
 export GO111MODULE=on
 


### PR DESCRIPTION
#### Summary
- use the newly added env vars from https://github.com/mattermost/actions-workflows/pull/27

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51985

