### PR TITLE
Don't display AI button when plugin doesn't support it

### DIFF
--- a/webapp/src/components/custom_post_types/post_type_recording.tsx
+++ b/webapp/src/components/custom_post_types/post_type_recording.tsx
@@ -12,7 +12,7 @@ const useAIAvailable = () => {
     return useSelector<GlobalState, boolean>((state) => Boolean(state.plugins?.plugins?.[aiPluginID]));
 };
 
-type CallsPostButtonClickedFunc = (post: any) => void;
+type CallsPostButtonClickedFunc = ((post: any) => void) | undefined;
 
 const useCallsPostButtonClicked = () => {
     return useSelector<GlobalState, CallsPostButtonClickedFunc>((state) => {
@@ -64,7 +64,7 @@ export const PostTypeRecording = (props: Props) => {
     return (
         <>
             <FormattedMessage defaultMessage={'Here\'s the call recording'}/>
-            {aiAvailable &&
+            {aiAvailable && callsPostButtonClicked &&
             <CreateMeetingSummaryButton
                 onClick={createMeetingSummary}
             >


### PR DESCRIPTION
#### Summary
The summarization button is showing up on community, but it does not work since the AI plugin version uploaded there does not support it yet. 

This fixes the issue by checking for the presence of the button clicked function before displaying the button. 