### PR TITLE
MM-53512 - Fix first load problems

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -772,7 +772,6 @@ export default class Plugin {
             }
         });
 
-        let configRetrieved = false;
         const onActivate = async () => {
             if (!getCurrentUserId(store.getState())) {
                 // not logged in, returning. Shouldn't happen, but being defensive.
@@ -781,12 +780,7 @@ export default class Plugin {
 
             unsubscribeActivateListener();
 
-            const res = await store.dispatch(getCallsConfig());
-
-            // @ts-ignore
-            if (!res.error) {
-                configRetrieved = true;
-            }
+            await store.dispatch(getCallsConfig());
 
             const actions = await fetchChannels();
             const currChannelId = getCurrentChannelId(store.getState());
@@ -838,12 +832,6 @@ export default class Plugin {
             const currentChannelId = getCurrentChannelId(store.getState());
             if (currChannelId !== currentChannelId) {
                 currChannelId = currentChannelId;
-
-                // If we haven't retrieved config, user must not have been logged in during onActivate
-                if (!configRetrieved) {
-                    store.dispatch(getCallsConfig());
-                    configRetrieved = true;
-                }
 
                 fetchChannelData(currChannelId).then((actions) =>
                     store.dispatch(batchActions(actions)),

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -765,12 +765,23 @@ export default class Plugin {
             return actions;
         };
 
+        // Run onActivate once we're logged in. Only run it once.
+        let activated = false;
+        const unsubscribeActivateListener = store.subscribe(() => {
+            if (getCurrentUserId(store.getState()) && !activated) {
+                activated = true;
+                onActivate();
+            }
+        });
+
         let configRetrieved = false;
         const onActivate = async () => {
             if (!getCurrentUserId(store.getState())) {
-                // not logged in, returning.
+                // not logged in, returning. Shouldn't happen, but being defensive.
                 return;
             }
+
+            unsubscribeActivateListener();
 
             const res = await store.dispatch(getCallsConfig());
 
@@ -822,8 +833,6 @@ export default class Plugin {
             }
             onActivate();
         });
-
-        onActivate();
 
         let currChannelId = getCurrentChannelId(store.getState());
         let joinCallParam = new URLSearchParams(window.location.search).get('join_call');

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -765,11 +765,9 @@ export default class Plugin {
             return actions;
         };
 
-        // Run onActivate once we're logged in. Only run it once.
-        let activated = false;
+        // Run onActivate once we're logged in.
         const unsubscribeActivateListener = store.subscribe(() => {
-            if (getCurrentUserId(store.getState()) && !activated) {
-                activated = true;
+            if (getCurrentUserId(store.getState())) {
                 onActivate();
             }
         });


### PR DESCRIPTION
#### Summary
- This fixes the first load problems we've had.
- Repro steps:
  - User A starts a DM call with User B (not logged in), User B logs in
  - Expected: User B should see the call icon in the DM channel and should get the incoming call notification with ringing
  - Actual (pre-PR): User B does not see the call icon in the DM channel, does not get the incoming call notification. User B will have to click on the DM channel itself to get the call icon in the LHS. They will not receive the call notification at all.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-53512
