### PR TITLE
Make widget menu(s) draggable

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -187,8 +187,10 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             },
             menu: {
                 position: 'absolute',
-                background: 'white',
-                color: 'var(--center-channel-color)',
+                bottom: 'calc(100% + 4px)',
+                width: '100%',
+                zIndex: -1,
+                appRegion: 'drag',
             },
             screenSharingPanel: {
                 position: 'relative',
@@ -1754,7 +1756,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
                 <div
                     ref={this.menuNode}
-                    style={{position: 'absolute', bottom: 'calc(100% + 4px)', width: '100%', zIndex: -1}}
+                    style={this.style.menu}
                 >
                     {this.renderNotificationBar()}
                     {this.renderAlertBanners()}


### PR DESCRIPTION
#### Summary

Making widget top menus draggable. This means participants list, screen sharing panel or the settings menu. Buttons are still an exception that stands and won't be draggable.

/cc @tanmay-des @lieut-data 

#### Video

https://user-images.githubusercontent.com/1832946/231522478-c74b81b9-79da-43cb-b511-b3fc2d682c50.mp4