### PR TITLE
[MM-57483] Add job config validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/jmoiron/sqlx v1.3.5
-	github.com/mattermost/calls-offloader v0.6.0
+	github.com/mattermost/calls-offloader v0.7.1-0.20240327193521-2fce52099a3b
 	github.com/mattermost/calls-recorder v0.6.4
 	github.com/mattermost/calls-transcriber v0.1.8
 	github.com/mattermost/logr/v2 v2.0.21

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/jmoiron/sqlx v1.3.5
-	github.com/mattermost/calls-offloader v0.7.1-0.20240327193521-2fce52099a3b
+	github.com/mattermost/calls-offloader v0.8.0
 	github.com/mattermost/calls-recorder v0.6.4
 	github.com/mattermost/calls-transcriber v0.1.8
 	github.com/mattermost/logr/v2 v2.0.21

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mattermost/calls-offloader v0.6.0 h1:0DlkX9gR9Eiw7Dv3Z+W7DuBzOgMD9aBEnGkAVIOKS74=
-github.com/mattermost/calls-offloader v0.6.0/go.mod h1:/xyDQiBZ0XNKNC/ALGp7pkGNApfC6v94CD7tPWGcFvM=
+github.com/mattermost/calls-offloader v0.7.1-0.20240327193521-2fce52099a3b h1:QzUz+edHrrk0Vh0zp23JjHIZ4MNeIzgy5ATJs3YxhUY=
+github.com/mattermost/calls-offloader v0.7.1-0.20240327193521-2fce52099a3b/go.mod h1:xmVZZfWM9KfTcOp2Zb8XdFRin4JBNcQqg+vcwtTmdPc=
 github.com/mattermost/calls-recorder v0.6.4 h1:LCS7a8Q4eGUbZmBkgARTwNLOUyJyxkDfrIpx/Gv26Uo=
 github.com/mattermost/calls-recorder v0.6.4/go.mod h1:v/52mE+wIXGJE7ZflpAkoyGd56hbVgC9ZuEBBaRd8KU=
 github.com/mattermost/calls-transcriber v0.1.8 h1:vwmxHxRHuuuo4wyf+ZfvDj5n2TNpebQO43Qy6u+BAQY=

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,6 @@ github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mattermost/calls-offloader v0.7.1-0.20240327193521-2fce52099a3b h1:QzUz+edHrrk0Vh0zp23JjHIZ4MNeIzgy5ATJs3YxhUY=
-github.com/mattermost/calls-offloader v0.7.1-0.20240327193521-2fce52099a3b/go.mod h1:xmVZZfWM9KfTcOp2Zb8XdFRin4JBNcQqg+vcwtTmdPc=
 github.com/mattermost/calls-offloader v0.8.0 h1:XCAAMR11V/wSlLIJl1DuUQ8PGT8RRwPFbtM4YGZvfLw=
 github.com/mattermost/calls-offloader v0.8.0/go.mod h1:xmVZZfWM9KfTcOp2Zb8XdFRin4JBNcQqg+vcwtTmdPc=
 github.com/mattermost/calls-recorder v0.6.4 h1:LCS7a8Q4eGUbZmBkgARTwNLOUyJyxkDfrIpx/Gv26Uo=

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,8 @@ github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattermost/calls-offloader v0.7.1-0.20240327193521-2fce52099a3b h1:QzUz+edHrrk0Vh0zp23JjHIZ4MNeIzgy5ATJs3YxhUY=
 github.com/mattermost/calls-offloader v0.7.1-0.20240327193521-2fce52099a3b/go.mod h1:xmVZZfWM9KfTcOp2Zb8XdFRin4JBNcQqg+vcwtTmdPc=
+github.com/mattermost/calls-offloader v0.8.0 h1:XCAAMR11V/wSlLIJl1DuUQ8PGT8RRwPFbtM4YGZvfLw=
+github.com/mattermost/calls-offloader v0.8.0/go.mod h1:xmVZZfWM9KfTcOp2Zb8XdFRin4JBNcQqg+vcwtTmdPc=
 github.com/mattermost/calls-recorder v0.6.4 h1:LCS7a8Q4eGUbZmBkgARTwNLOUyJyxkDfrIpx/Gv26Uo=
 github.com/mattermost/calls-recorder v0.6.4/go.mod h1:v/52mE+wIXGJE7ZflpAkoyGd56hbVgC9ZuEBBaRd8KU=
 github.com/mattermost/calls-transcriber v0.1.8 h1:vwmxHxRHuuuo4wyf+ZfvDj5n2TNpebQO43Qy6u+BAQY=


### PR DESCRIPTION
#### Summary

Now that we decoupled `calls-offloader` from the job configs we should validate them before creating a job since they'd be simply passed through.

#### Related PR

https://github.com/mattermost/calls-offloader/pull/55

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57483


