### PR TITLE
[MM-52497] Restore participants list scrollability in global widget

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -969,6 +969,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         borderRadius: '8px',
                         border: '1px solid rgba(var(--center-channel-color-rgb), 0.16)',
                         boxShadow: '0px 8px 24px rgba(0, 0, 0, 0.12)',
+                        appRegion: 'no-drag',
                     }}
                 >
                     <li
@@ -980,6 +981,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                             paddingTop: '16px',
                             color: 'var(--center-channel-color)',
                             background: 'var(--center-channel-bg)',
+                            appRegion: 'drag',
                         }}
                     >
                         {formatMessage({defaultMessage: 'Participants'})}

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -219,6 +219,27 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 border: '1px solid rgba(var(--center-channel-color-rgb), 0.16)',
                 boxShadow: '0px 8px 24px rgba(0, 0, 0, 0.12)',
             },
+            participantsList: {
+                width: '100%',
+                minWidth: 'revert',
+                maxWidth: 'revert',
+                maxHeight: '200px',
+                overflow: 'auto',
+                position: 'relative',
+                borderRadius: '8px',
+                border: '1px solid rgba(var(--center-channel-color-rgb), 0.16)',
+                boxShadow: '0px 8px 24px rgba(0, 0, 0, 0.12)',
+                appRegion: 'no-drag',
+            },
+            participantsListHeader: {
+                position: 'sticky',
+                top: '0',
+                transform: 'translateY(-8px)',
+                paddingTop: '16px',
+                color: 'var(--center-channel-color)',
+                background: 'var(--center-channel-bg)',
+                appRegion: 'drag',
+            },
         };
     };
 
@@ -959,30 +980,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 <ul
                     id='calls-widget-participants-list'
                     className='Menu__content dropdown-menu'
-                    style={{
-                        width: '100%',
-                        minWidth: 'revert',
-                        maxWidth: 'revert',
-                        maxHeight: '200px',
-                        overflow: 'auto',
-                        position: 'relative',
-                        borderRadius: '8px',
-                        border: '1px solid rgba(var(--center-channel-color-rgb), 0.16)',
-                        boxShadow: '0px 8px 24px rgba(0, 0, 0, 0.12)',
-                        appRegion: 'no-drag',
-                    }}
+                    style={this.style.participantsList}
                 >
                     <li
                         className='MenuHeader'
-                        style={{
-                            position: 'sticky',
-                            top: '0',
-                            transform: 'translateY(-8px)',
-                            paddingTop: '16px',
-                            color: 'var(--center-channel-color)',
-                            background: 'var(--center-channel-bg)',
-                            appRegion: 'drag',
-                        }}
+                        style={this.style.participantsListHeader}
                     >
                         {formatMessage({defaultMessage: 'Participants'})}
                     </li>


### PR DESCRIPTION
#### Summary

Setting the menus as draggable in https://github.com/mattermost/mattermost-plugin-calls/pull/400 had the unfortunate side effect of preventing any sort of mouse event from going through, including scrolling. 

PR will partially revert that in order to restore the expected scrolling functionality. We are stll keeping the menu header as draggable but the actual items won't be. I think that should be acceptable as it doesn't require having to resort to potentially complex workarounds.

Thanks once more to @lieut-data for spotting this.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52497