### PR TITLE
[MM-54520] Soft fail in case of missing post during state cleanup

### DIFF
--- a/server/channel_state.go
+++ b/server/channel_state.go
@@ -314,7 +314,7 @@ func (p *Plugin) cleanCallState(channelID string, state *channelState) error {
 
 	if state.Call != nil {
 		if _, err := p.updateCallPostEnded(state.Call.PostID, mapKeys(state.Call.Stats.Participants)); err != nil {
-			return err
+			p.LogError("failed to update call post", "err", err.Error())
 		}
 		state.Call = nil
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -333,6 +333,10 @@ func (p *Plugin) createCallStartedPost(state *channelState, userID, channelID, t
 }
 
 func (p *Plugin) updateCallPostEnded(postID string, participants []string) (float64, error) {
+	if postID == "" {
+		return 0, fmt.Errorf("postID should not be empty")
+	}
+
 	post, appErr := p.API.GetPost(postID)
 	if appErr != nil {
 		return 0, appErr


### PR DESCRIPTION
#### Summary

We log the error but otherwise proceed with cleaning up the state.

```
{"timestamp":"2023-09-25 09:12:36.362 -06:00","level":"error","msg":"failed to update call post","caller":"app/plugin_api.go:976","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).cleanCallState channel_state.go:317","err":"GetSinglePost: Unable to get the post."}
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54520