### PR TITLE
Add go version to cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,4 +14,6 @@ permissions:
 jobs:
   plugin-cd:
     uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main
+    with:
+      golang-version: "1.19"
     secrets: inherit


### PR DESCRIPTION
#### Summary
- cd builds are failing, hopefully this is all that's needed.

#### Ticket Link
- none

