### PR TITLE
[MM-54144] Fix screen thumbnail content overflow

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -814,6 +814,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         <video
                             id='screen-player'
                             ref={this.setScreenPlayerRef}
+                            style={{maxHeight: '188px'}}
                             width='100%'
                             height='100%'
                             autoPlay={true}


### PR DESCRIPTION
#### Summary

It's possibly the third time I try to fix this. It's easily reproducible on Community but not on local setup so maybe there's some conflicting definition taking place. Anyhow, forcing a max height on the video player element seems to be enough.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54144