### PR TITLE
Fix linter errors

### DIFF
--- a/lt/ws/client_test.go
+++ b/lt/ws/client_test.go
@@ -67,12 +67,6 @@ func TestClose(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		go func() {
-			// Just drain the event channel
-			for range c.EventChannel {
-			}
-		}()
-
 		err = c.SendMessage("test_action", map[string]interface{}{"test": "data"})
 		assert.Nil(t, err)
 
@@ -95,12 +89,6 @@ func TestClose(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		go func() {
-			// Just drain the event channel
-			for range c.EventChannel {
-			}
-		}()
-
 		err = c.SendMessage("test_action", map[string]interface{}{"test": "data"})
 		assert.Nil(t, err)
 
@@ -118,12 +106,6 @@ func TestClose(t *testing.T) {
 			AuthToken: "authToken",
 		})
 		require.Nil(t, err)
-
-		go func() {
-			// Just drain the event channel
-			for range c.EventChannel {
-			}
-		}()
 
 		err = c.SendMessage("test_action", map[string]interface{}{"test": "data"})
 		assert.Nil(t, err)
@@ -165,12 +147,6 @@ func TestSendMessage(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		go func() {
-			// Just drain the event channel
-			for range c.EventChannel {
-			}
-		}()
-
 		err = c.SendMessage("test_action", map[string]interface{}{"test": "data"})
 		assert.Nil(t, err)
 
@@ -190,12 +166,6 @@ func TestSendMessage(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		go func() {
-			// Just drain the event channel
-			for range c.EventChannel {
-			}
-		}()
-
 		err = c.SendMessage("test_action", map[string]interface{}{"test": "data"})
 		assert.Nil(t, err)
 
@@ -213,12 +183,6 @@ func TestSendMessage(t *testing.T) {
 			AuthToken: "authToken",
 		})
 		require.Nil(t, err)
-
-		go func() {
-			// Just drain the event channel
-			for range c.EventChannel {
-			}
-		}()
 
 		err = c.SendMessage("test_action", map[string]interface{}{"test": "data"})
 		assert.Nil(t, err)
@@ -239,12 +203,6 @@ func TestSendMessage(t *testing.T) {
 			AuthToken: "authToken",
 		})
 		require.Nil(t, err)
-
-		go func() {
-			// Just drain the event channel
-			for range c.EventChannel {
-			}
-		}()
 
 		err = c.SendMessage("test_action", map[string]interface{}{"test": "data"})
 		assert.Nil(t, err)

--- a/server/api.go
+++ b/server/api.go
@@ -27,7 +27,7 @@ var callDismissNotificationRE = regexp.MustCompile(`^/calls/([a-z0-9]+)/dismiss-
 
 const requestBodyMaxSizeBytes = 1024 * 1024 // 1MB
 
-func (p *Plugin) handleGetVersion(w http.ResponseWriter, r *http.Request) {
+func (p *Plugin) handleGetVersion(w http.ResponseWriter, _ *http.Request) {
 	info := map[string]interface{}{
 		"version": manifest.Version,
 		"build":   buildHash,
@@ -519,7 +519,7 @@ func (p *Plugin) checkAPIRateLimits(userID string) error {
 	return nil
 }
 
-func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
 	if strings.HasPrefix(r.URL.Path, "/version") {
 		p.handleGetVersion(w, r)
 		return

--- a/server/bot_api.go
+++ b/server/bot_api.go
@@ -37,7 +37,7 @@ func (p *Plugin) isBotSession(r *http.Request) bool {
 	return p.isBot(r.Header.Get("Mattermost-User-Id"))
 }
 
-func (p *Plugin) handleBotGetChannel(w http.ResponseWriter, r *http.Request, channelID string) {
+func (p *Plugin) handleBotGetChannel(w http.ResponseWriter, _ *http.Request, channelID string) {
 	channel, appErr := p.API.GetChannel(channelID)
 	if appErr != nil {
 		p.LogError(appErr.Error())
@@ -59,7 +59,7 @@ func (p *Plugin) handleBotGetUserImage(w http.ResponseWriter, r *http.Request, u
 	http.ServeContent(w, r, userID, time.Now(), bytes.NewReader(data))
 }
 
-func (p *Plugin) handleBotGetUpload(w http.ResponseWriter, r *http.Request, uploadID string) {
+func (p *Plugin) handleBotGetUpload(w http.ResponseWriter, _ *http.Request, uploadID string) {
 	var res httpResponse
 	defer p.httpResponseHandler(&res, w)
 

--- a/server/log.go
+++ b/server/log.go
@@ -115,7 +115,7 @@ func (l *logger) Flush() error {
 	return nil
 }
 
-func (l *logger) StdLogger(level logr.Level) *log.Logger {
+func (l *logger) StdLogger(_ logr.Level) *log.Logger {
 	return nil
 }
 
@@ -131,6 +131,6 @@ func (l *logger) IsLevelEnabled(_ logr.Level) bool {
 	return false
 }
 
-func (l *logger) With(fields ...logr.Field) *mlog.Logger {
+func (l *logger) With(_ ...logr.Field) *mlog.Logger {
 	return nil
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -104,7 +104,7 @@ func (p *Plugin) startSession(us *session, senderID string) {
 	}
 }
 
-func (p *Plugin) OnPluginClusterEvent(c *plugin.Context, ev model.PluginClusterEvent) {
+func (p *Plugin) OnPluginClusterEvent(_ *plugin.Context, ev model.PluginClusterEvent) {
 	select {
 	case p.clusterEvCh <- ev:
 	default:

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -149,11 +149,11 @@ func handleStatsCommand(fields []string) (*model.CommandResponse, error) {
 	}, nil
 }
 
-func (p *Plugin) handleEndCallCommand(userID, channelID string) (*model.CommandResponse, error) {
+func (p *Plugin) handleEndCallCommand(_, _ string) (*model.CommandResponse, error) {
 	return &model.CommandResponse{}, nil
 }
 
-func (p *Plugin) handleRecordingCommand(args *model.CommandArgs, fields []string) (*model.CommandResponse, error) {
+func (p *Plugin) handleRecordingCommand(_ *model.CommandArgs, fields []string) (*model.CommandResponse, error) {
 	if len(fields) != 3 {
 		return nil, fmt.Errorf("Invalid number of arguments provided")
 	}
@@ -165,7 +165,7 @@ func (p *Plugin) handleRecordingCommand(args *model.CommandArgs, fields []string
 	return &model.CommandResponse{}, nil
 }
 
-func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	fields := strings.Fields(args.Command)
 
 	rootCmd := strings.TrimPrefix(fields[0], "/")

--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -73,10 +73,8 @@ func (p *Plugin) uninitTelemetry() error {
 	if p.telemetry == nil {
 		return nil
 	}
-	if err := p.telemetry.Close(); err != nil {
-		return err
-	}
-	return nil
+	err := p.telemetry.Close()
+	return err
 }
 
 func (p *Plugin) initTelemetry(enableDiagnostics *bool) error {


### PR DESCRIPTION
#### Summary
- I run `make test && make check-style && make i18n-extract` before committing, and it looks like something changed and made `golangci-lint` more strict. Now `make check-style` will complete locally.

#### Ticket Link
- none
