### PR TITLE
Fix `npm link` for `@calls/common`

### DIFF
--- a/standalone/webpack.config.js
+++ b/standalone/webpack.config.js
@@ -106,6 +106,7 @@ module.exports = {
             'node_modules',
         ],
         extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
+        symlinks: false,
     },
     module: {
         rules: [

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = {
             'node_modules',
         ],
         extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
+        symlinks: false,
     },
     module: {
         rules: [


### PR DESCRIPTION
#### Summary

Working process is as follows:

1. Run `npm link` in your local `calls-common` repo directory.
2. Run `npm link @calls/common` in both `mattermost-plugins-calls/webapp` and `mattermost-plugin-calls/standalone`.
3. Build plugin as normal


