### PR TITLE
drop darwin from official manifest, build local platform for devs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,6 @@ ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
 else
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-linux-amd64;
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-linux-arm64;
-	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-darwin-amd64;
-	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-darwin-arm64;
 	cd server && env CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-freebsd-amd64;
 	cd server && env CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -trimpath -o dist/plugin-openbsd-amd64;
 endif
@@ -107,8 +105,6 @@ ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
 else
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -gcflags "all=-N -l" -trimpath -o dist/plugin-linux-amd64;
 	cd server && env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -gcflags "all=-N -l" -trimpath -o dist/plugin-linux-arm64;
-	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -gcflags "all=-N -l" -trimpath -o dist/plugin-darwin-amd64;
-	cd server && env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -gcflags "all=-N -l" -trimpath -o dist/plugin-darwin-arm64;
 	cd server && env CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -gcflags "all=-N -l" -trimpath -o dist/plugin-freebsd-amd64;
 	cd server && env CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -ldflags '$(LDFLAGS)' -gcflags "all=-N -l" -trimpath -o dist/plugin-openbsd-amd64;
 endif

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -65,6 +67,14 @@ func main() {
 	manifest, err := findManifest()
 	if err != nil {
 		panic("failed to find manifest: " + err.Error())
+	}
+
+	if manifest.HasServer() {
+		// Build only the current platform if MM_SERVICESETTINGS_ENABLEDEVELOPER is set.
+		if isDeveloperBuild, _ := strconv.ParseBool(os.Getenv("MM_SERVICESETTINGS_ENABLEDEVELOPER")); isDeveloperBuild {
+			manifest.Server.Executables = nil
+			manifest.Server.Executable = fmt.Sprintf("server/dist/plugin-%s-%s", runtime.GOOS, runtime.GOARCH)
+		}
 	}
 
 	cmd := os.Args[1]

--- a/plugin.json
+++ b/plugin.json
@@ -9,8 +9,6 @@
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",
       "linux-arm64": "server/dist/plugin-linux-arm64",
-      "darwin-amd64": "server/dist/plugin-darwin-amd64",
-      "darwin-arm64": "server/dist/plugin-darwin-arm64",
       "freebsd-amd64": "server/dist/plugin-freebsd-amd64",
       "openbsd-amd64": "server/dist/plugin-openbsd-amd64"
     }


### PR DESCRIPTION
#### Summary
The plugin.json manifest has been "lying", in that it lists support for MacOS (`darwin`) even though we don't support or distribute that. It's necessary to allow developers to work locally.

Fix this by detecting if `MM_SERVICESETTINGS_ENABLEDEVELOPER` is set as truthy in the environment, and dynamically rewriting the manifest to clear the `Executables` and instead the platform-agnostic `Executable`. The server won't know what platform is supported, but will assume it's the right one and "just run it", working fine in development while leaving CI and production builds unchanged.

Then unlist darwin from the canonical manifest.

This complements https://github.com/mattermost/matterbuild/pull/97.

#### Ticket Link
None.