### PR TITLE
[MM-55526] Fix /call leave command from thread

### DIFF
--- a/e2e/tests/popout.spec.ts
+++ b/e2e/tests/popout.spec.ts
@@ -259,4 +259,29 @@ test.describe('popout window', () => {
         await popOut.getByTestId('lower-hand-button').click();
         await expect(popOut.getByTestId('raise-hand-button')).toBeVisible();
     });
+
+    test('/call leave slash command', async ({page, context}) => {
+        const devPage = new PlaywrightDevPage(page);
+        await devPage.goto();
+        await devPage.startCall();
+
+        const [popOut, _] = await Promise.all([
+            context.waitForEvent('page'),
+            page.click('#calls-widget-expand-button'),
+        ]);
+        await expect(popOut.locator('#calls-expanded-view')).toBeVisible();
+
+        await popOut.click('#calls-popout-chat-button');
+
+        await expect(popOut.locator('#sidebar-right [data-testid=call-thread]')).toBeVisible();
+
+        const replyTextbox = popOut.locator('#reply_textbox');
+        const msg = '/call leave';
+        await replyTextbox.type(msg);
+        await replyTextbox.press('Enter');
+
+        // Verify we left the call.
+        await expect(popOut.isClosed()).toEqual(true);
+        await expect(page.locator('#calls-widget')).toBeHidden();
+    });
 });

--- a/e2e/tests/popout.spec.ts
+++ b/e2e/tests/popout.spec.ts
@@ -281,6 +281,7 @@ test.describe('popout window', () => {
         await replyTextbox.press('Enter');
 
         // Verify we left the call.
+        await devPage.wait(1000);
         await expect(popOut.isClosed()).toEqual(true);
         await expect(page.locator('#calls-widget')).toBeHidden();
     });

--- a/webapp/src/slash_commands.tsx
+++ b/webapp/src/slash_commands.tsx
@@ -95,8 +95,9 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
         return {};
     case 'leave':
         if (connectedID && args.channel_id === connectedID) {
-            if (window.callsClient) {
-                window.callsClient.disconnect();
+            const callsClient = window.opener ? window.opener.callsClient : window.callsClient;
+            if (callsClient) {
+                callsClient.disconnect();
                 return {};
             } else if (shouldRenderDesktopWidget()) {
                 sendDesktopEvent('calls-leave-call', {callID: args.channel_id});


### PR DESCRIPTION
#### Summary

When working on this ticket I realized the `/call leave` command wasn't working due to using `window.callsClient` instead of `window.opener.callsClient`. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55526
