### PR TITLE
[MM-57264] Close emoji picker and bar when a reaction is chosen

### DIFF
--- a/webapp/src/components/expanded_view/reaction_button.tsx
+++ b/webapp/src/components/expanded_view/reaction_button.tsx
@@ -8,7 +8,7 @@ import EmojiPicker, {
     SkinTonePickerLocation,
     SuggestionMode,
 } from 'emoji-picker-react';
-import React, {forwardRef, useImperativeHandle, useState} from 'react';
+import React, {forwardRef, useEffect, useImperativeHandle, useRef, useState} from 'react';
 import {OverlayTrigger} from 'react-bootstrap';
 import {useIntl} from 'react-intl';
 import {Emoji} from 'src/components/emoji/emoji';
@@ -47,20 +47,39 @@ export const ReactionButton = forwardRef(({trackEvent, isHandRaised}: Props, ref
         },
     }));
 
+    const innerRef = useRef<HTMLDivElement>(null);
+
+    const closeOnBlur = (e: Event) => {
+        if (innerRef && innerRef.current && e.target && innerRef.current.contains(e.target as Node)) {
+            return;
+        }
+
+        // hide everything
+        setShowPicker(false);
+        setShowBar(false);
+    };
+
+    const closeOnEscape = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+            // hide everything
+            setShowPicker(false);
+            setShowBar(false);
+        }
+    };
+
+    useEffect(() => {
+        document.addEventListener('click', closeOnBlur, true);
+        document.addEventListener('keyup', closeOnEscape, true);
+        return () => {
+            document.removeEventListener('click', closeOnBlur, true);
+            document.removeEventListener('keyup', closeOnEscape, true);
+        };
+    }, []);
+
     const callsClient = getCallsClient();
     const addReactionText = showBar ?
         formatMessage({defaultMessage: 'Close reactions'}) :
         formatMessage({defaultMessage: 'Add reaction'});
-
-    const handleUserPicksEmoji = (ecd: EmojiClickData) => {
-        const emojiData: EmojiData = {
-            name: findEmojiName(ecd.names),
-            skin: ecd.activeSkinTone,
-            unified: ecd.unified.toLowerCase(),
-            literal: ecd.emoji || '',
-        };
-        callsClient?.sendUserReaction(emojiData);
-    };
 
     const onRaiseHandToggle = () => {
         if (isHandRaised) {
@@ -91,10 +110,27 @@ export const ReactionButton = forwardRef(({trackEvent, isHandRaised}: Props, ref
         return !prev;
     });
 
+    const handleUserPicksEmoji = (ecd: EmojiClickData) => {
+        const emojiData: EmojiData = {
+            name: findEmojiName(ecd.names),
+            skin: ecd.activeSkinTone,
+            unified: ecd.unified.toLowerCase(),
+            literal: ecd.emoji || '',
+        };
+        callsClient?.sendUserReaction(emojiData);
+
+        // hide everything
+        setShowPicker(false);
+        setShowBar(false);
+    };
+
     return (
-        <div style={{position: 'relative'}}>
+        <div
+            style={{position: 'relative'}}
+            ref={innerRef}
+        >
             {showPicker &&
-                <PickerContainer>
+                <PickerContainer id={'calls-popout-emoji-picker'}>
                     <EmojiPicker
                         emojiVersion={EMOJI_VERSION}
                         emojiStyle={EmojiStyle.APPLE}
@@ -109,7 +145,7 @@ export const ReactionButton = forwardRef(({trackEvent, isHandRaised}: Props, ref
                 </PickerContainer>
             }
             {showBar &&
-                <Bar>
+                <Bar id={'calls-popout-emoji-bar'}>
                     <OverlayTrigger
                         key={'calls-popout-raisehand-button'}
                         placement='top'


### PR DESCRIPTION
#### Summary

PR implements some UX improvements to how the reaction bar and picker behave. We now close them automatically in all of the following cases:

- User reacts
- User presses ESC key
- User clicks outside the element

@matthewbirtch I left raising hand out of this logic since it wasn't specified but let me know.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57264