### PR TITLE
Move AI summarization button to the calls transcription post. Use the generated transcription.

### DIFF
--- a/e2e/tests/recordings.spec.ts
+++ b/e2e/tests/recordings.spec.ts
@@ -94,7 +94,7 @@ test.describe('call recordings and transcriptions', () => {
         await page.locator('.post__body').last().locator('.ThreadFooter button.ReplyButton').click();
         await expect(page.locator('.ThreadViewer').locator('.post__header').last()).toContainText('calls');
         await expect(page.locator('.ThreadViewer').locator('.post__header').last()).toContainText('BOT');
-        await expect(page.locator('.ThreadViewer').locator('.post__body').last().filter({has: page.locator('.post-message__text')})).toContainText('Here\'s the call transcription');
+        await expect(page.locator('.ThreadViewer').locator('.post__body').last().filter({has: page.getByTestId('calls-post-transcription-body')})).toContainText('Here\'s the call transcription');
         await expect(page.locator('.ThreadViewer').locator('.post__body').last().filter({has: page.getByTestId('fileAttachmentList')})).toBeVisible();
 
         // open recording's preview

--- a/server/bot_api.go
+++ b/server/bot_api.go
@@ -347,7 +347,7 @@ func (p *Plugin) handleBotPostTranscriptions(w http.ResponseWriter, r *http.Requ
 	}
 	transcriptionPost.AddProp("call_post_id", info.PostID)
 	transcriptionPost.AddProp("transcription_id", info.JobID)
-	transcriptionPost.AddProp("web_vtt_file_id", info.Transcriptions[0].FileIDs[0])
+	transcriptionPost.AddProp("captions", info.Transcriptions.ToClientCaptions())
 	trPost, appErr := p.API.CreatePost(transcriptionPost)
 	if appErr != nil {
 		res.Err = "failed to create post: " + appErr.Error()

--- a/server/bot_api.go
+++ b/server/bot_api.go
@@ -341,12 +341,13 @@ func (p *Plugin) handleBotPostTranscriptions(w http.ResponseWriter, r *http.Requ
 		UserId:    p.getBotID(),
 		ChannelId: callID,
 		Message:   postMsg,
-		Type:      "custom_calls_transcription",
+		Type:      callTranscriptionType,
 		RootId:    threadID,
 		FileIds:   []string{info.Transcriptions[0].FileIDs[1]},
 	}
 	transcriptionPost.AddProp("call_post_id", info.PostID)
 	transcriptionPost.AddProp("transcription_id", info.JobID)
+	transcriptionPost.AddProp("web_vtt_file_id", info.Transcriptions[0].FileIDs[0])
 	trPost, appErr := p.API.CreatePost(transcriptionPost)
 	if appErr != nil {
 		res.Err = "failed to create post: " + appErr.Error()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -29,6 +29,7 @@ import (
 const (
 	callStartPostType     = "custom_calls"
 	callRecordingPostType = "custom_calls_recording"
+	callTranscriptionType = "custom_calls_transcription"
 )
 
 // Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.

--- a/webapp/src/components/custom_post_types/post_type_recording.tsx
+++ b/webapp/src/components/custom_post_types/post_type_recording.tsx
@@ -1,84 +1,16 @@
-import {GlobalState} from '@mattermost/types/store';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector} from 'react-redux';
-import IconAI from 'src/components/icons/ai';
 import {transcriptionsEnabled} from 'src/selectors';
-import styled from 'styled-components';
 
-const aiPluginID = 'mattermost-ai';
-
-const useAIAvailable = () => {
-    //@ts-ignore plugins state is a thing
-    return useSelector<GlobalState, boolean>((state) => Boolean(state.plugins?.plugins?.[aiPluginID]));
-};
-
-type CallsPostButtonClickedFunc = ((post: any) => void) | undefined;
-
-const useCallsPostButtonClicked = () => {
-    return useSelector<GlobalState, CallsPostButtonClickedFunc>((state) => {
-        //@ts-ignore plugins state is a thing
-        return state['plugins-' + aiPluginID]?.callsPostButtonClicked;
-    });
-};
-
-const CreateMeetingSummaryButton = styled.button`
-	display: flex;
-	border: none;
-	height: 24px;
-	padding: 4px 10px;
-	margin-top: 8px;
-	margin-bottom: 8px;
-	align-items: center;
-	justify-content: center;
-	gap: 6px;
-	border-radius: 4px;
-	background: rgba(var(--center-channel-color-rgb), 0.08);
-    color: rgba(var(--center-channel-color-rgb), 0.64);
-	font-size: 12px;
-	font-weight: 600;
-	line-height: 16px;
-
-	:hover {
-		background: rgba(var(--center-channel-color-rgb), 0.12);
-        color: rgba(var(--center-channel-color-rgb), 0.72);
-	}
-
-	:active {
-		background: rgba(var(--button-bg-rgb), 0.08);
-		color: var(--button-bg);
-	}
-`;
-
-interface Props {
-    post: {id: string};
-}
-
-export const PostTypeRecording = (props: Props) => {
-    const aiAvailable = useAIAvailable();
-    const callsPostButtonClicked = useCallsPostButtonClicked();
-
+export const PostTypeRecording = () => {
     const hasTranscriptions = useSelector(transcriptionsEnabled);
 
-    const msg = hasTranscriptions ?
-        <FormattedMessage defaultMessage={'Here\'s the call recording. Transcription is processing and will be posted when ready.'}/> :
-        <FormattedMessage defaultMessage={'Here\'s the call recording'}/>;
-
-    const createMeetingSummary = () => {
-        callsPostButtonClicked?.(props.post);
-    };
+    const msg = hasTranscriptions ? <FormattedMessage defaultMessage={'Here\'s the call recording. Transcription is processing and will be posted when ready.'}/> : <FormattedMessage defaultMessage={'Here\'s the call recording'}/>;
 
     return (
         <>
             {msg}
-            {aiAvailable && callsPostButtonClicked &&
-            <CreateMeetingSummaryButton
-                onClick={createMeetingSummary}
-            >
-                <IconAI/>
-                <FormattedMessage defaultMessage={'Create meeting summary?'}/>
-            </CreateMeetingSummaryButton>
-            }
         </>
     );
 };

--- a/webapp/src/components/custom_post_types/post_type_transcription.tsx
+++ b/webapp/src/components/custom_post_types/post_type_transcription.tsx
@@ -1,0 +1,79 @@
+import {GlobalState} from '@mattermost/types/store';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import {useSelector} from 'react-redux';
+import IconAI from 'src/components/icons/ai';
+import styled from 'styled-components';
+
+const useAIAvailable = () => {
+    //@ts-ignore plugins state is a thing
+    return useSelector<GlobalState, boolean>((state) => Boolean(state.plugins?.plugins?.[aiPluginID]));
+};
+
+const aiPluginID = 'mattermost-ai';
+
+type CallsPostButtonClickedFunc = ((post: any) => void) | undefined;
+
+const useCallsPostButtonClicked = () => {
+    return useSelector<GlobalState, CallsPostButtonClickedFunc>((state) => {
+        //@ts-ignore plugins state is a thing
+        return state['plugins-' + aiPluginID]?.callsPostButtonClickedTranscription;
+    });
+};
+
+const CreateMeetingSummaryButton = styled.button`
+	display: flex;
+	border: none;
+	height: 24px;
+	padding: 4px 10px;
+	margin-top: 8px;
+	margin-bottom: 8px;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	border-radius: 4px;
+	background: rgba(var(--center-channel-color-rgb), 0.08);
+    color: rgba(var(--center-channel-color-rgb), 0.64);
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 16px;
+
+	:hover {
+		background: rgba(var(--center-channel-color-rgb), 0.12);
+        color: rgba(var(--center-channel-color-rgb), 0.72);
+	}
+
+	:active {
+		background: rgba(var(--button-bg-rgb), 0.08);
+		color: var(--button-bg);
+	}
+`;
+
+interface Props {
+    post: {id: string, message: string};
+}
+
+export const PostTypeTranscription = (props: Props) => {
+    const aiAvailable = useAIAvailable();
+    const callsPostButtonClicked = useCallsPostButtonClicked();
+
+    const createMeetingSummary = () => {
+        callsPostButtonClicked?.(props.post);
+    };
+
+    const msg = props.post.message;
+
+    return (
+        <>
+            {msg}
+            {aiAvailable && callsPostButtonClicked &&
+            <CreateMeetingSummaryButton
+                onClick={createMeetingSummary}
+            >
+                <IconAI/>
+                <FormattedMessage defaultMessage={'Create meeting summary?'}/>
+            </CreateMeetingSummaryButton>
+            }
+        </>
+    );
+};

--- a/webapp/src/components/custom_post_types/post_type_transcription.tsx
+++ b/webapp/src/components/custom_post_types/post_type_transcription.tsx
@@ -64,7 +64,7 @@ export const PostTypeTranscription = (props: Props) => {
     const msg = props.post.message;
 
     return (
-        <>
+        <div data-testid={'calls-post-transcription-body'}>
             {msg}
             {aiAvailable && callsPostButtonClicked &&
             <CreateMeetingSummaryButton
@@ -74,6 +74,6 @@ export const PostTypeTranscription = (props: Props) => {
                 <FormattedMessage defaultMessage={'Create meeting summary?'}/>
             </CreateMeetingSummaryButton>
             }
-        </>
+        </div>
     );
 };

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -9,6 +9,7 @@ export const RING_LENGTH = 30000;
 export const DEFAULT_RING_SOUND = 'Calm';
 export const CALL_START_POST_TYPE = 'custom_calls';
 export const CALL_RECORDING_POST_TYPE = 'custom_calls_recording';
+export const CALL_TRANSCRIPTION_POST_TYPE = 'custom_calls_transcription';
 
 // From mattermost-webapp/webapp/channels/src/utils/constants.tsx, importing causes tsc to throw fits.
 export const MESSAGE_DISPLAY = 'message_display';

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -44,7 +44,7 @@ import {PostTypeCloudTrialRequest} from 'src/components/custom_post_types/post_t
 import {PostTypeRecording} from 'src/components/custom_post_types/post_type_recording';
 import {IncomingCallContainer} from 'src/components/incoming_calls/call_container';
 import RecordingsFilePreview from 'src/components/recordings_file_preview';
-import {CALL_RECORDING_POST_TYPE, CALL_START_POST_TYPE, DisabledCallsErr} from 'src/constants';
+import {CALL_RECORDING_POST_TYPE, CALL_START_POST_TYPE, CALL_TRANSCRIPTION_POST_TYPE, DisabledCallsErr} from 'src/constants';
 import {desktopNotificationHandler} from 'src/desktop_notifications';
 import RestClient from 'src/rest_client';
 import slashCommandsHandler from 'src/slash_commands';
@@ -71,6 +71,7 @@ import ChannelHeaderDropdownButton from './components/channel_header_dropdown_bu
 import ChannelHeaderMenuButton from './components/channel_header_menu_button';
 import ChannelLinkLabel from './components/channel_link_label';
 import PostType from './components/custom_post_types/post_type';
+import {PostTypeTranscription} from './components/custom_post_types/post_type_transcription';
 import EndCallModal from './components/end_call_modal';
 import ExpandedView from './components/expanded_view';
 import ScreenSourceModal from './components/screen_source_modal';
@@ -254,6 +255,7 @@ export default class Plugin {
         registry.registerChannelToastComponent(injectIntl(ChannelCallToast));
         registry.registerPostTypeComponent(CALL_START_POST_TYPE, PostType);
         registry.registerPostTypeComponent(CALL_RECORDING_POST_TYPE, PostTypeRecording);
+        registry.registerPostTypeComponent(CALL_TRANSCRIPTION_POST_TYPE, PostTypeTranscription);
         registry.registerPostTypeComponent('custom_cloud_trial_req', PostTypeCloudTrialRequest);
         registry.registerNeedsTeamRoute('/expanded', injectIntl(ExpandedView));
         registry.registerGlobalComponent(injectIntl(SwitchCallModal));


### PR DESCRIPTION
#### Summary

Moves the AI summarization button to the to the call transcription post. 

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/3191642/6e06bc9d-4b49-4eac-ab30-1f6e2a7a48f8)


When used the button will now use the WebVTT generated transcript "attached" to that post.

As before, the versions of the calls and AI plugin must both support this for the button to show up.
