### PR TITLE
[MM-52648] Fix inconsistent participant name display in channel toast

### DIFF
--- a/webapp/src/components/connected_profiles.tsx
+++ b/webapp/src/components/connected_profiles.tsx
@@ -3,7 +3,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import {UserProfile} from '@mattermost/types/users';
 
-import {getUsersList} from '../utils';
+import {getUsersList, getUserDisplayName} from '../utils';
 
 import Avatar from './avatar/avatar';
 
@@ -29,7 +29,7 @@ const ConnectedProfiles = ({pictures, profiles, maxShowedProfiles, size, fontSiz
                 key={'call_thread_profile_' + profile.id}
                 overlay={
                     <Tooltip id='tooltip-username'>
-                        {profile.username}
+                        {getUserDisplayName(profile)}
                     </Tooltip>
                 }
             >


### PR DESCRIPTION
#### Summary

PR currently fixes the inconsistency but as @matthewbirtch suggested, it would be good to do a revision of all the places where we display participants names and check whether we should apply user display settings:

![image](https://user-images.githubusercontent.com/1832946/236149213-23e2156a-bb45-4875-955f-482a0897e700.png)

@tanmay-des Could you help with this? Some of the places would be:

- Participants list (both widget and expanded view)
- Participants grid (expanded view)
- Connected profiles in channel toast tooltip
- Connected profiles in chat thread root post tooltip
- Connected profiles in sidebar active call icon tooltip
- Reaction stream

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52648
