### PR TITLE
[MM-54494] Keep backwards compatibility with older MM versions

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -28,10 +28,14 @@ export function getUserStoragesForTest() {
     return [`${names[0]}StorageState.json`, `${names[1]}StorageState.json`];
 }
 
-export async function startCall(userState: string) {
+export async function newUserPage(userState: string) {
     const browser = await chromium.launch();
     const context = await browser.newContext({storageState: userState});
-    const userPage = new PlaywrightDevPage(await context.newPage());
+    return new PlaywrightDevPage(await context.newPage());
+}
+
+export async function startCall(userState: string) {
+    const userPage = await newUserPage(userState);
     await userPage.goto();
     await userPage.startCall();
     return userPage;

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -935,6 +935,11 @@ export default combineReducers({
     users,
     channelID,
     profiles,
+
+    // DEPRECATED - Needed to keep compatibility with older MM server
+    // version.
+    voiceConnectedProfiles: profiles,
+
     reactions,
     usersStatuses,
     calls,


### PR DESCRIPTION
#### Summary

We are still using `voiceConnectedProfiles` on webapp so we need to continue supporting it at least until we bump minimum server version.

#### Related PR

https://github.com/mattermost/mattermost/pull/24544

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54494