### PR TITLE
[MM-53986] Fix logic to toggle recordings

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -99,6 +99,7 @@ interface Props extends RouteComponentProps {
     callHostID: string,
     callHostChangeAt: number,
     callRecording?: CallRecordingReduxState,
+    isRecording: boolean,
     hideExpandedView: () => void,
     showScreenSourceModal: () => void,
     selectRhsPost?: (postID: string) => void,
@@ -442,12 +443,12 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
     }
 
     onRecordToggle = async (fromShortcut?: boolean) => {
-        if (!this.props.callRecording?.start_at || this.props.callRecording?.end_at > 0) {
-            await this.props.startCallRecording(this.props.channel.id);
-            this.props.trackEvent(Telemetry.Event.StartRecording, Telemetry.Source.ExpandedView, {initiator: fromShortcut ? 'shortcut' : 'button'});
-        } else {
+        if (this.props.isRecording) {
             await stopCallRecording(this.props.channel.id);
             this.props.trackEvent(Telemetry.Event.StopRecording, Telemetry.Source.ExpandedView, {initiator: fromShortcut ? 'shortcut' : 'button'});
+        } else {
+            await this.props.startCallRecording(this.props.channel.id);
+            this.props.trackEvent(Telemetry.Event.StartRecording, Telemetry.Source.ExpandedView, {initiator: fromShortcut ? 'shortcut' : 'button'});
         }
     };
 
@@ -987,7 +988,9 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         const isChatUnread = Boolean(this.props.threadUnreadReplies);
 
         const isHost = this.props.callHostID === this.props.currentUserID;
-        const isRecording = isHost && this.props.callRecording && this.props.callRecording.init_at > 0 && !this.props.callRecording.end_at && !this.props.callRecording.err;
+
+        const isRecording = isHost && this.props.isRecording;
+
         const recordTooltipText = isRecording ? formatMessage({defaultMessage: 'Stop recording'}) : formatMessage({defaultMessage: 'Record call'});
         const RecordIcon = isRecording ? RecordSquareIcon : RecordCircleIcon;
         const ShareIcon = isSharing ? UnshareScreenIcon : ShareScreenIcon;

--- a/webapp/src/components/expanded_view/index.ts
+++ b/webapp/src/components/expanded_view/index.ts
@@ -20,6 +20,7 @@ import {
 import {
     allowScreenSharing,
     callRecording,
+    isRecording,
     connectedChannelID,
     expandedView,
     getChannelUrlAndDisplayName,
@@ -79,6 +80,7 @@ const mapStateToProps = (state: GlobalState) => {
         callHostID: voiceChannelCallHostID(state, channel?.id) || '',
         callHostChangeAt: voiceChannelCallHostChangeAt(state, channel?.id) || 0,
         callRecording: callRecording(state, channel?.id),
+        isRecording: isRecording(state, channel?.id),
         screenSharingID,
         channel,
         channelTeam,

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -197,6 +197,18 @@ export const callRecording = (state: GlobalState, callID: string): CallRecording
     return pluginState(state).callsRecordings[callID];
 };
 
+export const isRecording = (state: GlobalState, callID: string): boolean => {
+    const recording = callRecording(state, callID);
+    if (!recording) {
+        return false;
+    }
+
+    // Toggle wise (start/stop) we don't care whether the recording job is actually running.
+    // We should be able to stop a recording even during the initialization phase.
+
+    return recording.init_at > recording.end_at;
+};
+
 export const expandedView = (state: GlobalState) => {
     return pluginState(state).expandedView;
 };


### PR DESCRIPTION
#### Summary

PR fixes an issue with toggling the recording state (start/stop). The logic was a bit overly complex which resulted in a bug preventing a host from stopping a recording if this was initializing but not started yet. Slash commands worked better although they were flawed as well (host would be allowed to start a recording while one was initializing, resulting in a server side error).

I am adding a dedicated selector so that we can share the same, simplified logic.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53986