### PR TITLE
[MM-55975] Fix regression when presenting session leaves call without previously…

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -206,8 +206,8 @@ func (p *Plugin) removeUserSession(state *channelState, userID, connID, channelI
 
 	state = state.Clone()
 
-	if state.Call.ScreenSharingID == userID {
-		state.Call.ScreenSharingID = ""
+	if state.Call.ScreenSharingSessionID == connID {
+		state.Call.ScreenSharingSessionID = ""
 		state.Call.ScreenStreamID = ""
 		if state.Call.ScreenStartAt > 0 {
 			state.Call.Stats.ScreenDuration += secondsSinceTimestamp(state.Call.ScreenStartAt)
@@ -311,7 +311,7 @@ func (p *Plugin) removeSession(us *session) error {
 		}, &model.WebsocketBroadcast{ChannelId: us.channelID, ReliableClusterSend: true})
 
 		// If the removed user was sharing we should send out a screen off event.
-		if prevState.Call.ScreenSharingID != "" && (currState.Call == nil || currState.Call.ScreenSharingID == "") {
+		if prevState.Call.ScreenSharingSessionID != "" && (currState.Call == nil || currState.Call.ScreenSharingSessionID == "") {
 			p.LogDebug("removed session was sharing, sending screen off event", "userID", us.userID, "connID", us.connID)
 			p.publishWebSocketEvent(wsEventUserScreenOff, map[string]interface{}{}, &model.WebsocketBroadcast{ChannelId: us.channelID, ReliableClusterSend: true})
 		}

--- a/server/state.go
+++ b/server/state.go
@@ -29,22 +29,22 @@ type callStats struct {
 }
 
 type callState struct {
-	ID                    string                `json:"id"`
-	StartAt               int64                 `json:"create_at"`
-	EndAt                 int64                 `json:"end_at"`
-	Sessions              map[string]*userState `json:"sessions,omitempty"`
-	OwnerID               string                `json:"owner_id"`
-	ThreadID              string                `json:"thread_id"`
-	PostID                string                `json:"post_id"`
-	ScreenSharingID       string                `json:"screen_sharing_id"`
-	ScreenStreamID        string                `json:"screen_stream_id"`
-	ScreenStartAt         int64                 `json:"screen_start_at"`
-	Stats                 callStats             `json:"stats"`
-	RTCDHost              string                `json:"rtcd_host"`
-	HostID                string                `json:"host_id"`
-	Recording             *jobState             `json:"recording,omitempty"`
-	Transcription         *jobState             `json:"transcription,omitempty"`
-	DismissedNotification map[string]bool       `json:"dismissed_notification,omitempty"`
+	ID                     string                `json:"id"`
+	StartAt                int64                 `json:"create_at"`
+	EndAt                  int64                 `json:"end_at"`
+	Sessions               map[string]*userState `json:"sessions,omitempty"`
+	OwnerID                string                `json:"owner_id"`
+	ThreadID               string                `json:"thread_id"`
+	PostID                 string                `json:"post_id"`
+	ScreenSharingSessionID string                `json:"screen_sharing_session_id"`
+	ScreenStreamID         string                `json:"screen_stream_id"`
+	ScreenStartAt          int64                 `json:"screen_start_at"`
+	Stats                  callStats             `json:"stats"`
+	RTCDHost               string                `json:"rtcd_host"`
+	HostID                 string                `json:"host_id"`
+	Recording              *jobState             `json:"recording,omitempty"`
+	Transcription          *jobState             `json:"transcription,omitempty"`
+	DismissedNotification  map[string]bool       `json:"dismissed_notification,omitempty"`
 }
 
 type channelState struct {
@@ -235,7 +235,7 @@ func (cs *callState) getClientState(botID, userID string) *CallStateClient {
 	}
 
 	var screenSharingUserID string
-	if s := cs.Sessions[cs.ScreenSharingID]; s != nil {
+	if s := cs.Sessions[cs.ScreenSharingSessionID]; s != nil {
 		screenSharingUserID = s.UserID
 	}
 
@@ -255,7 +255,7 @@ func (cs *callState) getClientState(botID, userID string) *CallStateClient {
 		// DEPRECATED since v0.21
 		ScreenSharingID: screenSharingUserID,
 
-		ScreenSharingSessionID: cs.ScreenSharingID,
+		ScreenSharingSessionID: cs.ScreenSharingSessionID,
 		OwnerID:                cs.OwnerID,
 		HostID:                 cs.HostID,
 		Recording:              cs.Recording.getClientState(),

--- a/server/state_test.go
+++ b/server/state_test.go
@@ -63,10 +63,10 @@ func TestCallStateGetClientState(t *testing.T) {
 					RaisedHand: 1100,
 				},
 			},
-			ThreadID:        "threadID",
-			ScreenSharingID: "sessionA",
-			OwnerID:         "ownerID",
-			HostID:          "hostID",
+			ThreadID:               "threadID",
+			ScreenSharingSessionID: "sessionA",
+			OwnerID:                "ownerID",
+			HostID:                 "hostID",
 		}
 		ccs := CallStateClient{
 			ID:      cs.ID,
@@ -88,7 +88,7 @@ func TestCallStateGetClientState(t *testing.T) {
 			},
 			ThreadID:               cs.ThreadID,
 			ScreenSharingID:        "userA",
-			ScreenSharingSessionID: cs.ScreenSharingID,
+			ScreenSharingSessionID: cs.ScreenSharingSessionID,
 			OwnerID:                cs.OwnerID,
 			HostID:                 cs.HostID,
 		}

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -117,17 +117,17 @@ func (p *Plugin) handleClientMessageTypeScreen(us *session, msg clientMessage, h
 	}
 
 	if msg.Type == clientMessageTypeScreenOn {
-		if state.Call.ScreenSharingID != "" {
-			return fmt.Errorf("cannot start screen sharing, someone else is sharing already: connID=%s", state.Call.ScreenSharingID)
+		if state.Call.ScreenSharingSessionID != "" {
+			return fmt.Errorf("cannot start screen sharing, someone else is sharing already: connID=%s", state.Call.ScreenSharingSessionID)
 		}
-		state.Call.ScreenSharingID = us.originalConnID
+		state.Call.ScreenSharingSessionID = us.originalConnID
 		state.Call.ScreenStreamID = data["screenStreamID"]
 		state.Call.ScreenStartAt = time.Now().Unix()
 	} else {
-		if state.Call.ScreenSharingID != us.originalConnID {
-			return fmt.Errorf("cannot stop screen sharing, someone else is sharing already: connID=%s", state.Call.ScreenSharingID)
+		if state.Call.ScreenSharingSessionID != us.originalConnID {
+			return fmt.Errorf("cannot stop screen sharing, someone else is sharing already: connID=%s", state.Call.ScreenSharingSessionID)
 		}
-		state.Call.ScreenSharingID = ""
+		state.Call.ScreenSharingSessionID = ""
 		state.Call.ScreenStreamID = ""
 		if state.Call.ScreenStartAt > 0 {
 			state.Call.Stats.ScreenDuration += secondsSinceTimestamp(state.Call.ScreenStartAt)


### PR DESCRIPTION
#### Summary

Multi session support caused a regression in the case of a presenter leaving the call without previously unsharing. This would cause the state to be in somewhat of a stuck state, preventing anyone else from sharing. The UI wasn't affected by this bug because the [check](https://github.com/mattermost/mattermost-plugin-calls/blob/53ab625c48e1c0a01290dd75523af6845c18ee2e/webapp/src/reducers.ts#L668-L674) on the redux side is correctly against the session id of user leaving.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55975