### PR TITLE
[MM-54562] Add panic recover to API handler

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -510,6 +510,12 @@ func (p *Plugin) checkAPIRateLimits(userID string) error {
 }
 
 func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.logPanic(r)
+		}
+	}()
+
 	if strings.HasPrefix(r.URL.Path, "/version") {
 		p.handleGetVersion(w)
 		return

--- a/server/log.go
+++ b/server/log.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/mattermost/logr/v2"
@@ -16,6 +17,14 @@ import (
 
 const pkgPath = "github.com/mattermost/mattermost-plugin-calls/server/"
 const rtcdPrefix = "/service/rtc"
+
+func (p *Plugin) logPanic(reason any) {
+	p.LogError(fmt.Sprintf("panic: %v", reason))
+
+	for _, line := range strings.Split(string(debug.Stack()), "\n") {
+		p.LogError(strings.TrimSpace(line))
+	}
+}
 
 func getErrOrigin() string {
 	var origin string


### PR DESCRIPTION
#### Summary

We add a recover function to catch panics at the API level. 

- A panic at this level won't cause the plugin to crash and potentially kill all running calls in the process.
- We get to log the stack trace at the error level and cleaned up correctly.

Example output:

```
{"timestamp":"2023-10-06 12:22:22.474 -06:00","level":"error","msg":"panic: runtime error: invalid memory address or nil pointer dereference","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:22"}
{"timestamp":"2023-10-06 12:22:22.474 -06:00","level":"error","msg":"goroutine 84 [running]:","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
{"timestamp":"2023-10-06 12:22:22.474 -06:00","level":"error","msg":"runtime/debug.Stack()","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
{"timestamp":"2023-10-06 12:22:22.474 -06:00","level":"error","msg":"runtime/debug/stack.go:24 +0x6b","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
{"timestamp":"2023-10-06 12:22:22.475 -06:00","level":"error","msg":"main.(*Plugin).logPanic(0xc0000fc400, {0x1497980, 0x1d996a0})","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
{"timestamp":"2023-10-06 12:22:22.475 -06:00","level":"error","msg":"github.com/mattermost/mattermost-plugin-calls/server/log.go:24 +0xca","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
{"timestamp":"2023-10-06 12:22:22.475 -06:00","level":"error","msg":"main.(*Plugin).ServeHTTP.func1()","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
{"timestamp":"2023-10-06 12:22:22.475 -06:00","level":"error","msg":"github.com/mattermost/mattermost-plugin-calls/server/api.go:518 +0x49","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
{"timestamp":"2023-10-06 12:22:22.475 -06:00","level":"error","msg":"panic({0x1497980?, 0x1d996a0?})","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
{"timestamp":"2023-10-06 12:22:22.475 -06:00","level":"error","msg":"runtime/panic.go:920 +0x290","caller":"app/plugin_api.go:984","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).logPanic log.go:25"}
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54562
