### PR TITLE
[MM-56048] Make access to global window properties safer

### DIFF
--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -43,7 +43,7 @@ import {pluginId} from 'plugin/manifest';
 import reducer from 'plugin/reducers';
 import RestClient from 'plugin/rest_client';
 import {callsConfig, iceServers, needsTURNCredentials} from 'plugin/selectors';
-import {DesktopNotificationArgs, Store} from 'plugin/types/mattermost-webapp';
+import {DesktopNotificationArgs, Store, WebAppUtils} from 'plugin/types/mattermost-webapp';
 import {
     getPluginPath,
     getWSConnectionURL,
@@ -302,6 +302,7 @@ declare global {
         e2eNotificationsSoundedAt?: number[],
         e2eNotificationsSoundStoppedAt?: number[],
         e2eRingLength?: number,
+        WebappUtils: WebAppUtils,
     }
 
     interface HTMLVideoElement {

--- a/webapp/src/browser_routing.ts
+++ b/webapp/src/browser_routing.ts
@@ -3,8 +3,10 @@
 
 import React from 'react';
 
+import {getWebappUtils} from './utils';
+
 // @ts-ignore
-const WebappUtils = window.opener ? window.opener.WebappUtils : window.WebappUtils;
+const WebappUtils = getWebappUtils();
 
 export const navigateToURL = (urlPath: string) => {
     WebappUtils.browserHistory.push(urlPath);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -95,7 +95,7 @@ import {
     ringingEnabled,
 } from './selectors';
 import {JOIN_CALL, keyToAction} from './shortcuts';
-import {DesktopNotificationArgs, PluginRegistry, Store} from './types/mattermost-webapp';
+import {DesktopNotificationArgs, PluginRegistry, Store, WebAppUtils} from './types/mattermost-webapp';
 import {
     desktopGTE,
     followThread,
@@ -820,7 +820,7 @@ declare global {
         e2eNotificationsSoundedAt?: number[],
         e2eNotificationsSoundStoppedAt?: number[],
         e2eRingLength?: number,
-        WebappUtils: any,
+        WebappUtils: WebAppUtils,
     }
 
     interface HTMLVideoElement {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -820,6 +820,7 @@ declare global {
         e2eNotificationsSoundedAt?: number[],
         e2eNotificationsSoundStoppedAt?: number[],
         e2eRingLength?: number,
+        WebappUtils: any,
     }
 
     interface HTMLVideoElement {

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -34,15 +34,22 @@ import {
     usersReactionsState,
 } from 'src/reducers';
 import {CallRecordingReduxState, CallsUserPreferences, ChannelState, IncomingCallNotification} from 'src/types/types';
-import {getChannelURL} from 'src/utils';
+import {getCallsClient, getChannelURL} from 'src/utils';
 
 import {pluginId} from './manifest';
 
 //@ts-ignore GlobalState is not complete
 const pluginState = (state: GlobalState) => state['plugins-' + pluginId] || {};
 
-export const channelIDForCurrentCall = (state: GlobalState): string =>
-    window.callsClient?.channelID || window.opener?.callsClient?.channelID || pluginState(state).clientStateReducer?.channelID || '';
+const clientState = (state: GlobalState) => pluginState(state).clientStateReducer;
+
+export const channelIDForCurrentCall: (state: GlobalState) => string =
+    createSelector(
+        'channelIDForCurrentCall',
+        getCallsClient,
+        clientState,
+        (callsClient, cState) => callsClient?.channelID || callsClient?.channelID || cState?.channelID || '',
+    );
 
 export const channelForCurrentCall: (state: GlobalState) => Channel | undefined =
     createSelector(

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -34,7 +34,7 @@ import {
     usersReactionsState,
 } from 'src/reducers';
 import {CallRecordingReduxState, CallsUserPreferences, ChannelState, IncomingCallNotification} from 'src/types/types';
-import {getCallsClient, getChannelURL} from 'src/utils';
+import {getCallsClientChannelID, getCallsClientInitTime, getCallsClientSessionID, getChannelURL} from 'src/utils';
 
 import {pluginId} from './manifest';
 
@@ -46,9 +46,9 @@ const clientState = (state: GlobalState) => pluginState(state).clientStateReduce
 export const channelIDForCurrentCall: (state: GlobalState) => string =
     createSelector(
         'channelIDForCurrentCall',
-        getCallsClient,
+        getCallsClientChannelID,
         clientState,
-        (callsClient, cState) => callsClient?.channelID || callsClient?.channelID || cState?.channelID || '',
+        (channelID, cState) => channelID || cState?.channelID || '',
     );
 
 export const channelForCurrentCall: (state: GlobalState) => Channel | undefined =
@@ -137,14 +137,12 @@ export const sessionsInCurrentCall: (state: GlobalState) => UserSessionState[] =
         (sessions, channelID) => Object.values(sessions[channelID] || {}),
     );
 
-const sessionIDForCurrentCall = () => window.callsClient?.getSessionID() || window.opener?.callsClient.getSessionID();
-
 export const sessionForCurrentCall: (state: GlobalState) => UserSessionState =
     createSelector(
         'sessionsInCurrentCall',
         sessionsInCalls,
         channelIDForCurrentCall,
-        sessionIDForCurrentCall,
+        getCallsClientSessionID,
         (sessions, channelID, sessionID) => sessions[channelID]?.[sessionID],
     );
 
@@ -169,9 +167,8 @@ export const callStartAtForCurrentCall: (state: GlobalState) => number =
         'callStartAtForCurrentCall',
         calls,
         channelIDForCurrentCall,
-        (callsStates, channelID) => callsStates[channelID]?.startAt ||
-          window.callsClient?.initTime ||
-          window.opener?.callsClient?.initTime || 0,
+        getCallsClientInitTime,
+        (callsStates, channelID, initTime) => callsStates[channelID]?.startAt || initTime || 0,
     );
 
 export const callInCurrentChannel: (state: GlobalState) => callState | undefined =

--- a/webapp/src/slash_commands.tsx
+++ b/webapp/src/slash_commands.tsx
@@ -24,7 +24,7 @@ import {
     profilesInCallInChannel,
 } from './selectors';
 import {Store} from './types/mattermost-webapp';
-import {sendDesktopEvent, shouldRenderDesktopWidget} from './utils';
+import {getCallsClient, sendDesktopEvent, shouldRenderDesktopWidget} from './utils';
 
 type joinCallFn = (channelId: string, teamId: string, title?: string, rootId?: string) => void;
 
@@ -95,7 +95,7 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
         return {};
     case 'leave':
         if (connectedID && args.channel_id === connectedID) {
-            const callsClient = window.opener ? window.opener.callsClient : window.callsClient;
+            const callsClient = getCallsClient();
             if (callsClient) {
                 callsClient.disconnect();
                 return {};

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -99,3 +99,11 @@ export type Store = BaseStore<GlobalState> & { dispatch: Dispatch }
 
 // eslint-disable-next-line
 export type Dispatch = ThunkDispatch<GlobalState, any, any>
+
+export type WebAppUtils = {
+
+    // @ts-ignore
+    modals: { openModal, ModalIdentifiers },
+    notificationSounds: { ring: (sound: string) => void, stopRing: () => void },
+    sendDesktopNotificationToMe: (title: string, body: string, channel: Channel, teamId: string, silent: boolean, soundName: string, url: string) => (dispatch: DispatchFunc) => void,
+};

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -289,6 +289,7 @@ describe('utils', () => {
         });
 
         test('window.WebappUtils defined', () => {
+            // @ts-ignore
             global.window.WebappUtils = {};
             const utils = getWebappUtils();
             expect(utils).toEqual(window.WebappUtils);

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -86,6 +86,18 @@ export function getCallsClient(): CallsClient | undefined {
     return callsClient;
 }
 
+export function getCallsClientChannelID(): string {
+    return getCallsClient()?.channelID || '';
+}
+
+export function getCallsClientSessionID(): string {
+    return getCallsClient()?.getSessionID() || '';
+}
+
+export function getCallsClientInitTime(): number {
+    return getCallsClient()?.initTime || 0;
+}
+
 export function shouldRenderCallsIncoming() {
     try {
         const win = window.opener ? window.opener : window;

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -77,18 +77,29 @@ export function getChannelURL(state: GlobalState, channel: Channel, teamId: stri
 }
 
 export function getCallsClient(): CallsClient | undefined {
-    return window.opener ? window.opener.callsClient : window.callsClient;
+    let callsClient;
+    try {
+        callsClient = window.opener ? window.opener.callsClient : window.callsClient;
+    } catch (err) {
+        logErr(err);
+    }
+    return callsClient;
 }
 
 export function shouldRenderCallsIncoming() {
-    const win = window.opener ? window.opener : window;
-    const nonChannels = window.location.pathname.startsWith('/boards') || window.location.pathname.startsWith('/playbooks') || window.location.pathname.includes(`${pluginId}/expanded/`);
-    if (win.desktop && nonChannels) {
+    try {
+        const win = window.opener ? window.opener : window;
+        const nonChannels = window.location.pathname.startsWith('/boards') || window.location.pathname.startsWith('/playbooks') || window.location.pathname.includes(`${pluginId}/expanded/`);
+        if (win.desktop && nonChannels) {
         // don't render when we're in desktop, or in boards or playbooks, or in the expanded view.
         // (can be simplified, but this is clearer)
+            return false;
+        }
+        return true;
+    } catch (err) {
+        logErr(err);
         return false;
     }
-    return true;
 }
 
 export function getUserDisplayName(user: UserProfile | undefined, shortForm?: boolean) {
@@ -509,4 +520,15 @@ export function notificationsStopRinging() {
     if (window.e2eNotificationsSoundStoppedAt) {
         window.e2eNotificationsSoundStoppedAt.push(Date.now());
     }
+}
+
+export function getWebappUtils() {
+    let utils;
+    try {
+        utils = window.opener ? window.opener.WebappUtils : window.WebappUtils;
+    } catch (err) {
+        logErr(err);
+    }
+
+    return utils;
 }

--- a/webapp/src/webapp_globals.ts
+++ b/webapp/src/webapp_globals.ts
@@ -1,21 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Channel} from '@mattermost/types/channels';
 import {GlobalState} from '@mattermost/types/store';
-import {DispatchFunc, Thunk} from 'mattermost-redux/types/actions';
+import {Thunk} from 'mattermost-redux/types/actions';
+import {WebAppUtils} from 'src/types/mattermost-webapp';
 
 export const {
     modals,
     notificationSounds,
     sendDesktopNotificationToMe,
-}: {
-
-    // @ts-ignore
-    modals: { openModal, ModalIdentifiers },
-    notificationSounds: { ring: (sound: string) => void, stopRing: () => void },
-    sendDesktopNotificationToMe: (title: string, body: string, channel: Channel, teamId: string, silent: boolean, soundName: string, url: string) => (dispatch: DispatchFunc) => void,
-} =
+}: WebAppUtils =
 
 // @ts-ignore
 global.WebappUtils ?? {};


### PR DESCRIPTION
#### Summary

PR adds some try/catch when accessing properties on the global `window` object to avoid failing with an uncaught error in the unlikely case the object not being accessible/defined (e.g. cross-origin like the bug report).

While reproducing this issue, I realized that the `channelIDForCurrentCall` selector was getting called hundreds of times on channel load. We are now using `createSelector` which should cache the result which seems to be drastically reducing the number of calls. Please let me know if it makes sense.

**Before**

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/1511d24d-229a-4267-9485-25cfdd718a59)

**After:**

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/38259518-e436-4458-8b8b-f93aa2341112)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56048
