### PR TITLE
Fix initialization for standalone client

### DIFF
--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -141,7 +141,8 @@ async function fetchChannelData(store: Store, channelID: string) {
     );
 
     if (!resp.call) {
-        throw new Error('call missing from response');
+        // This is expected if the client is starting the call.
+        return;
     }
 
     store.dispatch({
@@ -353,7 +354,13 @@ export default async function init(cfg: InitConfig) {
     const theme = getTheme(store.getState());
     applyTheme(theme);
 
-    await cfg.initCb(store, theme, channelID);
+    try {
+        await cfg.initCb(store, theme, channelID);
+    } catch (err) {
+        logErr('initCb failed', err);
+        window.callsClient?.destroy();
+        return;
+    }
 
     logDebug(`${cfg.name} init completed in ${Math.round(performance.now() - initStartTime)}ms`);
 }

--- a/standalone/src/recording/index.tsx
+++ b/standalone/src/recording/index.tsx
@@ -8,7 +8,7 @@ import {Theme} from 'mattermost-redux/types/themes';
 import {getCurrentUserId} from 'mattermost-webapp/packages/mattermost-redux/src/selectors/entities/users';
 import {logErr} from 'plugin/log';
 import {pluginId} from 'plugin/manifest';
-import {voiceConnectedProfilesInChannel} from 'plugin/selectors';
+import {voiceConnectedProfilesInChannel, voiceChannelCallStartAt} from 'plugin/selectors';
 import {Store} from 'plugin/types/mattermost-webapp';
 import {getProfilesByIds, getPluginPath, fetchTranslationsFile, setCallsGlobalCSSVars} from 'plugin/utils';
 import React from 'react';
@@ -71,6 +71,10 @@ async function initRecordingStore(store: Store, channelID: string) {
 }
 
 async function initRecording(store: Store, theme: Theme, channelID: string) {
+    if (!voiceChannelCallStartAt(store.getState(), channelID)) {
+        throw new Error('call is missing from store');
+    }
+
     await store.dispatch({
         type: VOICE_CHANNEL_USER_CONNECTED,
         data: {


### PR DESCRIPTION
#### Summary

A change in https://github.com/mattermost/mattermost-plugin-calls/pull/489 caused the standalone client to fail to connect when starting a call. We move the check into the logic dedicated to the recording client which can make the assumption of always joining an existing/ongoing call.

This problem was caught by e2e tests but unfortunately they are failing to update their status to Github due to an internal security issue which is being worked on (see https://community.mattermost.com/private-core/pl/yxta5iem53y1br93ksjdj7tkyh).

