### PR TITLE
[MM-55617] Surface config serialization errors

### DIFF
--- a/server/configuration.go
+++ b/server/configuration.go
@@ -444,16 +444,23 @@ func (p *Plugin) ConfigurationWillBeSaved(newCfg *model.Config) (*model.Config, 
 
 	configData := newCfg.PluginSettings.Plugins[manifest.Id]
 
+	appErr := model.NewAppError("saveConfig", "app.save_config.error", nil, "", http.StatusBadRequest)
+	appErr.SkipTranslation = true
+
 	js, err := json.Marshal(configData)
 	if err != nil {
-		p.LogError("failed to marshal config data", "error", err.Error())
-		return nil, nil
+		err = fmt.Errorf("failed to marshal config data: %w", err)
+		p.LogError(err.Error())
+		appErr.Message = err.Error()
+		return nil, appErr
 	}
 
 	var cfg configuration
 	if err := json.Unmarshal(js, &cfg); err != nil {
-		p.LogError("failed to unmarshal config data", "error", err.Error())
-		return nil, nil
+		err = fmt.Errorf("failed to unmarshal config data: %w", err)
+		p.LogError(err.Error())
+		appErr.Message = err.Error()
+		return nil, appErr
 	}
 
 	// Setting defaults prevents errors in case the plugin is updated after a new
@@ -461,9 +468,7 @@ func (p *Plugin) ConfigurationWillBeSaved(newCfg *model.Config) (*model.Config, 
 	cfg.SetDefaults()
 
 	if err := cfg.IsValid(); err != nil {
-		appErr := model.NewAppError("saveConfig", "app.save_config.error", nil, "", http.StatusBadRequest)
 		appErr.Message = err.Error()
-		appErr.SkipTranslation = true
 		return nil, appErr
 	}
 


### PR DESCRIPTION
#### Summary

I am not sure (which slightly worries me) why we didn't handle these. I want to think it was a simple oversight on my part. Still, they require MM >= 8.0 to show so they wouldn't have helped with the recent customer issue.

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/0d35e51e-5ab2-4b99-8219-048cabfbdecb)


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55617
