### PR TITLE
[MM-51852] Update server version to min version that has MM-51852

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "description": "Integrates real-time voice communication in Mattermost",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
-  "min_server_version": "9.2.0",
+  "min_server_version": "9.5.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "description": "Integrates real-time voice communication in Mattermost",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
-  "min_server_version": "7.8.0",
+  "min_server_version": "9.2.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
- https://github.com/mattermost/mattermost/pull/24731 has a breaking change, and the earliest server branch with that PR is 9.2.0, so make 9.2.0 our new min server version.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-56659