### PR TITLE
Bump minimum supported server version to current ESR

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "description": "Integrates real-time voice communication in Mattermost",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
-  "min_server_version": "7.6.0",
+  "min_server_version": "7.8.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary

7.7 support just ended last month. Going forward it would be good to keep the current ESR as our target minimum version unless strictly necessary to make an emergency bump.
