### PR TITLE
MM-54743 - Fix: In compact mode, the call card displays inline

### DIFF
--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -33,6 +33,7 @@ interface Props {
     isCloudPaid: boolean,
     maxParticipants: number,
     militaryTime: boolean,
+    compactDisplay: boolean,
 }
 
 const PostType = ({
@@ -42,6 +43,7 @@ const PostType = ({
     isCloudPaid,
     maxParticipants,
     militaryTime,
+    compactDisplay,
 }: Props) => {
     const intl = useIntl();
     const {formatMessage} = intl;
@@ -136,6 +138,8 @@ const PostType = ({
         );
     }
 
+    const compactTitle = compactDisplay ? '\u200b' : '';
+    const title = post.props.title ? <h3 className='markdown__heading'>{post.props.title}</h3> : compactTitle;
     const callActive = !post.props.end_at;
     const inCall = connectedID === post.channel_id;
     const button = inCall ? (
@@ -150,9 +154,7 @@ const PostType = ({
 
     return (
         <>
-            {post.props.title &&
-                <h3 className='markdown__heading'>{post.props.title}</h3>
-            }
+            {title}
             <Main data-testid={'call-thread'}>
                 <SubMain ended={Boolean(post.props.end_at)}>
                     <Left>

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -138,7 +138,7 @@ const PostType = ({
         );
     }
 
-    const compactTitle = compactDisplay ? '\u200b' : '';
+    const compactTitle = compactDisplay ? <br/> : <></>;
     const title = post.props.title ? <h3 className='markdown__heading'>{post.props.title}</h3> : compactTitle;
     const callActive = !post.props.end_at;
     const inCall = connectedID === post.channel_id;

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -33,6 +33,7 @@ interface Props {
     maxParticipants: number,
     militaryTime: boolean,
     compactDisplay: boolean,
+    isRHS: boolean,
 }
 
 const PostType = ({
@@ -43,6 +44,7 @@ const PostType = ({
     maxParticipants,
     militaryTime,
     compactDisplay,
+    isRHS,
 }: Props) => {
     const intl = useIntl();
     const {formatMessage} = intl;
@@ -137,7 +139,7 @@ const PostType = ({
         );
     }
 
-    const compactTitle = compactDisplay ? <br/> : <></>;
+    const compactTitle = compactDisplay && !isRHS ? <br/> : <></>;
     const title = post.props.title ? <h3 className='markdown__heading'>{post.props.title}</h3> : compactTitle;
     const callActive = !post.props.end_at;
     const inCall = connectedID === post.channel_id;

--- a/webapp/src/components/custom_post_types/post_type/index.ts
+++ b/webapp/src/components/custom_post_types/post_type/index.ts
@@ -14,6 +14,7 @@ import {
 
 interface OwnProps {
     post: Post,
+    isRHS: boolean,
 }
 
 const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {

--- a/webapp/src/components/custom_post_types/post_type/index.ts
+++ b/webapp/src/components/custom_post_types/post_type/index.ts
@@ -2,9 +2,10 @@ import {connect} from 'react-redux';
 
 import {Post} from '@mattermost/types/posts';
 import {GlobalState} from '@mattermost/types/store';
-import {Preferences} from 'mattermost-redux/constants';
-import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import Preferences from 'mattermost-redux/constants/preferences';
+import {get, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import PostType from 'src/components/custom_post_types/post_type/component';
+import {MESSAGE_DISPLAY, MESSAGE_DISPLAY_COMPACT, MESSAGE_DISPLAY_DEFAULT} from 'src/constants';
 import {
     profilesInCallInChannel,
     channelIDForCurrentCall,
@@ -24,6 +25,7 @@ const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
         isCloudPaid: isCloudProfessionalOrEnterpriseOrTrial(state),
         maxParticipants: maxParticipants(state),
         militaryTime: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false),
+        compactDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, MESSAGE_DISPLAY, MESSAGE_DISPLAY_DEFAULT) === MESSAGE_DISPLAY_COMPACT,
     };
 };
 

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -11,6 +11,11 @@ export const DEFAULT_RING_SOUND = 'Calm';
 export const CALL_START_POST_TYPE = 'custom_calls';
 export const CALL_RECORDING_POST_TYPE = 'custom_calls_recording';
 
+// From mattermost-webapp/webapp/channels/src/utils/constants.tsx, importing causes tsc to throw fits.
+export const MESSAGE_DISPLAY = 'message_display';
+export const MESSAGE_DISPLAY_COMPACT = 'compact';
+export const MESSAGE_DISPLAY_DEFAULT = 'clean';
+
 export const CallAlertConfigs: { [key: string]: CallAlertConfig } = {
     missingAudioInput: {
         type: CallAlertType.Error,


### PR DESCRIPTION
#### Summary
- Had to do some trickery to force the display to wrap (because we don't control our custom post's container).
- Doesn't affect non-compact mode, or when a call title is present. If you can think of any other situations I didn't think, please let me know.

| compact, full width | compact, reduced width |
|--|--|
| <img width="1006" alt="image" src="https://github.com/mattermost/mattermost-plugin-calls/assets/1490756/46ac1efc-cf12-4b39-bae2-73f2674eddc8"> | <img width="544" alt="image" src="https://github.com/mattermost/mattermost-plugin-calls/assets/1490756/c11090b2-3fb1-4106-ad52-f7d8ccbeb84c"> |

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-54743
