### PR TITLE
[MM-54551] Fix potential nil dereference panic

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -43,7 +43,12 @@ func (p *Plugin) setHandlerID(nodeID string) error {
 
 func (p *Plugin) getNotificationNameFormat(userID string) string {
 	config := p.API.GetConfig()
-	if !*config.PrivacySettings.ShowFullName {
+	if config == nil {
+		p.LogError("failed to get config")
+		return model.ShowUsername
+	}
+
+	if config.PrivacySettings.ShowFullName == nil || !*config.PrivacySettings.ShowFullName {
 		return model.ShowUsername
 	}
 


### PR DESCRIPTION
#### Summary

We had a report of failures to join calls starting in v0.19. At first it looked like a networking issue but upon further inspection of the logs we were able to find multiple plugin crashes due to SIGSEGV. 

Even if properly set to `false` in `config.json` the returned object was a nil pointer. Adding a couple of extra checks to avoid future regressions.

Given the severity of this I'd like to cut a new dot release once this is merged.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54551
