### PR TITLE
Allow compiling single build in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,14 @@ endif
 server-ci:
 ifneq ($(HAS_SERVER),)
 	mkdir -p server/dist;
+ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
+	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-linux-amd64;
+else
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-linux-amd64;
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-linux-arm64;
 	cd server && env CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-freebsd-amd64;
 	cd server && env CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-openbsd-amd64;
+endif
 endif
 
 ## Ensures NPM dependencies are installed without having to run this all the time.


### PR DESCRIPTION
#### Summary

I'd like to be able to build the plugin on a CI pipeline for testing purposes and don't want to waste resources compiling for all architectures.

