### PR TITLE
[MM-48545] Fix response in case of resumable upload

### DIFF
--- a/server/audit.go
+++ b/server/audit.go
@@ -30,9 +30,11 @@ func (p *Plugin) httpResponseHandler(res *httpResponse, w http.ResponseWriter) {
 		if res.Code != 0 {
 			w.WriteHeader(res.Code)
 		}
-		w.Header().Add("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(res); err != nil {
-			p.LogError(fmt.Sprintf("failed to encode data: %s", err))
+		if res.Code != http.StatusNoContent {
+			w.Header().Add("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(res); err != nil {
+				p.LogError(fmt.Sprintf("failed to encode data: %s", err))
+			}
 		}
 	}
 }
@@ -42,7 +44,7 @@ func (p *Plugin) httpAudit(handler string, res *httpResponse, w http.ResponseWri
 	if res.Err != "" {
 		logFields = append(logFields, "error", res.Err, "code", res.Code, "status", "fail")
 	} else {
-		logFields = append(logFields, "status", "success")
+		logFields = append(logFields, "code", res.Code, "status", "success")
 	}
 
 	p.httpResponseHandler(res, w)


### PR DESCRIPTION
#### Summary

Fixing the response handler in case of `http.StatusNoContent` which we support as part of the resumable upload handler for recordings. Without this we'd get an annoying `http: request method or response status code does not allow body` error logged.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48545