### PR TITLE
Fix recording error logic

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -1406,7 +1406,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             return null;
         }
 
-        const shouldShowError = recording?.error_at && dismissedAt > recording.error_at;
+        const shouldShowError = recording?.error_at && recording.error_at > dismissedAt;
 
         // If the prompt was dismissed after the recording has started and after the last host change
         // we don't show this again, unless there was a more recent error.

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -102,7 +102,7 @@ export default function RecordingInfoPrompt(props: Props) {
         return null;
     }
 
-    const shouldShowError = props.recording?.error_at && disclaimerDismissedAt > props.recording.error_at;
+    const shouldShowError = props.recording?.error_at && props.recording.error_at > disclaimerDismissedAt;
 
     // If the prompt was dismissed after the recording has started and after the last host change
     // we don't show this again, unless there was a more recent error.


### PR DESCRIPTION
#### Summary

The condition to show the error was actually inverted, causing the banner to get stuck indefinitely in case of error.

Note: we should likely review this logic and at least have it in a single place, although I don't know how much can be simplified.

