### PR TITLE
[MM-53205] Remove reaction(s) from store when sending user leaves call

### DIFF
--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -284,6 +284,19 @@ const reactionStatus = (state: userReactionsState = {}, action: usersStatusesAct
                     }),
             },
         };
+    case VOICE_CHANNEL_USER_DISCONNECTED:
+        if (!state[action.data.channelID] || !state[action.data.channelID].reactions) {
+            return state;
+        }
+
+        return {
+            ...state,
+            [action.data.channelID]: {
+                reactions: state[action.data.channelID].reactions.filter((r) => {
+                    return r.user_id !== action.data.userID;
+                }),
+            },
+        };
     default:
         return state;
     }


### PR DESCRIPTION
#### Summary

It doesn't look like we were updating the reducer when the user left the call. This should fix the issue. 
There could still be a race between disconnect and reaction events but that's more of an edge case. To cover that we'd have to check whether the user is connected to the call before queuing the reaction but at this time it seems a bit overkill.
 
#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53205