### PR TITLE
MM-53292 - Telemetry for DM/GM ringing notifications

### DIFF
--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -222,7 +222,9 @@ export const trackEvent = (event: Telemetry.Event, source: Telemetry.Source, pro
         Client4.doFetch(
             `${getPluginPath()}/telemetry/track`,
             {method: 'post', body: JSON.stringify(eventData)},
-        );
+        ).catch((e) => {
+            logErr(e);
+        });
     };
 };
 

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -33,7 +33,7 @@ import {
 
 import * as Telemetry from 'src/types/telemetry';
 import {ChannelType} from 'src/types/types';
-import {getPluginPath, isDMChannel, isGMChannel} from 'src/utils';
+import {getPluginPath, isDesktopApp, isDMChannel, isGMChannel} from 'src/utils';
 import {modals, notificationSounds, openPricingModal} from 'src/webapp_globals';
 
 import {
@@ -215,7 +215,7 @@ export const trackEvent = (event: Telemetry.Event, source: Telemetry.Source, pro
         }
         const eventData = {
             event,
-            clientType: window.desktop ? 'desktop' : 'web',
+            clientType: isDesktopApp() ? 'desktop' : 'web',
             source,
             props,
         };

--- a/webapp/src/components/incoming_calls/call_incoming_condensed.tsx
+++ b/webapp/src/components/incoming_calls/call_incoming_condensed.tsx
@@ -34,8 +34,8 @@ export const CallIncomingCondensed = ({call, onWidget = false, joinButtonBorder 
     const [callerName, others] = useGetCallerNameAndOthers(call, 10);
     const [showTooltip, setShowTooltip] = useState(false);
 
-    const [onDismiss, onJoin] = useDismissJoin(call.channelID, call.callID);
-    const onContainerClick = useOnChannelLinkClick(call);
+    const [onDismiss, onJoin] = useDismissJoin(call.channelID, call.callID, onWidget);
+    const onContainerClick = useOnChannelLinkClick(call, onWidget);
     useRingingAndNotification(call, onWidget);
 
     // Do not allow clicks in the webapp expanded view because Safari does not let us switch and focus parent.

--- a/webapp/src/components/incoming_calls/hooks.ts
+++ b/webapp/src/components/incoming_calls/hooks.ts
@@ -276,7 +276,7 @@ export const useOnChannelLinkClick = (call: IncomingCallNotification, onWidget =
 export const telemetrySource = (onWidget: boolean) => {
     if (onWidget) {
         return Telemetry.Source.Widget;
-    } else if (window.location.pathname.includes(`${pluginId}/expanded/`)) {
+    } else if (window.opener) {
         return Telemetry.Source.ExpandedView;
     }
 

--- a/webapp/src/components/incoming_calls/hooks.ts
+++ b/webapp/src/components/incoming_calls/hooks.ts
@@ -14,9 +14,10 @@ import {useIntl} from 'react-intl';
 import {useDispatch, useSelector, useStore} from 'react-redux';
 
 import {DID_NOTIFY_FOR_CALL, DID_RING_FOR_CALL} from 'src/action_types';
-import {dismissIncomingCallNotification, ringForCall, showSwitchCallModal} from 'src/actions';
+import {dismissIncomingCallNotification, ringForCall, showSwitchCallModal, trackEvent} from 'src/actions';
 import {DEFAULT_RING_SOUND} from 'src/constants';
 import {logDebug} from 'src/log';
+import {pluginId} from 'src/manifest';
 import {
     connectedChannelID,
     connectedTeam,
@@ -26,6 +27,7 @@ import {
     getStatusForCurrentUser,
     ringingForCall,
 } from 'src/selectors';
+import * as Telemetry from 'src/types/telemetry';
 import {ChannelType, IncomingCallNotification, UserStatuses} from 'src/types/types';
 import {
     desktopGTE,
@@ -38,20 +40,23 @@ import {
 } from 'src/utils';
 import {notificationSounds, sendDesktopNotificationToMe} from 'src/webapp_globals';
 
-export const useDismissJoin = (channelID: string, callID: string) => {
+export const useDismissJoin = (channelID: string, callID: string, onWidget = false) => {
     const store = useStore();
     const dispatch = useDispatch();
     const connectedID = useSelector(connectedChannelID) || '';
     const global = isDesktopApp();
+    const source = telemetrySource(onWidget);
 
     const onDismiss = (ev: React.MouseEvent<HTMLElement>) => {
         ev.stopPropagation();
         dispatch(dismissIncomingCallNotification(channelID, callID));
+        dispatch(trackEvent(Telemetry.Event.NotificationDismiss, source));
     };
 
     const onJoin = (ev: React.MouseEvent<HTMLElement>) => {
         ev.stopPropagation();
         notificationSounds?.stopRing(); // Stop ringing for _any_ incoming call.
+        dispatch(trackEvent(Telemetry.Event.NotificationJoin, source));
 
         if (connectedID) {
             // Note: notification will be dismissed from the SwitchCallModal
@@ -239,11 +244,13 @@ export const useGetCallerNameAndOthers = (call: IncomingCallNotification, splitA
     return [callerName, others];
 };
 
-export const useOnChannelLinkClick = (call: IncomingCallNotification) => {
+export const useOnChannelLinkClick = (call: IncomingCallNotification, onWidget = false) => {
+    const dispatch = useDispatch();
     const global = Boolean(isDesktopApp() && getCallsClient());
     const defaultTeam = useSelector(connectedTeam);
     const channel = useSelector((state: GlobalState) => getChannel(state, call.channelID));
     let channelURL = useSelector((state: GlobalState) => getChannelURL(state, channel, channel.team_id));
+    const source = telemetrySource(onWidget);
 
     if (global && channelURL.startsWith('/channels')) {
         // The global widget isn't resolving the currentTeam if we're on a regular channel, so we need to add it manually.
@@ -253,13 +260,25 @@ export const useOnChannelLinkClick = (call: IncomingCallNotification) => {
     if (global) {
         return () => {
             notificationSounds?.stopRing(); // User interacted with notifications, so stop ringing for _any_ incoming call.
+            dispatch(trackEvent(Telemetry.Event.NotificationClickGotoChannel, source));
             sendDesktopEvent('calls-link-click', {link: channelURL});
         };
     }
 
     return () => {
         notificationSounds?.stopRing();
+        dispatch(trackEvent(Telemetry.Event.NotificationClickGotoChannel, source));
         const win = window.opener ? window.opener : window;
         win.postMessage({type: 'browser-history-push-return', message: {pathName: channelURL}}, window.origin);
     };
+};
+
+export const telemetrySource = (onWidget: boolean) => {
+    if (onWidget) {
+        return Telemetry.Source.Widget;
+    } else if (window.location.pathname.includes(`${pluginId}/expanded/`)) {
+        return Telemetry.Source.ExpandedView;
+    }
+
+    return Telemetry.Source.Channels;
 };

--- a/webapp/src/components/incoming_calls/hooks.ts
+++ b/webapp/src/components/incoming_calls/hooks.ts
@@ -17,7 +17,6 @@ import {DID_NOTIFY_FOR_CALL, DID_RING_FOR_CALL} from 'src/action_types';
 import {dismissIncomingCallNotification, ringForCall, showSwitchCallModal, trackEvent} from 'src/actions';
 import {DEFAULT_RING_SOUND} from 'src/constants';
 import {logDebug} from 'src/log';
-import {pluginId} from 'src/manifest';
 import {
     connectedChannelID,
     connectedTeam,

--- a/webapp/src/types/telemetry.ts
+++ b/webapp/src/types/telemetry.ts
@@ -10,11 +10,14 @@ export enum Event {
     OpenChannelLink = 'user_open_channel_link',
     StartRecording = 'user_start_recording',
     StopRecording = 'user_stop_recording',
+    NotificationJoin = 'notification_join',
+    NotificationDismiss = 'notification_dismiss',
+    NotificationClickGotoChannel = 'notification_click_goto_channel',
 }
 
 export enum Source {
     Widget = 'widget',
     ExpandedView = 'expanded_view',
     SlashCommand = 'slash_command',
+    Channels = 'channels',
 }
-


### PR DESCRIPTION
#### Summary
- Adds the following three events to our telemetry:
  - `notification_join`
  - `notification_dismiss`
  - `notification_click_goto_channel`
- And the `channels` source, which along with the `widget` and `expanded_view` show where the event came from.
- A couple notes for feedback:
  - I assumed it doesn't matter if the event from the condensed notification comes from the global widget vs the webapp widget (events for those two sources will have the source set to `widget`).
  - Similarly, I assumed it doesn't matter if the LHS notification is a regular vs condensed notification (events for those two components will have the source set to `channels`).
- The expanded view on desktop was mistakenly reporting `clientType` of `web` instead of `desktop`, so telemetry prior to v8.1 & Calls v0.18.0 will be incorrect on that variable.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-53292