### PR TITLE
[MM-53508] Fix potentially empty profiles in expanded view

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -9,7 +9,6 @@ import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selec
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getThread as fetchThread} from 'mattermost-redux/actions/threads';
 import {getThread} from 'mattermost-redux/selectors/entities/threads';
-import {isCollapsedThreadsEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 import {ClientError} from 'mattermost-redux/client/client4';
@@ -222,7 +221,7 @@ export function prefetchThread(postId: string) {
         const teamId = getCurrentTeamId(state);
         const currentUserId = getCurrentUserId(state);
 
-        const thread = getThread(state, postId) ?? (await dispatch(fetchThread(currentUserId, teamId, postId, isCollapsedThreadsEnabled(state)))).data;
+        const thread = getThread(state, postId) ?? (await dispatch(fetchThread(currentUserId, teamId, postId, true))).data;
 
         return {data: thread};
     };


### PR DESCRIPTION
#### Summary

We had this strange issue where profiles would get emptied out almost randomly when loading the Calls expanded view:

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/3dd2869e-6f50-411b-8071-44e654622807)

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/bcd234c5-c64d-46f3-8d77-f924dd2ade43)

Today I was finally able to hunt this down to the `prefetchThread` action that internally calls `getThread`:

```js
getThread(userId: string, teamId: string, threadId: string, extended = true)
```

We were setting the last parameter (`extended`) based on whether CRT was enabled or not. This had the unfortunate effect of causing an almost empty profile to get loaded into the state. It's still unclear why we'd ever want to do that but hopefully someone from webapp can answer that.

@calebroseland Adding you as a sanity check since you originally added this code and if you have any additional thoughts on the above.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53508