### PR TITLE
MM-53004: apply intl to username conjunctions

### DIFF
--- a/webapp/src/components/channel_link_label/component.tsx
+++ b/webapp/src/components/channel_link_label/component.tsx
@@ -4,7 +4,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {UserProfile} from '@mattermost/types/users';
 import {Theme} from 'mattermost-redux/types/themes';
 
-import {getUsersList} from 'src/utils';
+import {getUserDisplayName} from 'src/utils';
 import ActiveCallIcon from 'src/components/icons/active_call_icon';
 
 interface Props {
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const ChannelLinkLabel = (props: Props) => {
-    const {formatMessage} = useIntl();
+    const {formatMessage, formatList} = useIntl();
 
     if (props.hasCall) {
         return (
@@ -24,7 +24,10 @@ const ChannelLinkLabel = (props: Props) => {
                     <Tooltip
                         id='call-profiles'
                     >
-                        {formatMessage({defaultMessage: '{list} {count, plural, =1 {is} other {are}} on the call'}, {count: props.profiles.length, list: getUsersList(props.profiles)})}
+                        {formatMessage({defaultMessage: '{list} {count, plural, =1 {is} other {are}} on the call'}, {
+                            count: props.profiles.length,
+                            list: formatList(props.profiles.map((user) => getUserDisplayName(user)), {type: 'conjunction'})
+                        })}
                     </Tooltip>
                 }
             >

--- a/webapp/src/components/connected_profiles.tsx
+++ b/webapp/src/components/connected_profiles.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {useIntl} from 'react-intl';
 
 import {UserProfile} from '@mattermost/types/users';
 
-import {getUsersList, getUserDisplayName} from '../utils';
+import {getUserDisplayName} from '../utils';
 
 import Avatar from './avatar/avatar';
 
@@ -21,6 +22,7 @@ const ConnectedProfiles = ({pictures, profiles, maxShowedProfiles, size, fontSiz
     const diff = profiles.length - maxShowedProfiles;
 
     const showedProfiles = diff > 0 ? profiles.slice(0, maxShowedProfiles) : profiles;
+    const {formatList} = useIntl();
 
     const els = showedProfiles.map((profile, idx) => {
         return (
@@ -53,7 +55,7 @@ const ConnectedProfiles = ({pictures, profiles, maxShowedProfiles, size, fontSiz
                     <Tooltip
                         id='call-profiles'
                     >
-                        {getUsersList(profiles)}
+                        {formatList(profiles.map((user) => getUserDisplayName(user)), {type: 'conjunction'})}
                     </Tooltip>
                 }
             >

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -287,19 +287,6 @@ export function hasExperimentalFlag() {
     return window.localStorage.getItem('calls_experimental_features') === 'on';
 }
 
-export function getUsersList(profiles: UserProfile[]) {
-    if (profiles.length === 0) {
-        return '';
-    }
-    if (profiles.length === 1) {
-        return getUserDisplayName(profiles[0]);
-    }
-    const list = profiles.slice(0, -1).map((profile) => {
-        return getUserDisplayName(profile);
-    }).join(', ');
-    return list + ' and ' + getUserDisplayName(profiles[profiles.length - 1]);
-}
-
 export function playSound(name: string) {
     let src = '';
     switch (name) {


### PR DESCRIPTION
#### Summary
Replaces `utils.getUsersList` with calls to the internationalized `formatList`. Context: https://community.mattermost.com/core/pl/315jwqduqinkxd1fgpm5ixg8de

##### One caveat 
Instead of always being en, it is always translated—so the list segment may be translated when the surrounding message isn't.

<img width="400" alt="CleanShot 2023-06-02 at 16 36 18@2x" src="https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/1094b9af-3760-409c-a258-0f589a88188e">

##### The benefit
All variations/lanugages are handled automatically.

<img width="121" alt="CleanShot 2023-06-02 at 16 23 11@2x" src="https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/ff3467d4-bbb7-431a-a5d7-f368df485a71">
<img width="120" alt="CleanShot 2023-06-02 at 16 29 45@2x" src="https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/751828a9-c190-4463-8c2a-1b4c4d5f2a81">
<img width="137" alt="CleanShot 2023-06-02 at 16 30 41@2x" src="https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/0e6016b2-c110-4af6-8617-e5308bc5ae97">
<img width="127" alt="CleanShot 2023-06-02 at 16 33 33@2x" src="https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/fed1871d-b040-473c-8bc8-75174ede8577">
<img width="128" alt="CleanShot 2023-06-02 at 16 39 00@2x" src="https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/923d780f-6931-4035-845e-e6a7ffae2d4e">
<img width="122" alt="CleanShot 2023-06-02 at 16 38 03@2x" src="https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/a5dd21e3-82ae-4bf6-b187-bf625d19b367">

![CleanShot 2023-06-02 at 16 18 26@2x](https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/4f7af799-4c20-47ef-92f7-d7a57258da8f)
![CleanShot 2023-06-02 at 16 18 05@2x](https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/ffa83294-c122-42d6-bb29-baab4ada2486)
![CleanShot 2023-06-02 at 16 21 03@2x](https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/a7298c01-a671-4968-9058-62430d128f54)
![CleanShot 2023-06-02 at 16 31 30@2x](https://github.com/mattermost/mattermost-plugin-calls/assets/11724372/7c8c3bf9-2ad6-4aec-86fb-ef2c7ace03ac)







#### Ticket Link
- Fixes https://mattermost.atlassian.net/browse/MM-53004

