### PR TITLE
Fix client state on Desktop

### DIFF
--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -434,6 +434,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             if (this.props.global) {
                 sendDesktopEvent('calls-joined-call', {
                     callID: window.callsClient?.channelID,
+                    sessionID: window.callsClient?.getSessionID(),
                 });
             }
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -529,7 +529,10 @@ export default class Plugin {
                 }
                 store.dispatch({
                     type: DESKTOP_WIDGET_CONNECTED,
-                    data: {channelID: ev.data.message.callID},
+                    data: {
+                        channel_id: ev.data.message.callID,
+                        session_id: ev.data.message.sessionID,
+                    },
                 });
             } else if (ev.data?.type === 'calls-join-request') {
                 // we can assume that we are already in a call, since the global widget sent this.

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -44,7 +44,7 @@ import {pluginId} from './manifest';
 const pluginState = (state: GlobalState) => state['plugins-' + pluginId] || {};
 
 export const channelIDForCurrentCall = (state: GlobalState): string =>
-    pluginState(state).channelID || window.callsClient?.channelID || window.opener?.callsClient?.channelID || '';
+    window.callsClient?.channelID || window.opener?.callsClient?.channelID || pluginState(state).clientStateReducer?.channelID || '';
 
 export const channelForCurrentCall: (state: GlobalState) => Channel | undefined =
     createSelector(


### PR DESCRIPTION
#### Summary

As part of multi-session support I removed a reducer handler which I forgot to replace properly. That is to handle the client state of the Desktop (webapp) side when we have the global widget. We now need to send the session ID to be able to match properly but other than that it's not too different from before. See [here](https://github.com/mattermost/mattermost-plugin-calls/blob/d834de28e4ec89d6f151dccc0f762dfbcdb75a62/webapp/src/reducers.ts#L219-L223) the previous handler, before removal.

