### PR TITLE
[MM-46676] Implement config option to override ICE candidates port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mattermost/logr/v2 v2.0.21
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.0.12
-	github.com/mattermost/rtcd v0.13.1-0.20240117195319-afe93ba017e0
+	github.com/mattermost/rtcd v0.13.1-0.20240123225600-e6976e37e812
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pion/interceptor v0.1.25
 	github.com/pion/rtp v1.8.3

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mattermost/logr/v2 v2.0.21
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.0.12
-	github.com/mattermost/rtcd v0.13.1-0.20240117174946-879c70ecd10f
+	github.com/mattermost/rtcd v0.13.1-0.20240117195319-afe93ba017e0
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pion/interceptor v0.1.25
 	github.com/pion/rtp v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,6 @@ github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy5
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
 github.com/mattermost/mattermost/server/public v0.0.12 h1:iunc9q4/XkArOrndEUn73uFw6v9TOEXEtp6Nm6Iv218=
 github.com/mattermost/mattermost/server/public v0.0.12/go.mod h1:Bk+atJcELCIk9Yeq5FoqTr+gra9704+X4amrlwlTgSc=
-github.com/mattermost/rtcd v0.13.1-0.20240117174946-879c70ecd10f h1:ZRpnwHGSEvIrZVsmozb4FW2S2vuWrivwWlwoAvBqQp0=
-github.com/mattermost/rtcd v0.13.1-0.20240117174946-879c70ecd10f/go.mod h1:I+BTpffHQqamaaZFJe0Lv3jvyLywBUXDQOks7YVUOTA=
 github.com/mattermost/rtcd v0.13.1-0.20240117195319-afe93ba017e0 h1:AQkm1WI+HEh7R31h7wc1N8cLYiUYh4Qr2y+sQhk3Qp0=
 github.com/mattermost/rtcd v0.13.1-0.20240117195319-afe93ba017e0/go.mod h1:I+BTpffHQqamaaZFJe0Lv3jvyLywBUXDQOks7YVUOTA=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy5
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
 github.com/mattermost/mattermost/server/public v0.0.12 h1:iunc9q4/XkArOrndEUn73uFw6v9TOEXEtp6Nm6Iv218=
 github.com/mattermost/mattermost/server/public v0.0.12/go.mod h1:Bk+atJcELCIk9Yeq5FoqTr+gra9704+X4amrlwlTgSc=
-github.com/mattermost/rtcd v0.13.1-0.20240117195319-afe93ba017e0 h1:AQkm1WI+HEh7R31h7wc1N8cLYiUYh4Qr2y+sQhk3Qp0=
-github.com/mattermost/rtcd v0.13.1-0.20240117195319-afe93ba017e0/go.mod h1:I+BTpffHQqamaaZFJe0Lv3jvyLywBUXDQOks7YVUOTA=
+github.com/mattermost/rtcd v0.13.1-0.20240123225600-e6976e37e812 h1:rBlM9qxowNzE8SOuxHyfsssiyKwkoLADQRQF3npjKY4=
+github.com/mattermost/rtcd v0.13.1-0.20240123225600-e6976e37e812/go.mod h1:I+BTpffHQqamaaZFJe0Lv3jvyLywBUXDQOks7YVUOTA=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/mattermost/mattermost/server/public v0.0.12 h1:iunc9q4/XkArOrndEUn73u
 github.com/mattermost/mattermost/server/public v0.0.12/go.mod h1:Bk+atJcELCIk9Yeq5FoqTr+gra9704+X4amrlwlTgSc=
 github.com/mattermost/rtcd v0.13.1-0.20240117174946-879c70ecd10f h1:ZRpnwHGSEvIrZVsmozb4FW2S2vuWrivwWlwoAvBqQp0=
 github.com/mattermost/rtcd v0.13.1-0.20240117174946-879c70ecd10f/go.mod h1:I+BTpffHQqamaaZFJe0Lv3jvyLywBUXDQOks7YVUOTA=
+github.com/mattermost/rtcd v0.13.1-0.20240117195319-afe93ba017e0 h1:AQkm1WI+HEh7R31h7wc1N8cLYiUYh4Qr2y+sQhk3Qp0=
+github.com/mattermost/rtcd v0.13.1-0.20240117195319-afe93ba017e0/go.mod h1:I+BTpffHQqamaaZFJe0Lv3jvyLywBUXDQOks7YVUOTA=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/plugin.json
+++ b/plugin.json
@@ -72,6 +72,13 @@
         "hosting": "on-prem"
       },
       {
+        "key": "ICEHostPortOverride",
+        "display_name": "ICE Host Port Override",
+        "type": "number",
+        "help_text": "(Optional) A port number to be used as an override for host candidates in place of the one used to listen on.\nNote: this port will apply to both UDP and TCP host candidates",
+        "hosting": "on-prem"
+      },
+      {
         "key": "RTCDServiceURL",
         "display_name": "RTCD service URL",
         "type": "text",

--- a/server/activate.go
+++ b/server/activate.go
@@ -181,6 +181,9 @@ func (p *Plugin) OnActivate() error {
 	if *cfg.ServerSideTURN {
 		rtcServerConfig.TURNConfig.StaticAuthSecret = cfg.TURNStaticAuthSecret
 	}
+	if cfg.ICEHostPortOverride != nil {
+		rtcServerConfig.ICEHostPortOverride = *cfg.ICEHostPortOverride
+	}
 	rtcServer, err := rtc.NewServer(rtcServerConfig, newLogger(p), p.metrics.RTCMetrics())
 	if err != nil {
 		p.LogError(err.Error())

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -34,6 +34,9 @@ import (
 type configuration struct {
 	// The IP (or hostname) to be used as the host ICE candidate.
 	ICEHostOverride string
+	// An optional port number to override the one used in ICE host candidates
+	// in place of the one used to listen on.
+	ICEHostPortOverride *int
 	// The local IP address used by the RTC server to listen on for UDP
 	// connections.
 	UDPServerAddress string
@@ -263,6 +266,10 @@ func (c *configuration) IsValid() error {
 		return fmt.Errorf("TranscriberModelSize is not valid")
 	}
 
+	if c.ICEHostPortOverride != nil && *c.ICEHostPortOverride != 0 && (*c.ICEHostPortOverride < minAllowedPort || *c.ICEHostPortOverride > maxAllowedPort) {
+		return fmt.Errorf("ICEHostPortOverride is not valid: %d is not in allowed range [%d, %d]", *c.ICEHostPortOverride, minAllowedPort, maxAllowedPort)
+	}
+
 	return nil
 }
 
@@ -342,6 +349,10 @@ func (c *configuration) Clone() *configuration {
 
 	if c.EnableRinging != nil {
 		cfg.EnableRinging = model.NewBool(*c.EnableRinging)
+	}
+
+	if c.ICEHostPortOverride != nil {
+		cfg.ICEHostPortOverride = model.NewInt(*c.ICEHostPortOverride)
 	}
 
 	return &cfg

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -104,6 +104,16 @@ func TestConfigurationIsValid(t *testing.T) {
 			err: "RecordingQuality is not valid",
 		},
 		{
+			name: "invalid ICEHostPortOverride",
+			input: func() configuration {
+				var cfg configuration
+				cfg.SetDefaults()
+				cfg.ICEHostPortOverride = model.NewInt(45)
+				return cfg
+			}(),
+			err: "ICEHostPortOverride is not valid: 45 is not in allowed range [80, 49151]",
+		},
+		{
 			name:  "defaults",
 			input: defaultConfig,
 		},

--- a/webapp/src/components/admin_console_settings/ice_host_port_override.tsx
+++ b/webapp/src/components/admin_console_settings/ice_host_port_override.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {ChangeEvent} from 'react';
+import {useSelector} from 'react-redux';
+import {
+    LabelRow, leftCol, rightCol,
+} from 'src/components/admin_console_settings/common';
+import {useHelptext} from 'src/components/admin_console_settings/hooks';
+import manifest from 'src/manifest';
+import {rtcdEnabled} from 'src/selectors';
+import {CustomComponentProps} from 'src/types/mattermost-webapp';
+
+const ICEHostPortOverride = (props: CustomComponentProps) => {
+    const isRTCDEnabled = useSelector(rtcdEnabled);
+    const helpText = useHelptext(props.helpText);
+
+    // Webapp doesn't pass the placeholder setting.
+    const placeholder = manifest.settings_schema?.settings.find((e) => e.key === 'ICEHostPortOverride')?.placeholder || '';
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        props.onChange(props.id, parseInt(e.target.value, 10));
+    };
+
+    return (
+        <div
+            data-testid={props.id}
+            className='form-group'
+        >
+            <div className={'control-label ' + leftCol}>
+                <LabelRow>
+                    <label
+                        data-testid={props.id + 'label'}
+                        htmlFor={props.id}
+                    >
+                        {props.label}
+                    </label>
+                </LabelRow>
+            </div>
+            <div className={rightCol}>
+                <input
+                    data-testid={props.id + 'number'}
+                    id={props.id}
+                    className='form-control'
+                    type={'number'}
+                    placeholder={placeholder}
+                    value={props.value === null ? '' : props.value}
+                    onChange={handleChange}
+                    disabled={props.disabled || isRTCDEnabled}
+                />
+                <div
+                    data-testid={props.id + 'help-text'}
+                    className='help-text'
+                >
+                    {helpText}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ICEHostPortOverride;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -27,6 +27,7 @@ import {
 import {navigateToURL} from 'src/browser_routing';
 import EnableIPv6 from 'src/components/admin_console_settings/enable_ipv6';
 import ICEHostOverride from 'src/components/admin_console_settings/ice_host_override';
+import ICEHostPortOverride from 'src/components/admin_console_settings/ice_host_port_override';
 import EnableRecordings from 'src/components/admin_console_settings/recordings/enable_recordings';
 import EnableTranscriptions from 'src/components/admin_console_settings/recordings/enable_transcriptions';
 import JobServiceURL from 'src/components/admin_console_settings/recordings/job_service_url';
@@ -377,6 +378,7 @@ export default class Plugin {
         registry.registerAdminConsoleCustomSetting('TCPServerPort', TCPServerPort);
         registry.registerAdminConsoleCustomSetting('EnableIPv6', EnableIPv6);
         registry.registerAdminConsoleCustomSetting('ICEHostOverride', ICEHostOverride);
+        registry.registerAdminConsoleCustomSetting('ICEHostPortOverride', ICEHostPortOverride);
         registry.registerAdminConsoleCustomSetting('ServerSideTURN', ServerSideTURN);
         registry.registerAdminConsoleCustomSetting('TranscriberModelSize', TranscriberModelSize);
 


### PR DESCRIPTION
#### Summary

PR adds a new `ICEHostPortOverride` config setting. More context in the linked PR.

#### Related PR

https://github.com/mattermost/rtcd/pull/129

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46676
