### PR TITLE
MM-53261 - Expanded view notifications

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1602,7 +1602,6 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         key={c.callID}
                         call={c}
                         onWidget={true}
-                        global={Boolean(this.props.global)}
                     />
                 ))}
             </div>

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {IntlShape} from 'react-intl';
 import {RouteComponentProps} from 'react-router-dom';
 import {compareSemVer} from 'semver-parser';
+
 import styled, {createGlobalStyle, css} from 'styled-components';
 import {MediaControlBar, MediaController, MediaFullscreenButton} from 'media-chrome/dist/react';
 
@@ -20,6 +21,8 @@ import {
     UserState,
 } from '@calls/common/lib/types';
 import {mosThreshold} from '@calls/common';
+
+import {ExpandedCallContainer} from 'src/components/incoming_calls/expanded_call_container';
 
 import {Emoji} from 'src/components/emoji/emoji';
 
@@ -180,6 +183,9 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                 flexDirection: 'column',
                 flex: '1',
             },
+            headerSpreader: {
+                marginRight: 'auto',
+            },
             closeViewButton: {
                 display: 'flex',
                 alignItems: 'center',
@@ -187,7 +193,6 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                 width: '40px',
                 height: '40px',
                 borderRadius: '4px',
-                marginLeft: 'auto',
             },
             participants: {
                 display: 'grid',
@@ -1016,10 +1021,12 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                             startAt={this.props.callStartAt}
                         />
                         <span style={{margin: '4px'}}>{untranslatable('•')}</span>
-                        <span style={{margin: '4px'}}>
+                        <span style={{margin: '4px', whiteSpace: 'nowrap'}}>
                             {formatMessage({defaultMessage: '{count, plural, =1 {# participant} other {# participants}}'}, {count: this.props.profiles.length})}
                         </span>
 
+                        <div style={this.style.headerSpreader}/>
+                        <ExpandedCallContainer/>
                         <button
                             className='button-close'
                             style={this.style.closeViewButton}

--- a/webapp/src/components/incoming_calls/call_incoming_condensed.tsx
+++ b/webapp/src/components/incoming_calls/call_incoming_condensed.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
 
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
 import {useDismissJoin, useRingingAndNotification} from 'src/components/incoming_calls/hooks';
 
@@ -21,16 +21,17 @@ import {IncomingCallNotification} from 'src/types/types';
 type Props = {
     call: IncomingCallNotification;
     onWidget?: boolean;
-    global?: boolean;
+    joinButtonBorder?: boolean;
+    className?: string;
 };
 
-export const CallIncomingCondensed = ({call, onWidget = false, global = false}: Props) => {
+export const CallIncomingCondensed = ({call, onWidget = false, joinButtonBorder = false, className}: Props) => {
     const {formatMessage} = useIntl();
     const teammateNameDisplay = useSelector(getTeammateNameDisplaySetting);
     const caller = useSelector((state: GlobalState) => getUser(state, call.callerID));
 
     useRingingAndNotification(call, onWidget);
-    const [onDismiss, onJoin] = useDismissJoin(call.channelID, call.callID, global);
+    const [onDismiss, onJoin] = useDismissJoin(call.channelID, call.callID);
 
     const callerName = displayUsername(caller, teammateNameDisplay, false);
     const message = (
@@ -44,25 +45,26 @@ export const CallIncomingCondensed = ({call, onWidget = false, global = false}: 
     );
 
     return (
-        <Container>
+        <Container className={className}>
             <Inner>
-                <Row>
-                    <Avatar
-                        url={Client4.getProfilePictureUrl(caller.id, caller.last_picture_update)}
-                        size={20}
-                        border={false}
-                    />
-                    <Message>
-                        {message}
-                    </Message>
-                    <SmallJoinButton onClick={onJoin}>
-                        <CompassIcon icon={'phone-in-talk'}/>
-                        {formatMessage({defaultMessage: 'Join'})}
-                    </SmallJoinButton>
-                    <XButton onClick={onDismiss}>
-                        <CompassIcon icon={'close'}/>
-                    </XButton>
-                </Row>
+                <Avatar
+                    url={Client4.getProfilePictureUrl(caller.id, caller.last_picture_update)}
+                    size={20}
+                    border={false}
+                />
+                <Message>
+                    {message}
+                </Message>
+                <SmallJoinButton
+                    border={joinButtonBorder}
+                    onClick={onJoin}
+                >
+                    <CompassIcon icon={'phone-in-talk'}/>
+                    {formatMessage({defaultMessage: 'Join'})}
+                </SmallJoinButton>
+                <XButton onClick={onDismiss}>
+                    <CompassIcon icon={'close'}/>
+                </XButton>
             </Inner>
         </Container>
     );
@@ -80,12 +82,10 @@ const Inner = styled.div`
     font-weight: 400;
     font-size: 12px;
     background-color: rgba(0, 0, 0, 0.16);
-`;
-
-const Row = styled.div`
     display: flex;
     flex-direction: row;
     align-items: center;
+    gap: 6px;
 `;
 
 const Message = styled.div`
@@ -93,22 +93,31 @@ const Message = styled.div`
     white-space: nowrap;
     text-overflow: ellipsis;
     color: var(--button-color);
-    margin: 0 auto 0 6px;
+    margin-right: auto;
 `;
 
-const SmallJoinButton = styled(Button)`
+const SmallJoinButton = styled(Button)<{border: boolean}>`
     justify-content: center;
     height: 24px;
     padding: 4px 10px 4px 0;
-    margin-left: 2px;
     font-weight: 600;
     font-size: 11px;
 
     background-color: rgba(var(--button-color-rgb), 0.12);
     color: var(--button-color);
 
+    ${({border}) => border && css`
+        background-color: transparent;
+        border-radius: 4px;
+        border: 1px solid var(--button-color);
+
+        &:hover {
+            background-color: rgba(var(--button-color-rgb), 0.12);
+        }
+    `}
+
     i {
-        font-size: 14px;
+        font-size: 15px;
         margin: 0 2px 0 5px;
     }
 `;
@@ -116,9 +125,10 @@ const SmallJoinButton = styled(Button)`
 const XButton = styled.button`
     border: 0;
     height: 24px;
-    padding: 0 4px;
-    margin-left: 2px;
+    padding: 0 3px;
+    margin-left: -2px;
     border-radius: 4px;
+    font-size: 15px;
     background-color: transparent;
     color: rgba(var(--button-color-rgb), 0.56);
 

--- a/webapp/src/components/incoming_calls/expanded_call_container.tsx
+++ b/webapp/src/components/incoming_calls/expanded_call_container.tsx
@@ -16,31 +16,26 @@ export const ExpandedCallContainer = () => {
     }
 
     return (
-        <OuterContainer>
-            <Container>
-                {calls.map((c) => (
-                    <StyledCallIncoming
-                        key={c.callID}
-                        call={c}
-                        joinButtonBorder={true}
-                    />
-                ))}
-            </Container>
-        </OuterContainer>
+        <Container>
+            {calls.map((c) => (
+                <StyledCallIncoming
+                    key={c.callID}
+                    call={c}
+                    joinButtonBorder={true}
+                />
+            ))}
+        </Container>
     );
 };
 
-const OuterContainer = styled.div`
-    text-align: right;
-    overflow: hidden;
-    white-space: nowrap;
-`;
-
 const Container = styled.div`
-    float: right;
     display: flex;
+    flex-direction: column;
+    align-self: flex-start;
+    margin-top: 8px;
     gap: 5px;
     margin-right: 7px;
+    z-index: 1;
 `;
 
 const StyledCallIncoming = styled(CallIncomingCondensed)`

--- a/webapp/src/components/incoming_calls/expanded_call_container.tsx
+++ b/webapp/src/components/incoming_calls/expanded_call_container.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {useSelector} from 'react-redux';
+
+import styled from 'styled-components';
+
+import {CallIncomingCondensed} from 'src/components/incoming_calls/call_incoming_condensed';
+
+import {ringingEnabled, sortedIncomingCalls} from 'src/selectors';
+
+export const ExpandedCallContainer = () => {
+    const enabled = useSelector(ringingEnabled);
+    const calls = useSelector(sortedIncomingCalls);
+
+    if (!enabled || calls.length === 0) {
+        return null;
+    }
+
+    return (
+        <OuterContainer>
+            <Container>
+                {calls.map((c) => (
+                    <StyledCallIncoming
+                        key={c.callID}
+                        call={c}
+                        joinButtonBorder={true}
+                    />
+                ))}
+            </Container>
+        </OuterContainer>
+    );
+};
+
+const OuterContainer = styled.div`
+    text-align: right;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
+const Container = styled.div`
+    float: right;
+    display: flex;
+    gap: 5px;
+    margin-right: 7px;
+`;
+
+const StyledCallIncoming = styled(CallIncomingCondensed)`
+    max-width: 287px;
+`;

--- a/webapp/src/components/incoming_calls/hooks.ts
+++ b/webapp/src/components/incoming_calls/hooks.ts
@@ -40,10 +40,10 @@ export const useDismissJoin = (channelID: string, callID: string) => {
     };
 
     const onJoin = () => {
-        dispatch(dismissIncomingCallNotification(channelID, callID));
-        notificationSounds?.stopRing(); // And stop ringing for _any_ incoming call.
+        notificationSounds?.stopRing(); // Stop ringing for _any_ incoming call.
 
         if (connectedID) {
+            // Note: notification will be dismissed from the SwitchCallModal
             if (global && desktopGTE(5, 5)) {
                 logDebug('sending calls-join-request message to desktop app');
                 sendDesktopEvent('calls-join-request', {
@@ -66,6 +66,9 @@ export const useDismissJoin = (channelID: string, callID: string) => {
             dispatch(showSwitchCallModal(channelID));
             return;
         }
+
+        // We weren't connected, so dismiss the notification here.
+        dispatch(dismissIncomingCallNotification(channelID, callID));
         window.postMessage({type: 'connectCall', channelID}, window.origin);
     };
 

--- a/webapp/src/components/incoming_calls/hooks.ts
+++ b/webapp/src/components/incoming_calls/hooks.ts
@@ -26,13 +26,14 @@ import {
     ringingForCall,
 } from 'src/selectors';
 import {ChannelType, IncomingCallNotification, UserStatuses} from 'src/types/types';
-import {desktopGTE, getChannelURL, sendDesktopEvent, shouldRenderDesktopWidget, split} from 'src/utils';
+import {desktopGTE, getChannelURL, isDesktopApp, sendDesktopEvent, shouldRenderDesktopWidget, split} from 'src/utils';
 import {notificationSounds, sendDesktopNotificationToMe} from 'src/webapp_globals';
 
-export const useDismissJoin = (channelID: string, callID: string, global = false) => {
+export const useDismissJoin = (channelID: string, callID: string) => {
     const store = useStore();
     const dispatch = useDispatch();
     const connectedID = useSelector(connectedChannelID) || '';
+    const global = isDesktopApp();
 
     const onDismiss = () => {
         dispatch(dismissIncomingCallNotification(channelID, callID));

--- a/webapp/src/components/switch_call_modal/component.tsx
+++ b/webapp/src/components/switch_call_modal/component.tsx
@@ -95,8 +95,9 @@ export default class SwitchCallModal extends React.PureComponent<Props> {
 
     private joinCall = () => {
         this.props.hideSwitchCallModal();
-        window.callsClient?.disconnect();
-        window.postMessage({type: 'connectCall', channelID: this.props.currentChannel.id}, window.origin);
+        const win = window.opener ? window.opener : window;
+        win.callsClient?.disconnect();
+        win.postMessage({type: 'connectCall', channelID: this.props.currentChannel.id}, win.origin);
     };
 
     componentDidMount() {

--- a/webapp/src/components/switch_call_modal/component.tsx
+++ b/webapp/src/components/switch_call_modal/component.tsx
@@ -16,7 +16,10 @@ interface Props {
     currentDMUser: UserProfile | undefined,
     connectedDMUser: UserProfile | undefined,
     show: boolean,
+    targetChannelID: string,
+    targetCallID: string,
     hideSwitchCallModal: () => void,
+    dismissIncomingCallNotification: (channelID: string, callID: string) => void,
 }
 
 export default class SwitchCallModal extends React.PureComponent<Props> {
@@ -93,7 +96,10 @@ export default class SwitchCallModal extends React.PureComponent<Props> {
         this.props.hideSwitchCallModal();
     };
 
-    private joinCall = () => {
+    private joinCall = async () => {
+        // If there is an incoming call notification, dismiss that (and for any other clients).
+        this.props.dismissIncomingCallNotification(this.props.targetChannelID, this.props.targetCallID);
+
         this.props.hideSwitchCallModal();
         const win = window.opener ? window.opener : window;
         win.callsClient?.disconnect();
@@ -121,17 +127,21 @@ export default class SwitchCallModal extends React.PureComponent<Props> {
         if (isDMChannel(this.props.connectedChannel)) {
             message1 = (<React.Fragment>
                 {formatMessage({defaultMessage: 'You\'re already in a call with {participant}.'}, {
-                    participant: (<span style={{fontWeight: 600}}>{getUserDisplayName(this.props.connectedDMUser)}</span>)})}
+                    participant: (
+                        <span style={{fontWeight: 600}}>{getUserDisplayName(this.props.connectedDMUser)}</span>),
+                })}
             </React.Fragment>);
         } else if (isGMChannel(this.props.connectedChannel)) {
             message1 = (<React.Fragment>
                 {formatMessage({defaultMessage: 'You\'re already in a call with {participants}.'}, {
-                    participants: (<span style={{fontWeight: 600}}>{this.props.connectedChannel.display_name}</span>)})}
+                    participants: (<span style={{fontWeight: 600}}>{this.props.connectedChannel.display_name}</span>),
+                })}
             </React.Fragment>);
         } else {
             message1 = (<React.Fragment>
                 {formatMessage({defaultMessage: 'You\'re already in a call in {channel}.'}, {
-                    channel: (<span style={{fontWeight: 600}}>{this.props.connectedChannel.display_name}</span>)})}
+                    channel: (<span style={{fontWeight: 600}}>{this.props.connectedChannel.display_name}</span>),
+                })}
             </React.Fragment>);
         }
 
@@ -139,17 +149,20 @@ export default class SwitchCallModal extends React.PureComponent<Props> {
         if (isDMChannel(this.props.currentChannel)) {
             message2 = (<React.Fragment>
                 {formatMessage({defaultMessage: 'Do you want to leave and join a call with {user}?'}, {
-                    user: (<span style={{fontWeight: 600}}>{getUserDisplayName(this.props.currentDMUser)}</span>)})}
+                    user: (<span style={{fontWeight: 600}}>{getUserDisplayName(this.props.currentDMUser)}</span>),
+                })}
             </React.Fragment>);
         } else if (isGMChannel(this.props.currentChannel)) {
             message2 = (<React.Fragment>
                 {formatMessage({defaultMessage: 'Do you want to leave and join a call with {users}?'}, {
-                    users: (<span style={{fontWeight: 600}}>{this.props.currentChannel.display_name}</span>)})}
+                    users: (<span style={{fontWeight: 600}}>{this.props.currentChannel.display_name}</span>),
+                })}
             </React.Fragment>);
         } else {
             message2 = (<React.Fragment>
                 {formatMessage({defaultMessage: 'Do you want to leave and join a call in {channel}?'}, {
-                    channel: (<span style={{fontWeight: 600}}>{this.props.currentChannel.display_name}</span>)})}
+                    channel: (<span style={{fontWeight: 600}}>{this.props.currentChannel.display_name}</span>),
+                })}
             </React.Fragment>);
         }
 
@@ -172,9 +185,9 @@ export default class SwitchCallModal extends React.PureComponent<Props> {
                         </span>
                     </div>
                     <div style={this.style.body as CSSProperties}>
-                        { message1 }
+                        {message1}
                         {untranslatable(' ')}
-                        { message2 }
+                        {message2}
                     </div>
                     <div style={this.style.footer}>
                         <button

--- a/webapp/src/components/switch_call_modal/index.ts
+++ b/webapp/src/components/switch_call_modal/index.ts
@@ -4,15 +4,16 @@ import {GlobalState} from '@mattermost/types/store';
 import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 
-import {hideSwitchCallModal} from '../../actions';
-import {connectedChannelID, switchCallModal} from '../../selectors';
-import {isDMChannel, getUserIdFromDM} from '../../utils';
+import {dismissIncomingCallNotification, hideSwitchCallModal} from 'src/actions';
+import {connectedChannelID, switchCallModal, voiceChannelCallID} from 'src/selectors';
+import {isDMChannel, getUserIdFromDM} from 'src/utils';
 
 import SwitchCallModal from './component';
 
 const mapStateToProps = (state: GlobalState) => {
     const switchCallState = switchCallModal(state);
     const connectedChannel = getChannel(state, connectedChannelID(state) || '');
+    const targetCallID = voiceChannelCallID(state, switchCallState.targetID || '') || '';
     const currentChannel = switchCallState.targetID ? getChannel(state, switchCallState.targetID) : getChannel(state, getCurrentChannelId(state));
 
     let connectedDMUser;
@@ -33,11 +34,14 @@ const mapStateToProps = (state: GlobalState) => {
         currentChannel,
         connectedDMUser,
         currentDMUser,
+        targetChannelID: switchCallState.targetID,
+        targetCallID,
     };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => bindActionCreators({
     hideSwitchCallModal,
+    dismissIncomingCallNotification,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(SwitchCallModal);

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -469,3 +469,11 @@ export function callStartedTimestampFn(intl: IntlShape, startAt?: number) {
 
     return DateTime.fromMillis(startAtMillis).toRelative() || '';
 }
+
+export function userAgent(): string {
+    return window.navigator.userAgent;
+}
+
+export function isDesktopApp(): boolean {
+    return userAgent().indexOf('Mattermost') !== -1 && userAgent().indexOf('Electron') !== -1;
+}


### PR DESCRIPTION
#### Summary
- Expanded view notifications

- I tweaked the css on the condensed notification (the one that appears above the global widget and above the first notification on the LHS of the webapp and desktop) to be closer to the designs (slightly larger icons, better spacing -- but the spacing on the lhs of the notification, around the avatar and lhs of the message, is a little different than the designs -- those I think are the tweaks Matt made in an earlier PR so I didn't adjust those):
<img width="298" alt="image" src="https://github.com/mattermost/mattermost-plugin-calls/assets/1490756/ae95d896-c507-4152-90ba-a9061f78bb2c">

- And here is the expanded view notification:
<img width="847" alt="image" src="https://github.com/mattermost/mattermost-plugin-calls/assets/1490756/21c6093e-191f-4772-b993-8e78d6adcf06">

A couple notes:
- Clicking join on the webapp brings up the switch call modal within the expanded view, and if you press leave&join then the expanded view is closed and you join the new call. Clicking join on the desktop focuses the switch call modal within the desktop's channels view, and if you press leave&join then the expanded view is closed and you join the new call. Little bit of a difference, due to the way communication works between the expanded view and the webapp vs. desktop.
- The expanded notifications will force the width of the expanded view to expand, which will cause the participant RHS list to be hidden if there isn't enough space, and will force the hangup icon off the right of the view. This will happen on very small screens. I'm not sure of what we want to do in this situation because it's kind of an edge case: you would have to be on a small screen (so small that the rest of the rhs panels would be kind of useless and wonky in the first place) and you would need to receive 2 or more incoming notifications at the same time. If it does happen, you can always close the notifications to bring the hang up icon back on screen. I'll leave it up to UX to decide if it's something we want to spend time fixing it, but the solution is not straightforward (I've tried expanding past the left and hiding the overflow, but it's a bit tricky and doesn't look great at all). Maybe there's another solution other than overflow to the left?

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-53261