### PR TITLE
Fix wider widget on desktop

### DIFF
--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -5,7 +5,7 @@ import configureStore from 'mattermost-redux/store';
 import {getMe} from 'mattermost-redux/actions/users';
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {getMyPreferences} from 'mattermost-redux/actions/preferences';
-import {getMyTeams} from 'mattermost-redux/actions/teams';
+import {getMyTeams, getMyTeamMembers} from 'mattermost-redux/actions/teams';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -258,7 +258,9 @@ export default async function init(cfg: InitConfig) {
         getMe()(store.dispatch, store.getState),
         getMyPreferences()(store.dispatch, store.getState),
         getMyTeams()(store.dispatch, store.getState),
+        getMyTeamMembers()(store.dispatch, store.getState),
     ]);
+
     if (cfg.initStore) {
         await cfg.initStore(store, channelID);
     }


### PR DESCRIPTION
#### Summary

It looks like https://github.com/mattermost/mattermost-plugin-calls/pull/393 wasn't really working on desktop due to a missing redux call preventing the selector from returning the teams.

Unfortunately this means that anyone using Desktop on 0.15.0 is essentially stuck with the shorter format.

@cpoile Could you give this a try on your side? May also be worth considering a dot release.
