### PR TITLE
[MM-54216] Bump ws rate limiting burst

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -47,7 +47,8 @@ type session struct {
 	leaveCh chan struct{}
 	left    int32
 
-	limiter *rate.Limiter
+	// rate limiter for incoming WebSocket messages.
+	wsMsgLimiter *rate.Limiter
 }
 
 func newUserSession(userID, channelID, connID string, rtc bool) *session {
@@ -62,7 +63,7 @@ func newUserSession(userID, channelID, connID string, rtc bool) *session {
 		wsReconnectCh:  make(chan struct{}),
 		leaveCh:        make(chan struct{}),
 		rtcCloseCh:     make(chan struct{}),
-		limiter:        rate.NewLimiter(2, 50),
+		wsMsgLimiter:   rate.NewLimiter(10, 100),
 		rtc:            rtc,
 	}
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -170,6 +170,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 	p.metrics.IncWebSocketEvent("in", msg.Type)
 	switch msg.Type {
 	case clientMessageTypeSDP:
+		p.LogDebug("received sdp", "connID", us.connID, "originalConnID", us.originalConnID, "userID", us.userID)
 		// if I am not the handler for this we relay the signaling message.
 		if handlerID != p.nodeID {
 			// need to relay signaling.
@@ -194,7 +195,7 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 			}
 		}
 	case clientMessageTypeICE:
-		p.LogDebug("candidate!")
+		p.LogDebug("received ice candidate", "connID", us.connID, "originalConnID", us.originalConnID, "userID", us.userID)
 		if handlerID == p.nodeID {
 			rtcMsg := rtc.Message{
 				SessionID: us.originalConnID,
@@ -748,7 +749,7 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 		return
 	}
 
-	if us != nil && !us.limiter.Allow() {
+	if us != nil && !us.wsMsgLimiter.Allow() {
 		p.LogError("message was dropped by rate limiter", "msgType", msg.Type, "userID", us.userID, "connID", us.connID)
 		return
 	}


### PR DESCRIPTION
#### Summary

It looks like Firefox can be spamming a very long list of candidates if running on an instance with many network interfaces and hit the rate limiter which will drop messages, potentially preventing proper connectivity. What's worse, upon first unmute or screen sharing attempt it will do more of the same.

Note to self: this should be the last time we bump this. If the problem reappears we need to investigate a different solution.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54216
