### PR TITLE
MM-56718: Conditionally access post

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -265,7 +265,7 @@ export default class Plugin {
         registry.registerGlobalComponent(injectIntl(IncomingCallContainer));
 
         registry.registerFilePreviewComponent((fi, post) => {
-            return String(post.type) === CALL_RECORDING_POST_TYPE;
+            return String(post?.type) === CALL_RECORDING_POST_TYPE;
         }, RecordingsFilePreview);
 
         registry.registerTranslations((locale: string) => {

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -69,7 +69,7 @@ export interface PluginRegistry {
 
     registerTranslations(handler: (locale: string) => Translations | Promise<Translations>);
 
-    registerFilePreviewComponent(overrideFn: (fi: FileInfo, post: Post) => boolean, component: React.ElementType);
+    registerFilePreviewComponent(overrideFn: (fi: FileInfo, post?: Post) => boolean, component: React.ElementType);
 }
 
 export type SlashCommandWillBePostedReturn = { error: string } | { message: string, args: CommandArgs } | unknown;


### PR DESCRIPTION
#### Summary
Discovered during https://github.com/mattermost/mattermost/pull/25889, `registerFilePreviewComponent` may not receive a post. Normally attachments are always associated with posts, but bookmark files don't have an associated post. 

Updating type and adding `?.` to account for this. https://github.com/mattermost/mattermost/pull/25889 contains a backwards-compat. fix to provide an empty object.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56718
