### PR TITLE
[MM-54000] Fix alignment and stretching of call icon in post component

### DIFF
--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -233,6 +233,7 @@ const Left = styled.div`
     flex-grow: 10;
     overflow: hidden;
     white-space: nowrap;
+    align-items: center;
 `;
 
 const Right = styled.div`
@@ -246,6 +247,7 @@ const CallIndicator = styled.div<{ ended: boolean }>`
     padding: 10px;
     width: 40px;
     height: 40px;
+    flex-shrink: 0;
 `;
 
 const MessageWrapper = styled.div`


### PR DESCRIPTION
#### Summary

PR disables shrinking of the call icon to prevent the stretch effect when the content wraps (e.g. frequent in RHS). Also setting the vertical alignment to be centered.

#### Before

![before_ended](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/8c339fc0-0a6c-41f1-919d-659867bc6710)

#### After

![after_ended](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/186c196d-7db7-424d-90bc-7f1d1a448e57)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54000
