### PR TITLE
[MM-53757] Don't show recording dialog on host change if previously dismissed

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1419,6 +1419,12 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             return null;
         }
 
+        // If the host has changed for the current recording after the banner was dismissed, we should show
+        // again only if the user is the new host.
+        if (dismissedAt > recording?.start_at && this.props.callHostChangeAt > dismissedAt && !isHost) {
+            return null;
+        }
+
         let header = formatMessage(CallRecordingDisclaimerStrings[isHost ? 'host' : 'participant'].header);
         let body = formatMessage(CallRecordingDisclaimerStrings[isHost ? 'host' : 'participant'].body);
         let confirmText = isHost ? formatMessage({defaultMessage: 'Dismiss'}) : formatMessage({defaultMessage: 'Understood'});

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -116,6 +116,12 @@ export default function RecordingInfoPrompt(props: Props) {
         return null;
     }
 
+    // If the host has changed for the current recording after the banner was dismissed, we should show
+    // again only if the user is the new host.
+    if (disclaimerDismissedAt > props.recording?.start_at && props.hostChangeAt > disclaimerDismissedAt && !props.isHost) {
+        return null;
+    }
+
     let testId = 'banner-recording';
     let header = formatMessage(CallRecordingDisclaimerStrings[props.isHost ? 'host' : 'participant'].header);
     let body = formatMessage(CallRecordingDisclaimerStrings[props.isHost ? 'host' : 'participant'].body);


### PR DESCRIPTION
#### Summary

Adding an additional check in case the host changes after the banner is dismissed. In such case we should only show it again if the current user is the new host.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53757