### PR TITLE
[MM-52382] Make job service client resilient to service restarts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 require (
 	github.com/Masterminds/semver v1.5.0
-	github.com/mattermost/calls-offloader v0.2.4-0.20230425234542-9125a63f69b8
+	github.com/mattermost/calls-offloader v0.2.4-0.20230504121311-54ac0f4223c0
 	github.com/mattermost/calls-recorder v0.3.0
 	github.com/mattermost/logr/v2 v2.0.15
 	github.com/mattermost/mattermost-plugin-api v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -572,8 +572,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/mattermost/calls-offloader v0.2.4-0.20230425234542-9125a63f69b8 h1:1Ob0sbT+zbE6tJeio4i7x1fc/7tlo1ssJLldC8tjRUk=
-github.com/mattermost/calls-offloader v0.2.4-0.20230425234542-9125a63f69b8/go.mod h1:GKhQ1cH7aMToSmOz3+ySN3++bhZzN5I8ugibDq08N5c=
+github.com/mattermost/calls-offloader v0.2.4-0.20230504121311-54ac0f4223c0 h1:dX40YvfEXoOlY8mcAKcgmTfHcrFj7GxGdejyBR6ex8M=
+github.com/mattermost/calls-offloader v0.2.4-0.20230504121311-54ac0f4223c0/go.mod h1:GKhQ1cH7aMToSmOz3+ySN3++bhZzN5I8ugibDq08N5c=
 github.com/mattermost/calls-recorder v0.3.0 h1:AFCyDwPeVLGjk4F3UQKmVhCp0o+0rGU6Prm6am0b7AQ=
 github.com/mattermost/calls-recorder v0.3.0/go.mod h1:hYhKgCc28uzcpkJjuja4tiLBfuPSCSQ6QHGkRFVygKM=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 h1:Khvh6waxG1cHc4Cz5ef9n3XVCxRWpAKUtqg9PJl5+y8=

--- a/server/job_api.go
+++ b/server/job_api.go
@@ -23,12 +23,12 @@ func (p *Plugin) handleGetJob(w http.ResponseWriter, r *http.Request, jobID stri
 		return
 	}
 
-	if p.jobService == nil {
+	if p.getJobService() == nil {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 
-	job, err := p.jobService.GetJob(jobID)
+	job, err := p.getJobService().GetJob(jobID)
 	if err != nil {
 		p.LogError("failed to get job", "err", err.Error(), "jobID", jobID)
 		http.NotFound(w, r)
@@ -50,12 +50,12 @@ func (p *Plugin) handleGetJobLogs(w http.ResponseWriter, r *http.Request, jobID 
 		return
 	}
 
-	if p.jobService == nil {
+	if p.getJobService() == nil {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 
-	data, err := p.jobService.GetJobLogs(jobID)
+	data, err := p.getJobService().GetJobLogs(jobID)
 	if err != nil {
 		p.LogError("failed to get job logs", "err", err.Error(), "jobID", jobID)
 		http.NotFound(w, r)

--- a/server/job_service.go
+++ b/server/job_service.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -233,8 +234,10 @@ func (p *Plugin) newJobService(serviceURL string) (*jobService, error) {
 	}, nil
 }
 
-func (s *jobService) RunJob(cfg job.Config) (job.Job, error) {
-	return s.client.CreateJob(cfg)
+func (p *Plugin) getJobService() *jobService {
+	p.mut.RLock()
+	defer p.mut.RUnlock()
+	return p.jobService
 }
 
 func (s *jobService) StopJob(channelID string) error {
@@ -247,11 +250,36 @@ func (s *jobService) StopJob(channelID string) error {
 }
 
 func (s *jobService) GetJob(jobID string) (job.Job, error) {
-	return s.client.GetJob(jobID)
+	jb, err := s.client.GetJob(jobID)
+
+	// Adding a check in case the service restarted and lost credentials. This is
+	// a common case when the offloader is running in kubernetes deployment. The
+	// solution is to re-initialize the service which will cause a new registration
+	// attempt.
+	if errors.Is(err, offloader.ErrUnauthorized) {
+		if err := s.reinitializeOnAuthError(); err != nil {
+			return job.Job{}, err
+		}
+		return s.client.GetJob(jobID)
+	}
+	return jb, err
 }
 
 func (s *jobService) GetJobLogs(jobID string) ([]byte, error) {
-	return s.client.GetJobLogs(jobID)
+	data, err := s.client.GetJobLogs(jobID)
+
+	// Adding a check in case the service restarted and lost credentials. This is
+	// a common case when the offloader is running in kubernetes deployment. The
+	// solution is to re-initialize the service which will cause a new registration
+	// attempt.
+	if errors.Is(err, offloader.ErrUnauthorized) {
+		if err := s.reinitializeOnAuthError(); err != nil {
+			return nil, err
+		}
+		return s.client.GetJobLogs(jobID)
+	}
+
+	return data, err
 }
 
 func (s *jobService) UpdateJobRunner(runner string) error {
@@ -301,15 +329,58 @@ func (s *jobService) RunRecordingJob(callID, postID, authToken string) (string, 
 	baseRecorderCfg.ThreadID = postID
 	baseRecorderCfg.AuthToken = authToken
 
-	job, err := s.RunJob(job.Config{
+	jobCfg := job.Config{
 		Type:           job.TypeRecording,
 		MaxDurationSec: maxDuration,
 		Runner:         recordingJobRunner,
 		InputData:      baseRecorderCfg.ToMap(),
-	})
-	if err != nil {
+	}
+
+	job, err := s.client.CreateJob(jobCfg)
+
+	// Adding a check in case the service restarted and lost credentials. This is
+	// a common case when the offloader is running in kubernetes deployment. The
+	// solution is to re-initialize the service which will cause a new registration
+	// attempt.
+	if errors.Is(err, offloader.ErrUnauthorized) {
+		if err := s.reinitializeOnAuthError(); err != nil {
+			return "", err
+		}
+
+		job, err := s.client.CreateJob(jobCfg)
+		if err != nil {
+			return "", err
+		}
+
+		return job.ID, nil
+	} else if err != nil {
 		return "", err
 	}
 
 	return job.ID, nil
+}
+
+func (s *jobService) Close() error {
+	return s.client.Close()
+}
+
+func (s *jobService) reinitializeOnAuthError() error {
+	s.ctx.LogWarn("received unauthorized error from job service, attempting re-initialization")
+
+	if err := s.Close(); err != nil {
+		s.ctx.LogError("failed to close job service client", "err", err.Error())
+	}
+
+	jobService, err := s.ctx.newJobService(s.ctx.getConfiguration().getJobServiceURL())
+	if err != nil {
+		return fmt.Errorf("failed to re-initialize service: %w", err)
+	}
+
+	s.ctx.LogInfo("job service re-initialized successfully")
+
+	s.ctx.mut.Lock()
+	s.ctx.jobService = jobService
+	s.ctx.mut.Unlock()
+
+	return nil
 }

--- a/server/recording_api.go
+++ b/server/recording_api.go
@@ -90,7 +90,7 @@ func (p *Plugin) handleRecordingAction(w http.ResponseWriter, r *http.Request, c
 		return
 	}
 
-	if p.jobService == nil {
+	if p.getJobService() == nil {
 		res.Err = "Job service is not initialized"
 		res.Code = http.StatusForbidden
 		return
@@ -160,7 +160,7 @@ func (p *Plugin) handleRecordingAction(w http.ResponseWriter, r *http.Request, c
 			"callID":   callID,
 			"recState": recState.getClientState().toMap(),
 		}, &model.WebsocketBroadcast{ChannelId: callID, ReliableClusterSend: true})
-		recJobID, err := p.jobService.RunRecordingJob(callID, postID, p.botSession.Token)
+		recJobID, err := p.getJobService().RunRecordingJob(callID, postID, p.botSession.Token)
 		if err != nil {
 			// resetting state in case the job failed to run
 			if err := p.kvSetAtomicChannelState(callID, func(state *channelState) (*channelState, error) {
@@ -211,7 +211,7 @@ func (p *Plugin) handleRecordingAction(w http.ResponseWriter, r *http.Request, c
 			"recState": recState.getClientState().toMap(),
 		}, &model.WebsocketBroadcast{ChannelId: callID, ReliableClusterSend: true})
 
-		if err := p.jobService.StopJob(callID); err != nil {
+		if err := p.getJobService().StopJob(callID); err != nil {
 			res.Err = "failed to stop recording job: " + err.Error()
 			res.Code = http.StatusInternalServerError
 			return

--- a/server/session.go
+++ b/server/session.go
@@ -319,7 +319,7 @@ func (p *Plugin) removeSession(us *session) error {
 	// If the bot is the only user left in the call we automatically stop the recording.
 	if currState.Call != nil && currState.Call.Recording != nil && len(currState.Call.Users) == 1 && currState.Call.Users[p.getBotID()] != nil {
 		p.LogDebug("all users left call with recording in progress, stopping", "channelID", us.channelID, "jobID", currState.Call.Recording.JobID)
-		if err := p.jobService.StopJob(us.channelID); err != nil {
+		if err := p.getJobService().StopJob(us.channelID); err != nil {
 			p.LogError("failed to stop recording job", "error", err.Error(), "channelID", us.channelID, "jobID", currState.Call.Recording.JobID)
 		}
 	}


### PR DESCRIPTION
#### Summary

Adding some logic to make it play nicely with the service potentially restarting and losing stored credentials in the process which is the typical behaviour when running offloader in kubernetes.

#### Related PR

https://github.com/mattermost/calls-offloader/pull/27

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52382