### PR TITLE
Fix close button on global widget banner

### DIFF
--- a/webapp/src/components/call_widget/widget_banner.tsx
+++ b/webapp/src/components/call_widget/widget_banner.tsx
@@ -217,6 +217,7 @@ const Icon = styled.div<{fill?: string, color?: string}>`
 const CloseButton = styled(Icon)`
   cursor: pointer;
   margin-top: 4px;
+  app-region: no-drag;
 
   :hover {
     background: rgba(var(--center-channel-color-rgb), 0.08);


### PR DESCRIPTION
#### Summary

Similar issue to https://github.com/mattermost/mattermost-plugin-calls/pull/410 . We need to explicitly set `app-region: no-drag` in order for the element to be clickable.

