### PR TITLE
Fix fetching captions

### DIFF
--- a/server/bot_api.go
+++ b/server/bot_api.go
@@ -327,7 +327,7 @@ func (p *Plugin) handleBotPostTranscriptions(w http.ResponseWriter, r *http.Requ
 	// Updating the file to point to the existing call post solves this problem
 	// without requiring us to expose a dedicated API nor attach the file which
 	// we don't want to show.
-	if err := p.updateFileInfoPostID(info.Transcriptions[0].FileIDs[0], info.PostID); err != nil {
+	if err := p.updateFileInfoPostID(info.Transcriptions[0].FileIDs[0], callID, info.PostID); err != nil {
 		res.Err = "failed to update fileinfo post id: " + err.Error()
 		res.Code = http.StatusInternalServerError
 	}

--- a/server/store.go
+++ b/server/store.go
@@ -109,8 +109,9 @@ func (p *Plugin) GetPost(postID string) (*model.Post, error) {
 	return &post, nil
 }
 
-func (p *Plugin) updateFileInfoPostID(fileID, postID string) error {
+func (p *Plugin) updateFileInfoPostID(fileID, channelID, postID string) error {
 	qb := getQueryBuilder(p.driverName).Update("FileInfo").
+		Set("ChannelId", channelID).
 		Set("PostId", postID).
 		Where(sq.Eq{"Id": fileID})
 	q, args, err := qb.ToSql()


### PR DESCRIPTION
#### Summary

Since https://github.com/mattermost/mattermost/pull/26239 permissions checks on files require a channel ID to be set so it's not sufficient to use the post ID.

