### PR TITLE
[MM-57327] Set basename on default client as well if present

### DIFF
--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -41,6 +41,7 @@ import {
 import {pluginId} from 'plugin/manifest';
 import reducer from 'plugin/reducers';
 import RestClient from 'plugin/rest_client';
+import {Client4} from 'mattermost-redux/client';
 import {callsConfig, iceServers, needsTURNCredentials} from 'plugin/selectors';
 import {DesktopNotificationArgs, Store, WebAppUtils} from 'plugin/types/mattermost-webapp';
 import {
@@ -162,7 +163,11 @@ export default async function init(cfg: InitConfig) {
 
     // Setting the base URL if present, in case MM is running under a subpath.
     if (window.basename) {
+        // If present, we need to set the basename on both the client we use (RestClient)
+        // and the default one (Client4) used by internal Redux actions. Not doing so
+        // would break Calls widget on installations served under a subpath.
         RestClient.setUrl(window.basename);
+        Client4.setUrl(window.basename);
     }
     RestClient.setToken(getToken());
 

--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -28,6 +28,7 @@ import {
 import {WebSocketMessage} from '@mattermost/client/websocket';
 import type {DesktopAPI} from '@mattermost/desktop-api';
 import {setServerVersion} from 'mattermost-redux/actions/general';
+import {Client4} from 'mattermost-redux/client';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme, Theme} from 'mattermost-redux/selectors/entities/preferences';
@@ -41,7 +42,6 @@ import {
 import {pluginId} from 'plugin/manifest';
 import reducer from 'plugin/reducers';
 import RestClient from 'plugin/rest_client';
-import {Client4} from 'mattermost-redux/client';
 import {callsConfig, iceServers, needsTURNCredentials} from 'plugin/selectors';
 import {DesktopNotificationArgs, Store, WebAppUtils} from 'plugin/types/mattermost-webapp';
 import {


### PR DESCRIPTION
#### Summary

The default client used by redux action wasn't accounting for the `basename` any longer so it would break any use of Calls from desktop against installations served under a subpath. Explicitly setting the url seems to fix this.

I think this may be a regression introduced in https://github.com/mattermost/mattermost-plugin-calls/pull/555/files#diff-2aac6bf65edf6e3c7580f45c0aee032bcdded5c0adb7a5ef9929ee31b74e0ad3. 

@cpoile Please let me know if you think this should be addressed differently. It doesn't look great but at the same time I didn't want to go as far as implementing our own basic actions to load MM data in Redux.

Fixes #660 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57327
