### PR TITLE
[MM-57737] Improve client side call state consistency

### DIFF
--- a/server/client_message.go
+++ b/server/client_message.go
@@ -29,6 +29,7 @@ const (
 	clientMessageTypeReact       = "react"
 	clientMessageTypeCaption     = "caption"
 	clientMessageTypeMetric      = "metric"
+	clientMessageTypeCallState   = "call_state"
 )
 
 func (m *clientMessage) ToJSON() ([]byte, error) {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -888,6 +888,40 @@ func (p *Plugin) handleReconnect(userID, connID, channelID, originalConnID, prev
 	return nil
 }
 
+func (p *Plugin) handleCallStateRequest(channelID, userID, connID string) error {
+	// We should go through only if the user has permissions to the requested channel
+	// or if the user is the Calls bot.
+	if !(p.isBot(userID) || p.API.HasPermissionToChannel(userID, channelID, model.PermissionReadChannel)) {
+		return fmt.Errorf("forbidden")
+	}
+
+	// Locking is not ideal but it's the only way to guarantee a race free
+	// sequence and a consistent state.
+	// On the client we should make sure to make this request only when strictly
+	// necessary (i.e first load, joining call, reconnecting).
+	state, err := p.lockCallReturnState(channelID)
+	if err != nil {
+		return fmt.Errorf("failed to lock call: %w", err)
+	}
+	defer p.unlockCall(channelID)
+
+	if state == nil {
+		return fmt.Errorf("no call ongoing")
+	}
+
+	clientStateData, err := json.Marshal(state.getClientState(p.getBotID(), userID))
+	if err != nil {
+		return fmt.Errorf("failed to marshal client state: %w", err)
+	}
+
+	p.publishWebSocketEvent(wsEventCallState, map[string]interface{}{
+		"channel_id": channelID,
+		"call":       string(clientStateData),
+	}, &model.WebsocketBroadcast{ConnectionId: connID, ReliableClusterSend: true})
+
+	return nil
+}
+
 func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model.WebSocketRequest) {
 	var msg clientMessage
 	msg.Type = strings.TrimPrefix(req.Action, wsActionPrefix)
@@ -896,10 +930,14 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 	us := p.sessions[connID]
 	p.mut.RUnlock()
 
-	if msg.Type != clientMessageTypeJoin &&
-		msg.Type != clientMessageTypeLeave &&
-		msg.Type != clientMessageTypeReconnect && us == nil {
-		return
+	if us == nil {
+		// Only a few events don't require a user session to exist. For anything else
+		// we should return.
+		switch msg.Type {
+		case clientMessageTypeJoin, clientMessageTypeLeave, clientMessageTypeReconnect, clientMessageTypeCallState:
+		default:
+			return
+		}
 	}
 
 	if us != nil && !us.wsMsgLimiter.Allow() {
@@ -985,6 +1023,19 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 			p.LogError(err.Error())
 		}
 
+		return
+	case clientMessageTypeCallState:
+		p.metrics.IncWebSocketEvent("in", "call_state")
+
+		channelID, _ := req.Data["channelID"].(string)
+		if channelID == "" {
+			p.LogError("missing channelID")
+			return
+		}
+
+		if err := p.handleCallStateRequest(channelID, userID, connID); err != nil {
+			p.LogError("handleCallStateRequest failed", "err", err.Error(), "userID", userID, "connID", connID)
+		}
 		return
 	case clientMessageTypeSDP:
 		msgData, ok := req.Data["data"].([]byte)

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -359,3 +359,68 @@ func TestWSReader(t *testing.T) {
 		})
 	})
 }
+
+func TestHandleCallStateRequest(t *testing.T) {
+	mockAPI := &pluginMocks.MockAPI{}
+	mockMetrics := &serverMocks.MockMetrics{}
+
+	p := Plugin{
+		MattermostPlugin: plugin.MattermostPlugin{
+			API: mockAPI,
+		},
+		callsClusterLocks: map[string]*cluster.Mutex{},
+		metrics:           mockMetrics,
+	}
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+	p.store = store
+
+	mockAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+	mockMetrics.On("ObserveClusterMutexGrabTime", "mutex_call", mock.AnythingOfType("float64"))
+	mockMetrics.On("ObserveClusterMutexLockedTime", "mutex_call", mock.AnythingOfType("float64"))
+	mockMetrics.On("IncStoreOp", "KVGet")
+	mockMetrics.On("IncStoreOp", "KVSet")
+
+	channelID := model.NewId()
+	userID := model.NewId()
+	connID := model.NewId()
+
+	t.Run("no permissions", func(t *testing.T) {
+		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil).Once()
+		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(false).Once()
+		err := p.handleCallStateRequest(channelID, userID, connID)
+		require.EqualError(t, err, "forbidden")
+	})
+
+	t.Run("no call ongoing", func(t *testing.T) {
+		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil).Once()
+		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(true).Once()
+		err := p.handleCallStateRequest(channelID, userID, connID)
+		require.EqualError(t, err, "no call ongoing")
+	})
+
+	t.Run("active call", func(t *testing.T) {
+		err := p.store.CreateCall(&public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			ChannelID: channelID,
+			StartAt:   time.Now().UnixMilli(),
+			PostID:    model.NewId(),
+			ThreadID:  model.NewId(),
+			OwnerID:   model.NewId(),
+		})
+		require.NoError(t, err)
+
+		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil).Once()
+		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(true).Once()
+		mockMetrics.On("IncWebSocketEvent", "out", "call_state").Once()
+		mockAPI.On("PublishWebSocketEvent", "call_state", mock.Anything, mock.Anything).Once()
+
+		err = p.handleCallStateRequest(channelID, userID, connID)
+		require.NoError(t, err)
+	})
+}

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -163,6 +163,8 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
     private pushToTalk = false;
     private screenPlayer: HTMLVideoElement | null = null;
 
+    static contextType = window.ProductApi.WebSocketProvider;
+
     #unlockNavigation?: () => void;
 
     private genStyle: () => Record<string, React.CSSProperties> = () => {
@@ -592,8 +594,15 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
     public componentDidMount() {
         const callsClient = getCallsClient();
         if (!callsClient) {
+            logErr('callsClient should be defined');
             return;
         }
+
+        // On mount we request the call state through websocket. This avoids
+        // making a potentially racy HTTP call and should guarantee
+        // a consistent state.
+        logDebug('requesting call state through ws');
+        this.context.sendMessage('custom_com.mattermost.calls_call_state', {channelID: callsClient.channelID});
 
         // keyboard shortcuts
         window.addEventListener('keydown', this.handleKBShortcuts, true);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1,15 +1,14 @@
 /* eslint-disable max-lines */
 
 import {CallChannelState} from '@calls/common/lib/types';
+import WebSocketClient from '@mattermost/client/websocket';
 import type {DesktopAPI} from '@mattermost/desktop-api';
-import {getChannel as getChannelAction} from 'mattermost-redux/actions/channels';
-import {getProfilesByIds as getProfilesByIdsAction} from 'mattermost-redux/actions/users';
 import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import {getCurrentUserId, getUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
-import React from 'react';
+import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
+import React, {useEffect} from 'react';
 import ReactDOM from 'react-dom';
 import {injectIntl, IntlProvider} from 'react-intl';
 import {Provider} from 'react-redux';
@@ -21,7 +20,6 @@ import {
     displayFreeTrial,
     getCallsConfig,
     incomingCallOnChannel,
-    loadCallState,
     showScreenSourceModal,
     showSwitchCallModal,
 } from 'src/actions';
@@ -111,13 +109,11 @@ import {DesktopNotificationArgs, PluginRegistry, Store, WebAppUtils} from './typ
 import {
     followThread,
     getChannelURL,
-    getExpandedChannelID,
     getPluginPath,
     getProfilesForSessions,
     getTranslations,
-    getUserIdFromDM,
     getWSConnectionURL,
-    isDMChannel,
+    isCallsPopOut,
     playSound,
     sendDesktopEvent,
     shouldRenderDesktopWidget,
@@ -635,12 +631,17 @@ export default class Plugin {
             );
         };
 
-        const fetchChannels = async (): Promise<AnyAction[]> => {
+        const fetchChannels = async (skipChannelID?: string): Promise<AnyAction[]> => {
             const actions = [];
             try {
                 const data = await RestClient.fetch<CallChannelState[]>(`${getPluginPath()}/channels`, {method: 'get'});
 
                 for (let i = 0; i < data.length; i++) {
+                    if (skipChannelID === data[i].channel_id) {
+                        logDebug('skipping channel from state loading', skipChannelID);
+                        continue;
+                    }
+
                     actions.push({
                         type: RECEIVED_CHANNEL_STATE,
                         data: {
@@ -714,59 +715,14 @@ export default class Plugin {
             }
         };
 
-        const fetchChannelData = async (channelID: string) => {
-            if (!channelID) {
-                // Must be Global threads view, or another view that isn't a channel.
-                logDebug('fetchChannelData: missing channelID');
-                return;
-            }
-
-            let channel = getChannel(store.getState(), channelID);
-            if (!channel) {
-                await store.dispatch(getChannelAction(channelID));
-                channel = getChannel(store.getState(), channelID);
-            }
-
-            if (isDMChannel(channel)) {
-                const otherID = getUserIdFromDM(channel.name, getCurrentUserId(store.getState()));
-                const dmUser = getUser(store.getState(), otherID);
-                if (!dmUser) {
-                    store.dispatch(getProfilesByIdsAction([otherID]));
-                }
-            }
-
-            await registerHeaderMenuComponentIfNeeded(channelID);
-
-            try {
-                const data = await RestClient.fetch<CallChannelState>(`${getPluginPath()}/${channelID}`, {method: 'get'});
-                store.dispatch({
-                    type: RECEIVED_CHANNEL_STATE,
-                    data: {id: channelID, enabled: data.enabled},
-                });
-
-                const call = data.call;
-                if (!call) {
-                    return;
-                }
-
-                await store.dispatch(loadCallState(channelID, call));
-            } catch (err) {
-                logErr(err);
-                store.dispatch({
-                    type: RECEIVED_CHANNEL_STATE,
-                    data: {id: channelID, enabled: false},
-                });
-            }
-        };
-
         // Run onActivate once we're logged in.
         const unsubscribeActivateListener = store.subscribe(() => {
-            if (getCurrentUserId(store.getState())) {
+            if (getCurrentUserId(store.getState()) && !isCallsPopOut()) {
                 onActivate();
             }
         });
 
-        const onActivate = async () => {
+        const onActivate = async (wsClient?: WebSocketClient) => {
             if (!getCurrentUserId(store.getState())) {
                 // not logged in, returning. Shouldn't happen, but being defensive.
                 return;
@@ -776,18 +732,29 @@ export default class Plugin {
 
             await store.dispatch(getCallsConfig());
 
-            const actions = await fetchChannels();
-            const currChannelId = getCurrentChannelId(store.getState());
-            if (currChannelId) {
-                await fetchChannelData(currChannelId);
-            } else {
-                const expandedID = getExpandedChannelID();
-                if (expandedID.length > 0) {
-                    await fetchChannelData(expandedID);
+            const currentCallChannelID = channelIDForCurrentCall(store.getState());
+
+            // We pass currentCallChannelID so that we
+            // can skip loading its state as a result of the HTTP calls in
+            // fetchChannels since it would be racy.
+            const actions = await fetchChannels(currentCallChannelID);
+            store.dispatch(batchActions(actions));
+
+            // If indeed we are in a call we should request the up-to-date
+            // state from websocket.
+            if (currentCallChannelID) {
+                if (wsClient) {
+                    logDebug('requesting call state through ws');
+                    wsClient.sendMessage('custom_com.mattermost.calls_call_state', {channelID: currentCallChannelID});
+                } else {
+                    logErr('unexpected missing wsClient');
                 }
             }
 
-            store.dispatch(batchActions(actions));
+            const currChannelId = getCurrentChannelId(store.getState());
+            if (currChannelId) {
+                await registerHeaderMenuComponentIfNeeded(currChannelId);
+            }
         };
 
         this.unsubscribers.push(() => {
@@ -800,17 +767,29 @@ export default class Plugin {
             });
         });
 
-        this.registerWebSocketEvents(registry, store);
-        this.registerReconnectHandler(registry, store, () => {
-            logDebug('websocket reconnect handler');
-            if (!window.callsClient) {
-                logDebug('resetting state');
-                store.dispatch({
-                    type: UNINIT,
+        // A dummy React component so we can access webapp's
+        // WebSocket client through the provided hook. Just lovely.
+        registry.registerGlobalComponent(() => {
+            const client = window.ProductApi.useWebSocketClient();
+
+            useEffect(() => {
+                logDebug('registering ws reconnect handler');
+                // eslint-disable-next-line max-nested-callbacks
+                this.registerReconnectHandler(registry, store, () => {
+                    logDebug('websocket reconnect handler');
+                    if (!window.callsClient) {
+                        logDebug('resetting state');
+                        store.dispatch({
+                            type: UNINIT,
+                        });
+                    }
+                    onActivate(client);
                 });
-            }
-            onActivate();
+            }, []);
+
+            return null;
         });
+        this.registerWebSocketEvents(registry, store);
 
         let currChannelId = getCurrentChannelId(store.getState());
         let joinCallParam = new URLSearchParams(window.location.search).get('join_call');
@@ -878,6 +857,11 @@ declare global {
         e2eNotificationsSoundStoppedAt?: number[],
         e2eRingLength?: number,
         WebappUtils: WebAppUtils,
+
+        ProductApi: {
+            useWebSocketClient: () => WebSocketClient,
+            WebSocketProvider: React.Context<WebSocketClient>,
+        };
     }
 
     interface HTMLVideoElement {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -637,6 +637,9 @@ export default class Plugin {
                 const data = await RestClient.fetch<CallChannelState[]>(`${getPluginPath()}/channels`, {method: 'get'});
 
                 for (let i = 0; i < data.length; i++) {
+                    // Skipping the channel for the current call here is important
+                    // as it can avoid an inconsistent state for the current call due to a race.
+                    // State for the current call should ONLY be mutated as a result of websocket events, not HTTP calls.
                     if (skipChannelID === data[i].channel_id) {
                         logDebug('skipping channel from state loading', skipChannelID);
                         continue;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -717,7 +717,7 @@ export default class Plugin {
 
         // Run onActivate once we're logged in.
         const unsubscribeActivateListener = store.subscribe(() => {
-            if (getCurrentUserId(store.getState()) && !isCallsPopOut()) {
+            if (getCurrentUserId(store.getState())) {
                 onActivate();
             }
         });
@@ -731,6 +731,13 @@ export default class Plugin {
             unsubscribeActivateListener();
 
             await store.dispatch(getCallsConfig());
+
+            // We don't care about fetching other calls states in pop out.
+            // Current call state will be requested over websocket
+            // from the ExpandedView component itself.
+            if (isCallsPopOut()) {
+                return;
+            }
 
             const currentCallChannelID = channelIDForCurrentCall(store.getState());
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -99,6 +99,16 @@ export function getCallsClientInitTime(): number {
     return getCallsClient()?.initTime || 0;
 }
 
+export function isCallsPopOut(): boolean {
+    try {
+        return window.opener && window.opener.callsClient;
+    } catch (err) {
+        logErr(err);
+        return false;
+    }
+    return false;
+}
+
 export function shouldRenderCallsIncoming() {
     try {
         const win = window.opener ? window.opener : window;


### PR DESCRIPTION
#### Summary

PR should fix most of the remaining call state data races originally mentioned in https://github.com/mattermost/mattermost-plugin-calls/pull/512, specifically when loading the pop out window and in case of a websocket reconnect.

This is done by implementing a websocket request handler that returns the calls state under lock. Using the websocket channel as opposed to making HTTP request should guarantee a valid sequencing of potentially concurrent events (e.g. users joining, leaving, etc).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57737

