### PR TITLE
Use sidebar bg to generate calls bg

### DIFF
--- a/standalone/src/recording/index.tsx
+++ b/standalone/src/recording/index.tsx
@@ -88,7 +88,7 @@ async function initRecording(store: Store, theme: Theme, channelID: string) {
         });
     }
 
-    setCallsGlobalCSSVars(theme.sidebarTextHoverBg);
+    setCallsGlobalCSSVars(theme.sidebarBg);
 
     const locale = getCurrentUserLocale(store.getState()) || 'en';
     let messages;

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -160,7 +160,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
     #unlockNavigation?: () => void;
 
     private genStyle: () => Record<string, React.CSSProperties> = () => {
-        setCallsGlobalCSSVars(this.props.theme.sidebarTextHoverBg);
+        setCallsGlobalCSSVars(this.props.theme.sidebarBg);
 
         return {
             root: {


### PR DESCRIPTION
#### Summary

As discussed in https://community.mattermost.com/core/pl/jokj8sb6fpga7fyfh3txfbsara we are going to use `sidebarBg` to improve support on custom themes.

I suppose this may need updating on the mobile side but should be trivial.
