### PR TITLE
[MM-57290] Calls widget: improve screen sharing preview UX

### DIFF
--- a/webapp/src/components/call_widget/component.scss
+++ b/webapp/src/components/call_widget/component.scss
@@ -119,3 +119,26 @@ a.calls-channel-link {
 #calls-widget-menu-screenshare.unavailable {
   background: none;
 }
+
+#calls-widget #calls-widget-stop-screenshare {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 8px 16px;
+    background: var(--error-text);
+    color: white;
+    border-radius: 4px;
+    font-weight: 600;
+
+    &:hover {
+        background: linear-gradient(0deg, var(--error-text), var(--error-text)),
+            linear-gradient(0deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.08));
+        background-blend-mode: multiply;
+    }
+
+    &:active {
+        background: linear-gradient(0deg, var(--error-text), var(--error-text)),
+            linear-gradient(0deg, rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.16));
+        background-blend-mode: multiply;
+    }
+}

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -838,9 +838,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                             display: 'flex',
                             width: '100%',
                             height: '100%',
-                            background: 'rgba(var(--dnd-indicator-rgb), 0.4)',
+                            top: '1px',
+                            background: 'rgba(63, 67, 80, 0.4)',
                             justifyContent: 'center',
                             alignItems: 'center',
+                            borderRadius: '8px',
                             zIndex: 1001,
                         }}
                     >
@@ -910,7 +912,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     <span
                         style={{
                             marginTop: '8px',
-                            color: 'rgba(var(--center-channel-color-rgb), 0.56)',
+                            color: 'rgba(var(--center-channel-color-rgb), 0.72)',
                             fontSize: '12px',
                             padding: '0 8px',
                             textAlign: 'center',

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -847,18 +847,9 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                         }}
                     >
                         <button
+                            id='calls-widget-stop-screenshare'
                             data-testid='calls-widget-stop-screenshare'
                             className='cursor--pointer style--none'
-                            style={{
-                                display: 'flex',
-                                justifyContent: 'center',
-                                alignItems: 'center',
-                                padding: '8px 16px',
-                                background: 'var(--dnd-indicator)',
-                                color: 'white',
-                                borderRadius: '4px',
-                                fontWeight: 600,
-                            }}
                             onClick={() => this.onShareScreenToggle()}
                         >
                             {formatMessage({defaultMessage: 'Stop sharing'})}


### PR DESCRIPTION
#### Summary

PR improves the calls widget screen sharing preview.

@matthewbirtch I took a chance to also update the button to follow the color and hover/active states. Let me know if that wasn't expected.

#### Screenshots

*Before*

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/dc6779e2-e27c-45c9-a43e-884a85ec0968)

*After*

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/7f955c86-7d9f-4930-88e2-8c0901fff506)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57290
