### PR TITLE
[MM-42464] SQL store: `calls_sessions`

### DIFF
--- a/server/db/call_session.go
+++ b/server/db/call_session.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/mattermost/mattermost-plugin-calls/server/public"
+
+	sq "github.com/mattermost/squirrel"
+)
+
+func (s *Store) CreateCallSession(session *public.CallSession) error {
+	s.metrics.IncStoreOp("CreateCallSession")
+
+	if session == nil {
+		return fmt.Errorf("session should not be nil")
+	}
+
+	if err := session.IsValid(); err != nil {
+		return fmt.Errorf("invalid call session: %w", err)
+	}
+
+	qb := getQueryBuilder(s.driverName).
+		Insert("calls_sessions").
+		Columns("ID", "CallID", "UserID", "JoinAt", "Unmuted", "RaisedHand").
+		Values(session.ID, session.CallID, session.UserID, session.JoinAt, session.Unmuted, session.RaisedHand)
+
+	q, args, err := qb.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	_, err = s.wDB.Exec(q, args...)
+	if err != nil {
+		return fmt.Errorf("failed to run query: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) UpdateCallSession(session *public.CallSession) error {
+	s.metrics.IncStoreOp("UpdateCallSession")
+
+	if session == nil {
+		return fmt.Errorf("session should not be nil")
+	}
+
+	qb := getQueryBuilder(s.driverName).
+		Update("calls_sessions").
+		Set("Unmuted", session.Unmuted).
+		Set("RaisedHand", session.RaisedHand).
+		Where(sq.Eq{"ID": session.ID})
+
+	q, args, err := qb.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	res, err := s.wDB.Exec(q, args...)
+	if err != nil {
+		return fmt.Errorf("failed to run query: %w", err)
+	}
+
+	count, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if count != 1 {
+		return fmt.Errorf("failed to update call session")
+	}
+
+	return nil
+}
+
+func (s *Store) DeleteCallSession(id string) error {
+	s.metrics.IncStoreOp("DeleteCallSession")
+
+	qb := getQueryBuilder(s.driverName).
+		Delete("calls_sessions").
+		Where(sq.Eq{"ID": id})
+
+	q, args, err := qb.ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	_, err = s.wDB.Exec(q, args...)
+	if err != nil {
+		return fmt.Errorf("failed to run query: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) GetCallSession(id string, opts GetCallSessionOpts) (*public.CallSession, error) {
+	s.metrics.IncStoreOp("GetCallSession")
+
+	qb := getQueryBuilder(s.driverName).Select("*").
+		From("calls_sessions").
+		Where(sq.Eq{"ID": id})
+
+	q, args, err := qb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	var session public.CallSession
+	if err := s.dbXFromGetOpts(opts).Get(&session, q, args...); err == sql.ErrNoRows {
+		return nil, fmt.Errorf("call session not found")
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get call session: %w", err)
+	}
+
+	return &session, nil
+}
+
+func (s *Store) GetCallSessions(callID string, opts GetCallSessionOpts) ([]*public.CallSession, error) {
+	s.metrics.IncStoreOp("GetCallSessions")
+
+	qb := getQueryBuilder(s.driverName).Select("*").
+		From("calls_sessions").
+		Where(sq.Eq{"CallID": callID})
+
+	q, args, err := qb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	sessions := []*public.CallSession{}
+	if err := s.dbXFromGetOpts(opts).Select(&sessions, q, args...); err != nil {
+		return nil, fmt.Errorf("failed to get call sessions: %w", err)
+	}
+
+	return sessions, nil
+}

--- a/server/db/call_session_test.go
+++ b/server/db/call_session_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-calls/server/public"
+
+	"github.com/mattermost/mattermost/server/public/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallSessionStore(t *testing.T) {
+	t.Parallel()
+	testStore(t, map[string]func(t *testing.T, store *Store){
+		"TestCreateCallSession": testCreateCallSession,
+		"TestDeleteCallSession": testDeleteCallSession,
+		"TestUpdateCallSession": testUpdateCallSession,
+		"TestGetCallSession":    testGetCallSession,
+		"TestGetCallSessions":   testGetCallSessions,
+	})
+}
+
+func testCreateCallSession(t *testing.T, store *Store) {
+	t.Run("invalid", func(t *testing.T) {
+		err := store.CreateCallSession(nil)
+		require.EqualError(t, err, "session should not be nil")
+
+		err = store.CreateCallSession(&public.CallSession{})
+		require.EqualError(t, err, "invalid call session: invalid ID: should not be empty")
+
+		err = store.CreateCallSession(&public.CallSession{
+			ID: model.NewId(),
+		})
+		require.EqualError(t, err, "invalid call session: invalid CallID: should not be empty")
+
+		err = store.CreateCallSession(&public.CallSession{
+			ID:     model.NewId(),
+			CallID: model.NewId(),
+		})
+		require.EqualError(t, err, "invalid call session: invalid UserID: should not be empty")
+
+		err = store.CreateCallSession(&public.CallSession{
+			ID:     model.NewId(),
+			CallID: model.NewId(),
+			UserID: model.NewId(),
+		})
+		require.EqualError(t, err, "invalid call session: invalid JoinAt: should not be zero")
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		session := &public.CallSession{
+			ID:         model.NewId(),
+			CallID:     model.NewId(),
+			UserID:     model.NewId(),
+			JoinAt:     time.Now().UnixMilli(),
+			Unmuted:    true,
+			RaisedHand: time.Now().UnixMilli(),
+		}
+
+		err := store.CreateCallSession(session)
+		require.NoError(t, err)
+
+		gotSession, err := store.GetCallSession(session.ID, GetCallSessionOpts{
+			FromWriter: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, session, gotSession)
+	})
+}
+
+func testUpdateCallSession(t *testing.T, store *Store) {
+	t.Run("nil", func(t *testing.T) {
+		var session *public.CallSession
+		err := store.UpdateCallSession(session)
+		require.EqualError(t, err, "session should not be nil")
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		err := store.UpdateCallSession(&public.CallSession{
+			ID: "sessionID",
+		})
+		require.EqualError(t, err, "failed to update call session")
+	})
+
+	t.Run("existing", func(t *testing.T) {
+		session := &public.CallSession{
+			ID:      model.NewId(),
+			CallID:  model.NewId(),
+			UserID:  model.NewId(),
+			JoinAt:  time.Now().UnixMilli(),
+			Unmuted: true,
+		}
+
+		err := store.CreateCallSession(session)
+		require.NoError(t, err)
+
+		session.RaisedHand = time.Now().UnixMilli()
+		session.Unmuted = false
+
+		err = store.UpdateCallSession(session)
+		require.NoError(t, err)
+
+		gotSession, err := store.GetCallSession(session.ID, GetCallSessionOpts{
+			FromWriter: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, session, gotSession)
+	})
+}
+
+func testDeleteCallSession(t *testing.T, store *Store) {
+	t.Run("missing", func(t *testing.T) {
+		err := store.DeleteCallSession(model.NewId())
+		require.NoError(t, err)
+	})
+
+	t.Run("existing", func(t *testing.T) {
+		session := &public.CallSession{
+			ID:      model.NewId(),
+			CallID:  model.NewId(),
+			UserID:  model.NewId(),
+			JoinAt:  time.Now().UnixMilli(),
+			Unmuted: true,
+		}
+
+		err := store.CreateCallSession(session)
+		require.NoError(t, err)
+
+		_, err = store.GetCallSession(session.ID, GetCallSessionOpts{
+			FromWriter: true,
+		})
+		require.NoError(t, err)
+
+		err = store.DeleteCallSession(session.ID)
+		require.NoError(t, err)
+
+		_, err = store.GetCallSession(session.ID, GetCallSessionOpts{
+			FromWriter: true,
+		})
+		require.EqualError(t, err, "call session not found")
+	})
+}
+
+func testGetCallSession(t *testing.T, store *Store) {
+	t.Run("missing", func(t *testing.T) {
+		session, err := store.GetCallSession(model.NewId(), GetCallSessionOpts{})
+		require.EqualError(t, err, "call session not found")
+		require.Nil(t, session)
+	})
+
+	t.Run("existing", func(t *testing.T) {
+		session := &public.CallSession{
+			ID:      model.NewId(),
+			CallID:  model.NewId(),
+			UserID:  model.NewId(),
+			JoinAt:  time.Now().UnixMilli(),
+			Unmuted: true,
+		}
+
+		err := store.CreateCallSession(session)
+		require.NoError(t, err)
+
+		gotSession, err := store.GetCallSession(session.ID, GetCallSessionOpts{
+			FromWriter: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, session, gotSession)
+	})
+}
+
+func testGetCallSessions(t *testing.T, store *Store) {
+	t.Run("no sessions", func(t *testing.T) {
+		sessions, err := store.GetCallSessions(model.NewId(), GetCallSessionOpts{})
+		require.NoError(t, err)
+		require.NotNil(t, sessions)
+		require.Empty(t, sessions)
+	})
+
+	t.Run("multiple sessions", func(t *testing.T) {
+		var sessions []*public.CallSession
+		callID := model.NewId()
+		for i := 0; i < 10; i++ {
+			sessions = append(sessions, &public.CallSession{
+				ID:     model.NewId(),
+				CallID: callID,
+				UserID: model.NewId(),
+				JoinAt: time.Now().UnixMilli(),
+			})
+
+			err := store.CreateCallSession(sessions[i])
+			require.NoError(t, err)
+		}
+
+		gotSessions, err := store.GetCallSessions(callID, GetCallSessionOpts{})
+		require.NoError(t, err)
+		require.Len(t, gotSessions, 10)
+		require.ElementsMatch(t, sessions, gotSessions)
+	})
+}

--- a/server/db/call_store_test.go
+++ b/server/db/call_store_test.go
@@ -48,8 +48,8 @@ func testCreateCall(t *testing.T, store *Store) {
 			Stats: public.CallStats{
 				ScreenDuration: 45,
 			},
-			Props: map[string]any{
-				"test_prop": "test",
+			Props: public.CallProps{
+				Hosts: []string{"userA", "userB"},
 			},
 		}
 
@@ -82,8 +82,8 @@ func testDeleteCall(t *testing.T, store *Store) {
 			Stats: public.CallStats{
 				ScreenDuration: 45,
 			},
-			Props: map[string]any{
-				"test_prop": "test",
+			Props: public.CallProps{
+				Hosts: []string{"userA", "userB"},
 			},
 		}
 
@@ -120,8 +120,8 @@ func testDeleteCallByChannelID(t *testing.T, store *Store) {
 			Stats: public.CallStats{
 				ScreenDuration: 45,
 			},
-			Props: map[string]any{
-				"test_prop": "test",
+			Props: public.CallProps{
+				Hosts: []string{"userA", "userB"},
 			},
 		}
 
@@ -166,8 +166,8 @@ func testUpdateCall(t *testing.T, store *Store) {
 			Stats: public.CallStats{
 				ScreenDuration: 45,
 			},
-			Props: map[string]any{
-				"test_prop": "test",
+			Props: public.CallProps{
+				Hosts: []string{"userA", "userB"},
 			},
 		}
 
@@ -177,8 +177,7 @@ func testUpdateCall(t *testing.T, store *Store) {
 
 		call.Participants = append(call.Participants, model.NewId())
 		call.Stats.ScreenDuration = 4545
-		call.Props["new_prop"] = float64(45)
-		call.Props["test_prop"] = "updated"
+		call.Props.ScreenSharingSessionID = "sessionA"
 
 		err = store.UpdateCall(call)
 		require.NoError(t, err)
@@ -209,8 +208,8 @@ func testGetCall(t *testing.T, store *Store) {
 			Stats: public.CallStats{
 				ScreenDuration: 45,
 			},
-			Props: map[string]any{
-				"test_prop": "test",
+			Props: public.CallProps{
+				Hosts: []string{"userA", "userB"},
 			},
 		}
 
@@ -243,8 +242,8 @@ func testGetCallByChannelID(t *testing.T, store *Store) {
 			Stats: public.CallStats{
 				ScreenDuration: 45,
 			},
-			Props: map[string]any{
-				"test_prop": "test",
+			Props: public.CallProps{
+				Hosts: []string{"userA", "userB"},
 			},
 		}
 

--- a/server/db/migrate_test.go
+++ b/server/db/migrate_test.go
@@ -29,6 +29,9 @@ func TestMigrate(t *testing.T) {
 		_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls`)
 		require.EqualError(t, err, `pq: relation "calls" does not exist`)
 
+		_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls_sessions`)
+		require.EqualError(t, err, `pq: relation "calls_sessions" does not exist`)
+
 		t.Run("empty pluginkeyvaluestore", func(t *testing.T) {
 			t.Run("up", func(t *testing.T) {
 				err := store.Migrate(models.Up, false)
@@ -42,6 +45,10 @@ func TestMigrate(t *testing.T) {
 				err = store.wDBx.Get(&count, `SELECT COUNT(*) FROM calls`)
 				require.NoError(t, err)
 				require.Zero(t, count)
+
+				err = store.wDBx.Get(&count, `SELECT COUNT(*) FROM calls_sessions`)
+				require.NoError(t, err)
+				require.Zero(t, count)
 			})
 
 			t.Run("down", func(t *testing.T) {
@@ -53,6 +60,9 @@ func TestMigrate(t *testing.T) {
 
 				_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls`)
 				require.EqualError(t, err, `pq: relation "calls" does not exist`)
+
+				_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls_sessions`)
+				require.EqualError(t, err, `pq: relation "calls_sessions" does not exist`)
 			})
 		})
 
@@ -105,6 +115,9 @@ func TestMigrate(t *testing.T) {
 
 				_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls`)
 				require.EqualError(t, err, `pq: relation "calls" does not exist`)
+
+				_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls_sessions`)
+				require.EqualError(t, err, `pq: relation "calls_sessions" does not exist`)
 			})
 		})
 	})
@@ -121,6 +134,12 @@ func TestMigrate(t *testing.T) {
 		_, err := store.wDB.Exec(`SELECT COUNT(*) FROM calls_channels`)
 		require.EqualError(t, err, `Error 1146 (42S02): Table 'mattermost_test.calls_channels' doesn't exist`)
 
+		_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls`)
+		require.EqualError(t, err, `Error 1146 (42S02): Table 'mattermost_test.calls' doesn't exist`)
+
+		_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls_sessions`)
+		require.EqualError(t, err, `Error 1146 (42S02): Table 'mattermost_test.calls_sessions' doesn't exist`)
+
 		t.Run("empty PluginKeyValueStore", func(t *testing.T) {
 			t.Run("up", func(t *testing.T) {
 				err := store.Migrate(models.Up, false)
@@ -134,6 +153,10 @@ func TestMigrate(t *testing.T) {
 				err = store.wDBx.Get(&count, `SELECT COUNT(*) FROM calls`)
 				require.NoError(t, err)
 				require.Zero(t, count)
+
+				err = store.wDBx.Get(&count, `SELECT COUNT(*) FROM calls_sessions`)
+				require.NoError(t, err)
+				require.Zero(t, count)
 			})
 
 			t.Run("down", func(t *testing.T) {
@@ -145,6 +168,9 @@ func TestMigrate(t *testing.T) {
 
 				_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls`)
 				require.EqualError(t, err, `Error 1146 (42S02): Table 'mattermost_test.calls' doesn't exist`)
+
+				_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls_sessions`)
+				require.EqualError(t, err, `Error 1146 (42S02): Table 'mattermost_test.calls_sessions' doesn't exist`)
 			})
 		})
 
@@ -197,6 +223,9 @@ func TestMigrate(t *testing.T) {
 
 				_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls`)
 				require.EqualError(t, err, `Error 1146 (42S02): Table 'mattermost_test.calls' doesn't exist`)
+
+				_, err = store.wDB.Exec(`SELECT COUNT(*) FROM calls_sessions`)
+				require.EqualError(t, err, `Error 1146 (42S02): Table 'mattermost_test.calls_sessions' doesn't exist`)
 			})
 		})
 	})

--- a/server/db/migrations/migrations.list
+++ b/server/db/migrations/migrations.list
@@ -4,7 +4,11 @@ server/db/migrations/mysql/000001_create_calls_channels.down.sql
 server/db/migrations/mysql/000001_create_calls_channels.up.sql
 server/db/migrations/mysql/000002_create_calls.down.sql
 server/db/migrations/mysql/000002_create_calls.up.sql
+server/db/migrations/mysql/000003_create_calls_sessions.down.sql
+server/db/migrations/mysql/000003_create_calls_sessions.up.sql
 server/db/migrations/postgres/000001_create_calls_channels.down.sql
 server/db/migrations/postgres/000001_create_calls_channels.up.sql
 server/db/migrations/postgres/000002_create_calls.down.sql
 server/db/migrations/postgres/000002_create_calls.up.sql
+server/db/migrations/postgres/000003_create_calls_sessions.down.sql
+server/db/migrations/postgres/000003_create_calls_sessions.up.sql

--- a/server/db/migrations/mysql/000001_create_calls_channels.up.sql
+++ b/server/db/migrations/mysql/000001_create_calls_channels.up.sql
@@ -1,8 +1,7 @@
 CREATE TABLE IF NOT EXISTS calls_channels (
-    ChannelID varchar(26) NOT NULL,
+    ChannelID varchar(26) PRIMARY KEY,
     Enabled BOOLEAN,
-		Props JSON,
-    PRIMARY KEY (ChannelId)
+    Props JSON
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE PROCEDURE migrate_calls_channels ()

--- a/server/db/migrations/mysql/000003_create_calls_sessions.down.sql
+++ b/server/db/migrations/mysql/000003_create_calls_sessions.down.sql
@@ -1,0 +1,16 @@
+SET @preparedStatement = (SELECT IF(
+    (
+        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE table_name = 'calls_sessions'
+        AND table_schema = DATABASE()
+        AND index_name = 'idx_calls_sessions_call_id'
+    ) > 0,
+    'DROP INDEX idx_calls_sessions_call_id ON calls_sessions;',
+    'SELECT 1'
+));
+
+PREPARE removeIndexIfExists FROM @preparedStatement;
+EXECUTE removeIndexIfExists;
+DEALLOCATE PREPARE removeIndexIfExists;
+
+DROP TABLE IF EXISTS calls_sessions;

--- a/server/db/migrations/mysql/000003_create_calls_sessions.up.sql
+++ b/server/db/migrations/mysql/000003_create_calls_sessions.up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS calls_sessions (
+    ID VARCHAR(26) PRIMARY KEY,
+    CallID VARCHAR(26),
+    UserID VARCHAR(26),
+    JoinAt BIGINT,
+    Unmuted BOOLEAN,
+    RaisedHand BIGINT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+SET @preparedStatement = (SELECT IF(
+    (
+        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE table_name = 'calls_sessions'
+        AND table_schema = DATABASE()
+        AND index_name = 'idx_calls_sessions_call_id'
+    ) > 0,
+    'SELECT 1',
+    'CREATE INDEX idx_calls_sessions_call_id ON calls_sessions(CallID);'
+));
+
+PREPARE createIndexIfNotExists FROM @preparedStatement;
+EXECUTE createIndexIfNotExists;
+DEALLOCATE PREPARE createIndexIfNotExists;

--- a/server/db/migrations/postgres/000003_create_calls_sessions.down.sql
+++ b/server/db/migrations/postgres/000003_create_calls_sessions.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_calls_sessions_call_id;
+
+DROP TABLE IF EXISTS calls_sessions;

--- a/server/db/migrations/postgres/000003_create_calls_sessions.up.sql
+++ b/server/db/migrations/postgres/000003_create_calls_sessions.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS calls_sessions (
+    id VARCHAR(26) PRIMARY KEY,
+    callid VARCHAR(26),
+    userid VARCHAR(26),
+    joinat bigint,
+    unmuted  boolean,
+    raisedhand bigint
+);
+
+CREATE INDEX IF NOT EXISTS idx_calls_sessions_call_id ON calls_sessions (callid);

--- a/server/db/opts.go
+++ b/server/db/opts.go
@@ -23,6 +23,14 @@ func (o GetCallsChannelOpts) UseWriter() bool {
 	return o.FromWriter
 }
 
+type GetCallSessionOpts struct {
+	FromWriter bool
+}
+
+func (o GetCallSessionOpts) UseWriter() bool {
+	return o.FromWriter
+}
+
 type getOpts interface {
 	UseWriter() bool
 }

--- a/server/public/adapters.go
+++ b/server/public/adapters.go
@@ -48,3 +48,16 @@ func (cs *CallStats) Scan(src any) error {
 
 	return json.Unmarshal(data, cs)
 }
+
+func (cp CallProps) Value() (driver.Value, error) {
+	return json.Marshal(cp)
+}
+
+func (cp *CallProps) Scan(src any) error {
+	data, ok := src.([]byte)
+	if !ok {
+		return fmt.Errorf("unsupported source type %T", src)
+	}
+
+	return json.Unmarshal(data, cp)
+}

--- a/server/public/call.go
+++ b/server/public/call.go
@@ -13,9 +13,16 @@ type Call struct {
 	OwnerID      string      `json:"owner_id"`
 	Participants StringArray `json:"participants"`
 	Stats        CallStats   `json:"stats"`
-	Props        StringMap   `json:"props"`
+	Props        CallProps   `json:"props"`
+}
+
+type CallProps struct {
+	Hosts                  []string        `json:"hosts,omitempty"`
+	RTCDHost               string          `json:"rtcd_host,omitempty"`
+	ScreenSharingSessionID string          `json:"screen_sharing_session_id,omitempty"`
+	DismissedNotification  map[string]bool `json:"dismissed_notification,omitempty"`
 }
 
 type CallStats struct {
-	ScreenDuration int `json:"screen_duration"`
+	ScreenDuration int `json:"screen_duration,omitempty"`
 }

--- a/server/public/call_session.go
+++ b/server/public/call_session.go
@@ -1,0 +1,34 @@
+package public
+
+import (
+	"fmt"
+)
+
+type CallSession struct {
+	ID         string `json:"id"`
+	CallID     string `json:"call_id"`
+	UserID     string `json:"user_id"`
+	JoinAt     int64  `json:"join_at"`
+	Unmuted    bool   `json:"unmuted"`
+	RaisedHand int64  `json:"raised_hand"`
+}
+
+func (s CallSession) IsValid() error {
+	if s.ID == "" {
+		return fmt.Errorf("invalid ID: should not be empty")
+	}
+
+	if s.CallID == "" {
+		return fmt.Errorf("invalid CallID: should not be empty")
+	}
+
+	if s.UserID == "" {
+		return fmt.Errorf("invalid UserID: should not be empty")
+	}
+
+	if s.JoinAt == 0 {
+		return fmt.Errorf("invalid JoinAt: should not be zero")
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### Summary

This is the last bit in terms of new tables (for now). 

As discussed, I am leaving jobs stuff behind for the time being while we figure out if we need them or if we can still rely on post props.

I'll also need to likely tweak some things such as adding indexes but I prefer to defer that to the upcoming PR which will be updating the business logic as it will become clearer how and when we fetch data.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42464

#### Parent PR

https://github.com/mattermost/mattermost-plugin-calls/pull/647