### PR TITLE
[MM-55245] Move reaction picker on top of reaction stream

### DIFF
--- a/webapp/src/components/expanded_view/reaction_button.tsx
+++ b/webapp/src/components/expanded_view/reaction_button.tsx
@@ -223,7 +223,7 @@ const QuickSelect = ({emoji, handleClick}: QuickSelectProps) => {
 
 const PickerContainer = styled.div`
     position: absolute;
-    z-index: 1;
+    z-index: 10;
     top: -394px;
     left: -242px;
 
@@ -250,6 +250,7 @@ const PickerContainer = styled.div`
 
 const Bar = styled.div`
     position: absolute;
+    z-index: 10;
     top: -68px;
     left: -242px;
     width: 416px;


### PR DESCRIPTION
#### Summary

Nothing fancy, just regulating the `z-index`.

#### Screenshots

Before:

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/541acb7a-73e8-486a-8fd8-7c75eb87082c)

After:

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/89534713-dae6-4b79-879c-43db67ee525e)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55245