### PR TITLE
[MM-53988] Improve logic for showing recording stopped banner

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -34,7 +34,7 @@ import UnmutedIcon from 'src/components/icons/unmuted_icon';
 import UnraisedHandIcon from 'src/components/icons/unraised_hand';
 import UnshareScreenIcon from 'src/components/icons/unshare_screen';
 import {CallIncomingCondensed} from 'src/components/incoming_calls/call_incoming_condensed';
-import {CallAlertConfigs, CallRecordingDisclaimerStrings, CALL_HOST_CHANGE_THRESHOLD} from 'src/constants';
+import {CallAlertConfigs, CallRecordingDisclaimerStrings} from 'src/constants';
 import {logDebug, logErr} from 'src/log';
 import {
     keyToAction,
@@ -1432,9 +1432,8 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         }
 
         // If the user became host after the recording has ended we don't want to
-        // show the "Recording has stopped" banner, unless the change happened very
-        // recently (i.e. in the last minute).
-        if (isHost && hasRecEnded && (this.props.callHostChangeAt - recording.end_at) > CALL_HOST_CHANGE_THRESHOLD) {
+        // show the "Recording has stopped" banner.
+        if (isHost && hasRecEnded && this.props.callHostChangeAt > recording.end_at) {
             if (!shouldShowError) {
                 return null;
             }

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -5,7 +5,6 @@ import CompassIcon from 'src/components/icons/compassIcon';
 import RecordCircleIcon from 'src/components/icons/record_circle';
 import {
     CallRecordingDisclaimerStrings,
-    CALL_HOST_CHANGE_THRESHOLD,
 } from 'src/constants';
 import {CallRecordingReduxState} from 'src/types/types';
 import {
@@ -132,7 +131,7 @@ export default function RecordingInfoPrompt(props: Props) {
     // If the user became host after the recording has ended we only show
     // the "Recording has stopped" message if the change happened very
     // recently (i.e. in the last minute).
-    if (props.isHost && hasRecEnded && (props.hostChangeAt - props.recording.end_at) > CALL_HOST_CHANGE_THRESHOLD) {
+    if (props.isHost && hasRecEnded && props.hostChangeAt > props.recording.end_at) {
         if (!shouldShowError) {
             return null;
         }

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -5,6 +5,7 @@ import CompassIcon from 'src/components/icons/compassIcon';
 import RecordCircleIcon from 'src/components/icons/record_circle';
 import {
     CallRecordingDisclaimerStrings,
+    CALL_HOST_CHANGE_THRESHOLD,
 } from 'src/constants';
 import {CallRecordingReduxState} from 'src/types/types';
 import {
@@ -53,7 +54,7 @@ export default function RecordingInfoPrompt(props: Props) {
         }
     }, [props.isHost, props.recording, recordingWillEndSoon, getMinutesLeftBeforeEnd]);
 
-    const hasRecEnded = props.recording?.end_at;
+    const hasRecEnded = (props.recording?.end_at ?? 0) > (props.recording?.start_at ?? 0);
 
     // Unfortunately we cannot update the local redux state immediately because the props.channel is not available,
     // so we have to check which is more up to date and use that.
@@ -102,10 +103,12 @@ export default function RecordingInfoPrompt(props: Props) {
         return null;
     }
 
+    const shouldShowError = props.recording?.error_at && disclaimerDismissedAt > props.recording.error_at;
+
     // If the prompt was dismissed after the recording has started and after the last host change
     // we don't show this again, unless there was a more recent error.
     if (!hasRecEnded && disclaimerDismissedAt > props.recording?.start_at && disclaimerDismissedAt > props.hostChangeAt) {
-        if (!props.recording?.error_at || disclaimerDismissedAt > props.recording.error_at) {
+        if (!shouldShowError) {
             return null;
         }
     }
@@ -113,13 +116,26 @@ export default function RecordingInfoPrompt(props: Props) {
     // If the prompt was dismissed after the recording has ended then we
     // don't show this again.
     if (hasRecEnded && disclaimerDismissedAt > props.recording?.end_at) {
-        return null;
+        if (!shouldShowError) {
+            return null;
+        }
     }
 
     // If the host has changed for the current recording after the banner was dismissed, we should show
     // again only if the user is the new host.
     if (disclaimerDismissedAt > props.recording?.start_at && props.hostChangeAt > disclaimerDismissedAt && !props.isHost) {
-        return null;
+        if (!shouldShowError) {
+            return null;
+        }
+    }
+
+    // If the user became host after the recording has ended we only show
+    // the "Recording has stopped" message if the change happened very
+    // recently (i.e. in the last minute).
+    if (props.isHost && hasRecEnded && (props.hostChangeAt - props.recording.end_at) > CALL_HOST_CHANGE_THRESHOLD) {
+        if (!shouldShowError) {
+            return null;
+        }
     }
 
     let testId = 'banner-recording';

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -128,9 +128,8 @@ export default function RecordingInfoPrompt(props: Props) {
         }
     }
 
-    // If the user became host after the recording has ended we only show
-    // the "Recording has stopped" message if the change happened very
-    // recently (i.e. in the last minute).
+    // If the user became host after the recording has ended we don't want to
+    // show the "Recording has stopped" banner.
     if (props.isHost && hasRecEnded && props.hostChangeAt > props.recording.end_at) {
         if (!shouldShowError) {
             return null;

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -8,6 +8,7 @@ export const JOINED_USER_NOTIFICATION_TIMEOUT = 5000;
 export const MAX_CHANNEL_LINK_TOOLTIP_NAMES = 8;
 export const RING_LENGTH = 30000;
 export const DEFAULT_RING_SOUND = 'Calm';
+export const CALL_HOST_CHANGE_THRESHOLD = 60000; // 1 minute
 
 export const CallAlertConfigs: {[key: string]: CallAlertConfig} = {
     missingAudioInput: {

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -8,7 +8,6 @@ export const JOINED_USER_NOTIFICATION_TIMEOUT = 5000;
 export const MAX_CHANNEL_LINK_TOOLTIP_NAMES = 8;
 export const RING_LENGTH = 30000;
 export const DEFAULT_RING_SOUND = 'Calm';
-export const CALL_HOST_CHANGE_THRESHOLD = 60000; // 1 minute
 
 export const CallAlertConfigs: {[key: string]: CallAlertConfig} = {
     missingAudioInput: {


### PR DESCRIPTION
#### Summary

PR fixes an issues that would cause the *Recording has stopped. Processing...* message to appear to a newly changed host regardless of when the recording ended.

~~I am adding a threshold (currently one minute) after which we wouldn't show this. Technically we could just show it to the host at the time of stopping the recording but felt it may be useful to keep it around in case of a sudden host change. Overall though I don't have a strong opinion myself and feel it's more of a UX decision.~~

Regardless of what we do here, at some point (likely as part of host controls) we may want to design a message to inform a user that they became the host.

/cc @matthewbirtch in case you'd like to chime in on any of the above.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53988