### PR TITLE
[MM-52604] Refactor e2e users state generation

### DIFF
--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -1,17 +1,13 @@
+import {UserState} from './types';
+
 export const baseURL = process.env.MM_SITE_URL || 'http://localhost:8065';
 export const defaultTeam = 'calls';
-export const userState = {
-    admin: {
-        username: 'sysadmin',
-        password: 'Sys@dmin-sample1',
-        storageStatePath: 'adminStorageState.json',
-    },
-    users: ['calls-user1', 'calls-user2', 'calls-user3', 'calls-user4', 'calls-user5', 'calls-user6', 'calls-user7', 'calls-user8'].map((name) => {
-        return {
-            username: name,
-            password: 'U$er-sample1',
-            storageStatePath: `${name}StorageState.json`,
-        };
-    }),
+export const adminState: UserState = {
+    username: 'sysadmin',
+    password: 'Sys@dmin-sample1',
+    storageStatePath: 'adminStorageState.json',
 };
+export const userPrefix = 'calls-user';
+export const userPassword = 'U$er-sample1';
+export const channelPrefix = 'calls';
 export const pluginID = 'com.mattermost.calls';

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -2,12 +2,15 @@ import * as fs from 'fs/promises';
 
 import {FullConfig} from '@playwright/test';
 
-import {userState} from './constants';
+import {adminState, userPrefix} from './constants';
 
 async function globalTeardown(config: FullConfig) {
-    await fs.unlink(userState.admin.storageStatePath);
-    for (const user of userState.users) {
-        await fs.unlink(user.storageStatePath);
+    const numUsers = config.workers * 2;
+
+    await fs.unlink(adminState.storageStatePath);
+
+    for (let i = 0; i < numUsers; i++) {
+        await fs.unlink(`${userPrefix}${i}StorageState.json`);
     }
 }
 

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@babel/core": "7.20.12",
         "@babel/eslint-parser": "7.19.1",
-        "@playwright/test": "1.31.2",
+        "@playwright/test": "1.33.0",
         "@typescript-eslint/eslint-plugin": "5.49.0",
         "eslint": "8.33.0",
         "eslint-plugin-import": "2.27.5"
@@ -535,13 +535,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
+      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.33.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2919,9 +2919,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -3901,14 +3901,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
+      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.31.2"
+        "playwright-core": "1.33.0"
       }
     },
     "@types/json-schema": {
@@ -5576,9 +5576,9 @@
       "dev": true
     },
     "playwright-core": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
       "dev": true
     },
     "prelude-ls": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@babel/core": "7.20.12",
     "@babel/eslint-parser": "7.19.1",
-    "@playwright/test": "1.31.2",
+    "@playwright/test": "1.33.0",
     "@typescript-eslint/eslint-plugin": "5.49.0",
     "eslint": "8.33.0",
     "eslint-plugin-import": "2.27.5"

--- a/e2e/tests/global_widget.spec.ts
+++ b/e2e/tests/global_widget.spec.ts
@@ -1,11 +1,11 @@
 import {test, expect} from '@playwright/test';
 
-import {userState, baseURL, defaultTeam, pluginID} from '../constants';
+import {baseURL, defaultTeam, pluginID} from '../constants';
 
-import {getChannelNamesForTest, getUserIdxForTest} from '../utils';
+import {getChannelNamesForTest, getUserStoragesForTest} from '../utils';
 
 test.describe('global widget', () => {
-    test.use({storageState: userState.users[getUserIdxForTest()].storageStatePath});
+    test.use({storageState: getUserStoragesForTest()[0]});
 
     test('start call', async ({page, request}) => {
         const channelName = getChannelNamesForTest()[0];

--- a/e2e/tests/join_call.spec.ts
+++ b/e2e/tests/join_call.spec.ts
@@ -1,10 +1,10 @@
 import {test, expect, chromium} from '@playwright/test';
 
 import PlaywrightDevPage from '../page';
-import {userState} from '../constants';
-import {startCall, getUserIdxForTest} from '../utils';
+import {startCall, getUserStoragesForTest, getUsernamesForTest} from '../utils';
 
-const userIdx = getUserIdxForTest();
+const userStorages = getUserStoragesForTest();
+const usernames = getUsernamesForTest();
 
 test.beforeEach(async ({page, context}) => {
     const devPage = new PlaywrightDevPage(page);
@@ -12,11 +12,11 @@ test.beforeEach(async ({page, context}) => {
 });
 
 test.describe('join call', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('channel header button', async ({page}) => {
         // start a call
-        const userPage = await startCall(userState.users[userIdx + 1].storageStatePath);
+        const userPage = await startCall(userStorages[1]);
 
         const devPage = new PlaywrightDevPage(page);
         await devPage.joinCall();
@@ -27,7 +27,7 @@ test.describe('join call', () => {
 
     test('channel toast', async ({page}) => {
         // start a call
-        const userPage = await startCall(userState.users[userIdx + 1].storageStatePath);
+        const userPage = await startCall(userStorages[1]);
 
         await page.locator('.post__body').last().scrollIntoViewIfNeeded();
 
@@ -38,7 +38,7 @@ test.describe('join call', () => {
         await joinCallToast.click();
 
         await expect(userPage.page.getByTestId('call-joined-participant-notification')).toBeVisible();
-        await expect(userPage.page.getByTestId('call-joined-participant-notification')).toContainText(userState.users[userIdx].username + ' has joined the call.');
+        await expect(userPage.page.getByTestId('call-joined-participant-notification')).toContainText(usernames[0] + ' has joined the call.');
 
         await expect(page.locator('#calls-widget')).toBeVisible();
 
@@ -50,7 +50,7 @@ test.describe('join call', () => {
 
     test('call thread', async ({page}) => {
         // start a call
-        const userPage = await startCall(userState.users[userIdx + 1].storageStatePath);
+        const userPage = await startCall(userStorages[1]);
 
         const joinCallButton = page.locator('.post__body').last().locator('button:has-text("Join call")');
         await expect(joinCallButton).toBeVisible();

--- a/e2e/tests/media.spec.ts
+++ b/e2e/tests/media.spec.ts
@@ -1,12 +1,12 @@
 import {test, expect, chromium} from '@playwright/test';
 
-import {userState, baseURL, defaultTeam, pluginID} from '../constants';
+import {baseURL, defaultTeam, pluginID} from '../constants';
 
-import {getUserIdxForTest, startCall} from '../utils';
+import {getUserStoragesForTest, startCall} from '../utils';
 
 import PlaywrightDevPage from '../page';
 
-const userIdx = getUserIdxForTest();
+const userStorages = getUserStoragesForTest();
 
 test.beforeEach(async ({page, context}) => {
     const devPage = new PlaywrightDevPage(page);
@@ -14,10 +14,10 @@ test.beforeEach(async ({page, context}) => {
 });
 
 test.describe('screen sharing', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('share screen button', async ({page}) => {
-        const userPage = await startCall(userState.users[userIdx + 1].storageStatePath);
+        const userPage = await startCall(userStorages[1]);
 
         const devPage = new PlaywrightDevPage(page);
         await devPage.joinCall();
@@ -46,7 +46,7 @@ test.describe('screen sharing', () => {
     });
 
     test('share screen keyboard shortcut', async ({page}) => {
-        const userPage = await startCall(userState.users[userIdx + 1].storageStatePath);
+        const userPage = await startCall(userStorages[1]);
 
         const devPage = new PlaywrightDevPage(page);
         await devPage.joinCall();
@@ -85,10 +85,10 @@ test.describe('screen sharing', () => {
 });
 
 test.describe('sending voice', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('unmuting', async ({page}) => {
-        const userPage = await startCall(userState.users[userIdx + 1].storageStatePath);
+        const userPage = await startCall(userStorages[1]);
 
         const devPage = new PlaywrightDevPage(page);
         await devPage.joinCall();

--- a/e2e/tests/popout.spec.ts
+++ b/e2e/tests/popout.spec.ts
@@ -1,13 +1,13 @@
 import {test, expect} from '@playwright/test';
 
 import PlaywrightDevPage from '../page';
-import {userState} from '../constants';
-import {getChannelNamesForTest, getUserIdxForTest} from '../utils';
+import {getChannelNamesForTest, getUserStoragesForTest, getUsernamesForTest} from '../utils';
 
-const userIdx = getUserIdxForTest();
+const userStorages = getUserStoragesForTest();
+const usernames = getUsernamesForTest();
 
 test.describe('popout window', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('popout opens muted', async ({page, context}) => {
         const devPage = new PlaywrightDevPage(page);
@@ -29,7 +29,7 @@ test.describe('popout window', () => {
 
     test('popout opens in a DM channel', async ({page, context}) => {
         const devPage = new PlaywrightDevPage(page);
-        await devPage.gotoDM(userState.users[userIdx + 1].username);
+        await devPage.gotoDM(usernames[1]);
         await devPage.startCall();
 
         const [popOut, _] = await Promise.all([
@@ -85,7 +85,7 @@ test.describe('popout window', () => {
 
     test('supports chat in a DM channel', async ({page, context}) => {
         const devPage = new PlaywrightDevPage(page);
-        await devPage.gotoDM(userState.users[userIdx + 1].username);
+        await devPage.gotoDM(usernames[1]);
         await devPage.startCall();
 
         const [popOut, _] = await Promise.all([

--- a/e2e/tests/recordings.spec.ts
+++ b/e2e/tests/recordings.spec.ts
@@ -1,6 +1,8 @@
 import {test, expect, chromium} from '@playwright/test';
 
-import {userState, baseURL, defaultTeam, pluginID} from '../constants';
+import {baseURL, defaultTeam, pluginID} from '../constants';
+
+import {getUserStoragesForTest} from '../utils';
 
 import PlaywrightDevPage from '../page';
 
@@ -10,7 +12,7 @@ test.beforeEach(async ({page, context}) => {
 });
 
 test.describe('call recordings', () => {
-    test.use({storageState: userState.users[6].storageStatePath});
+    test.use({storageState: getUserStoragesForTest()[0]});
 
     test('recording - slash command', async ({page}) => {
         // start call

--- a/e2e/tests/shortcuts.spec.ts
+++ b/e2e/tests/shortcuts.spec.ts
@@ -3,10 +3,7 @@ import {readFile} from 'fs/promises';
 import {test, expect, chromium} from '@playwright/test';
 
 import PlaywrightDevPage from '../page';
-import {userState} from '../constants';
-import {getUserIdxForTest} from '../utils';
-
-const userIdx = getUserIdxForTest();
+import {getUserStoragesForTest} from '../utils';
 
 test.beforeEach(async ({page, context}) => {
     const devPage = new PlaywrightDevPage(page);
@@ -14,7 +11,7 @@ test.beforeEach(async ({page, context}) => {
 });
 
 test.describe('keyboard shortcuts', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: getUserStoragesForTest()[0]});
 
     test('join/leave call', async ({page}) => {
         const devPage = new PlaywrightDevPage(page);

--- a/e2e/tests/start_call.spec.ts
+++ b/e2e/tests/start_call.spec.ts
@@ -3,17 +3,12 @@ import {readFile} from 'fs/promises';
 import {test, expect, chromium} from '@playwright/test';
 
 import PlaywrightDevPage from '../page';
-import {userState} from '../constants';
-import {getUserIdxForTest, getChannelNamesForTest} from '../utils';
+import {getChannelNamesForTest, getUsernamesForTest, getUserStoragesForTest} from '../utils';
 
-declare global {
-    interface Window {
-        callsClient: any,
-        desktop: any,
-    }
-}
+import {adminState} from '../constants';
 
-const userIdx = getUserIdxForTest();
+const userStorages = getUserStoragesForTest();
+const usernames = getUsernamesForTest();
 
 test.beforeEach(async ({page, context}, info) => {
     // Small optimization to avoid loading an unnecessary channel.
@@ -25,7 +20,7 @@ test.beforeEach(async ({page, context}, info) => {
 });
 
 test.describe('start/join call in channel with calls disabled', () => {
-    test.use({storageState: userState.admin.storageStatePath});
+    test.use({storageState: adminState.storageStatePath});
 
     test('/call start', async ({page}) => {
         const devPage = new PlaywrightDevPage(page);
@@ -57,7 +52,7 @@ test.describe('start/join call in channel with calls disabled', () => {
 });
 
 test.describe('start new call', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('channel header button', async ({page}) => {
         const devPage = new PlaywrightDevPage(page);
@@ -78,7 +73,7 @@ test.describe('start new call', () => {
 
     test('dm channel', async ({page, context}) => {
         const devPage = new PlaywrightDevPage(page);
-        await devPage.gotoDM(userState.users[userIdx + 1].username);
+        await devPage.gotoDM(usernames[1]);
         await devPage.startCall();
         await devPage.wait(1000);
         expect(await page.locator('#calls-widget .calls-widget-bottom-bar').screenshot()).toMatchSnapshot('dm-calls-widget-bottom-bar.png');
@@ -119,7 +114,7 @@ test.describe('start new call', () => {
         await expect(page.locator('#calls-widget')).toBeVisible();
 
         // verify the call post is created in the thread.
-        await expect(page.locator('#rhsContainer').filter({has: page.getByText(`${userState.users[userIdx].username} started a call`)})).toBeVisible();
+        await expect(page.locator('#rhsContainer').filter({has: page.getByText(`${usernames[0]} started a call`)})).toBeVisible();
 
         await page.locator('#reply_textbox').fill('/call leave');
         await page.locator('#reply_textbox').press('Control+Enter');
@@ -160,7 +155,7 @@ test.describe('start new call', () => {
 });
 
 test.describe('desktop', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('screen sharing < 5.1.0', async ({page}) => {
         await page.evaluate(() => {
@@ -211,7 +206,7 @@ test.describe('desktop', () => {
 });
 
 test.describe('auto join link', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('public channel', async ({page, context}) => {
         await page.locator('#post_textbox').fill('/call link');
@@ -235,7 +230,7 @@ test.describe('auto join link', () => {
 
     test('dm channel', async ({page, context}) => {
         const devPage = new PlaywrightDevPage(page);
-        await devPage.gotoDM(userState.users[userIdx + 1].username);
+        await devPage.gotoDM(usernames[1]);
 
         await page.locator('#post_textbox').fill('/call link');
         await page.locator('[data-testid=SendMessageButton]').click();
@@ -258,7 +253,7 @@ test.describe('auto join link', () => {
 });
 
 test.describe('setting audio input device', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('no default', async ({page}) => {
         const devPage = new PlaywrightDevPage(page);
@@ -331,7 +326,7 @@ test.describe('setting audio input device', () => {
 });
 
 test.describe('setting audio output device', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('no default', async ({page}) => {
         const devPage = new PlaywrightDevPage(page);
@@ -404,7 +399,7 @@ test.describe('setting audio output device', () => {
 });
 
 test.describe('switching products', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    test.use({storageState: userStorages[0]});
 
     test('boards', async ({page}) => {
         const devPage = new PlaywrightDevPage(page);
@@ -431,7 +426,7 @@ test.describe('switching products', () => {
 });
 
 test.describe('switching views', () => {
-    test.use({storageState: userState.admin.storageStatePath});
+    test.use({storageState: adminState.storageStatePath});
 
     test('system console', async ({page}) => {
         // Using the second channel allocated for the test to avoid a potential

--- a/e2e/tests/switch_call.spec.ts
+++ b/e2e/tests/switch_call.spec.ts
@@ -1,10 +1,7 @@
 import {test, expect, chromium} from '@playwright/test';
 
 import PlaywrightDevPage from '../page';
-import {userState} from '../constants';
-import {getUserIdxForTest} from '../utils';
-
-const userIdx = getUserIdxForTest();
+import {getUserStoragesForTest, getUserIdxForTest} from '../utils';
 
 test.beforeEach(async ({page, context}) => {
     const devPage = new PlaywrightDevPage(page);
@@ -12,7 +9,8 @@ test.beforeEach(async ({page, context}) => {
 });
 
 test.describe('switch call', () => {
-    test.use({storageState: userState.users[userIdx].storageStatePath});
+    const userIdx = getUserIdxForTest();
+    test.use({storageState: getUserStoragesForTest()[0]});
 
     test('exit modal - cancel button', async ({page}) => {
         const devPage = new PlaywrightDevPage(page);

--- a/e2e/tests/types.ts
+++ b/e2e/tests/types.ts
@@ -1,7 +1,0 @@
-declare global {
-    interface Window {
-        isHandRaised: boolean;
-    }
-}
-
-export {};

--- a/e2e/types.ts
+++ b/e2e/types.ts
@@ -1,0 +1,14 @@
+declare global {
+    interface Window {
+        callsClient: any,
+        desktop: any,
+        isHandRaised: boolean;
+    }
+}
+
+export type UserState = {
+    username: string;
+    password: string;
+    storageStatePath: string;
+};
+

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -2,12 +2,14 @@ import {chromium} from '@playwright/test';
 
 import PlaywrightDevPage from './page';
 
+import {userPrefix, channelPrefix} from './constants';
+
 export function getChannelNamesForTest() {
     let idx = 0;
     if (process.env.TEST_PARALLEL_INDEX) {
         idx = parseInt(String(process.env.TEST_PARALLEL_INDEX), 10) * 2;
     }
-    return [`calls${idx}`, `calls${idx + 1}`];
+    return [`${channelPrefix}${idx}`, `${channelPrefix}${idx + 1}`];
 }
 
 export function getUserIdxForTest() {
@@ -15,6 +17,16 @@ export function getUserIdxForTest() {
         return parseInt(String(process.env.TEST_PARALLEL_INDEX), 10) * 2;
     }
     return 0;
+}
+
+export function getUsernamesForTest() {
+    const idx = getUserIdxForTest();
+    return [`${userPrefix}${idx}`, `${userPrefix}${idx + 1}`];
+}
+
+export function getUserStoragesForTest() {
+    const names = getUsernamesForTest();
+    return [`${names[0]}StorageState.json`, `${names[1]}StorageState.json`];
 }
 
 export async function startCall(userState: string) {


### PR DESCRIPTION
#### Summary

PR refactors a bit how we are handling users state in e2e tests. Originally we'd be using a constant array for simplicity but that wasn't ideal so we are removing that and rely on the state of the server instead by generating usernames on the fly through the expected pattern (`calls-user` prefix + test index).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52604
