### PR TITLE
[MM-53994] Fix potential stuck session due to ws client leak

### DIFF
--- a/server/rtcd.go
+++ b/server/rtcd.go
@@ -583,14 +583,15 @@ func (m *rtcdClientManager) handleClientMsg(msg rtcd.ClientMessage) error {
 			return fmt.Errorf("missing sessionID")
 		}
 		m.ctx.LogDebug("received close message from rtcd", "sessionID", sessionID)
-		m.ctx.mut.RLock()
-		us := m.ctx.sessions[sessionID]
-		m.ctx.mut.RUnlock()
+		us := m.ctx.getSessionByOriginalID(sessionID)
 		if us != nil && atomic.CompareAndSwapInt32(&us.rtcClosed, 0, 1) {
 			m.ctx.LogDebug("closing rtc close channel", "sessionID", sessionID)
 			close(us.rtcCloseCh)
 			return m.ctx.removeSession(us)
 		}
+
+		m.ctx.LogDebug("session not found or rtc conn already closed", "sessionID", sessionID)
+
 		return nil
 	}
 

--- a/server/session.go
+++ b/server/session.go
@@ -340,3 +340,28 @@ func (p *Plugin) removeSession(us *session) error {
 	}
 	return nil
 }
+
+// getSessionByOriginalID retrieves a session by its original connection ID
+// which is also the session ID matching the RTC connection.
+func (p *Plugin) getSessionByOriginalID(sessionID string) *session {
+	p.mut.RLock()
+	defer p.mut.RUnlock()
+
+	// We first try to see if the session is mapped by its original ID since
+	// it's more efficient and the most probable case.
+	us := p.sessions[sessionID]
+	if us != nil {
+		return us
+	}
+
+	// If we can't find one, we resort to looping through all the sessions to
+	// check against the originalConnID field. This would be necessary only if
+	// the session reconnected throughout the call with a new ws connection ID.
+	for _, s := range p.sessions {
+		if s.originalConnID == sessionID {
+			return s
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### Summary

This was a fun one. A session was stuck in the call state after the client explicitly left the call and the RTC connection was closed, only to reconnect on the ws channel every now and then hours after the fact.

They key issue here was that we were improperly using the state of the WebSocket object field (`callsClient.ws.ws`) as a way to differentiate between an explicit disconnect (e.g. user leaving call) vs an event triggered disconnect (e.g. network issue). Unfortunately the logic didn't account for the potential edge case of an explicit disconnect happening right after a network disconnect.

The sequence of events was roughly the following:

1. A websocket disconnect happens (network/service related).
  a. `this.ws` is set to `null` in the `ws.onclose` handler.
  b. `close()` gets called and initializes the reconnect handler.
2. User explicitly leaves call before the ws client is able to reconnect.
  a. `callsClient.disconnect()` gets called.
  b. `callsClient.ws.close()` gets called.
  c. `callsClients.ws.ws` is `null` due to step 1a so we try to reconnect again instead of terminating the ws connection.
3. `callsClient` object is cleared from window but essentially leaked given its ws client was never properly closed and will endlessly try to reconnect on any future disconnect.

Note: I am aware the above sequence was likely more useful to me, happy to explain anything unclear.

To fix the above we move the reconnect logic into its own method and solely rely on `callsClient.ws.closed` to decide whether we should reconnect or not. 

In addition to the above, we also fix a related issue on the server side which would have prevented the stuck session (not the client side leak though). The problem here was that a reconnected session may have have changed its websocket connection ID which would then differ from the original session ID used to track the RTC session.

Big thanks to @wiggin77 for providing client logs which turned out to be key into figure out what was going on.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53994