### PR TITLE
Bump docker images

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -232,8 +232,8 @@
   },
   "props": {
     "min_rtcd_version": "v0.12.0",
-    "min_offloader_version": "v0.6.0",
-    "calls_recorder_version": "v0.6.4",
-    "calls_transcriber_version": "v0.1.8"
+    "min_offloader_version": "v0.7.0",
+    "calls_recorder_version": "v0.7.0",
+    "calls_transcriber_version": "v0.1.9"
   }
 }


### PR DESCRIPTION
#### Summary

Bumping our docker image versions to the latest releases. Will run e2e against https://git.internal.mattermost.com/qa/calls-e2e-testing/-/merge_requests/49 before merging.


