### PR TITLE
[MM-56178] Fix failure to update call post (MySQL)

### DIFF
--- a/server/store.go
+++ b/server/store.go
@@ -31,6 +31,9 @@ func (p *Plugin) initDB() error {
 		return fmt.Errorf("failed to ping writer DB: %w", err)
 	}
 	p.wDBx = sqlx.NewDb(p.wDB, p.driverName)
+	if p.driverName == model.DatabaseDriverMysql {
+		p.wDBx.MapperFunc(func(s string) string { return s })
+	}
 
 	p.LogInfo("handle to writer DB initialized successfully", "driver", p.driverName)
 


### PR DESCRIPTION
#### Summary

Looks like MySQL needs a special no-op mapper function in order to correctly translate columns into struct fields.

I wish we could add a test for this but we need some work to make proper integrations tests that run against both db engines. I'll take care of it though. 

For now I manually tested this on both db drivers and it's looking good.
 
#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56178
