### PR TITLE
Set a captions_file_id post prop to avoid indirection when fetching captions file for video preview

### DIFF
--- a/server/job_metadata.go
+++ b/server/job_metadata.go
@@ -12,9 +12,9 @@ type jobMetadata struct {
 	FileID string
 	// PostID is the Post.Id that holds the job's artifacts (e.g. recording post).
 	PostID string
-	// RecID is the recording ID.
+	// RecID is the recording job ID.
 	RecID string
-	// TrID is the transcription ID.
+	// TrID is the transcription job ID.
 	TrID string
 }
 
@@ -96,7 +96,8 @@ func (p *Plugin) saveRecordingMetadata(postID, recID, trID string) error {
 	post.AddProp("recordings", recordings)
 
 	// This is where we map a transcription to a recording.
-	// This information will be used by the client when rendering the recording preview.
+	// This information will be used when the transcribing job completes to populate
+	// the recording post props with the captions file id.
 	if trID != "" {
 		tm := jobMetadata{
 			RecID: recID,

--- a/webapp/src/components/recordings_file_preview.tsx
+++ b/webapp/src/components/recordings_file_preview.tsx
@@ -1,10 +1,7 @@
 import {FileInfo} from '@mattermost/types/files';
 import {Post} from '@mattermost/types/posts';
-import {GlobalState} from '@mattermost/types/store';
 import {Client4} from 'mattermost-redux/client';
-import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import React, {useMemo} from 'react';
-import {useSelector} from 'react-redux';
 import styled from 'styled-components';
 
 type Props = {
@@ -13,12 +10,7 @@ type Props = {
 }
 
 const RecordingsFilePreview = ({fileInfo, post}: Props) => {
-    const callPost = useSelector((state: GlobalState) => getPost(state, post.props?.call_post_id));
-
-    const recording = callPost?.props?.recordings?.[post.props?.recording_id];
-    const transcription = callPost?.props?.transcriptions?.[recording?.tr_id];
-
-    const now = useMemo(() => Date.now(), [recording, transcription]);
+    const now = useMemo(() => Date.now(), [post.props.captions_file_id]);
 
     return (
         <Video
@@ -31,13 +23,13 @@ const RecordingsFilePreview = ({fileInfo, post}: Props) => {
                 src={Client4.getFileUrl(fileInfo.id, now)}
                 type={fileInfo.mime_type}
             />
-            { transcription?.file_id &&
+            { post.props.captions_file_id &&
             <track
                 data-testid='calls-recording-transcription'
                 label='Transcription'
                 kind='subtitles'
                 srcLang='en'
-                src={Client4.getFileUrl(transcription.file_id, now)}
+                src={Client4.getFileUrl(post.props.captions_file_id, now)}
                 default={true}
             />
             }


### PR DESCRIPTION
#### Summary

Adding some logic to save the VTT captions file id into the recording post props so it can be access directly.

I am keeping everything else the same in the call post props even if slightly redundant as this "centralized" data may still be useful if we ever want to retroactively populate calls info whenever we migrate to a proper SQL schema.