### PR TITLE
Make update and delete store operations idempotent

### DIFF
--- a/server/db/calls_channels_store.go
+++ b/server/db/calls_channels_store.go
@@ -95,18 +95,9 @@ func (s *Store) UpdateCallsChannel(channel *public.CallsChannel) error {
 		return fmt.Errorf("failed to prepare query: %w", err)
 	}
 
-	res, err := s.wDB.Exec(q, args...)
+	_, err = s.wDB.Exec(q, args...)
 	if err != nil {
 		return fmt.Errorf("failed to run query: %w", err)
-	}
-
-	count, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-
-	if count != 1 {
-		return fmt.Errorf("failed to update calls channel")
 	}
 
 	return nil

--- a/server/db/calls_channels_store_test.go
+++ b/server/db/calls_channels_store_test.go
@@ -64,13 +64,6 @@ func testUpdateCallsChannel(t *testing.T, store *Store) {
 		require.EqualError(t, err, "invalid channel: should not be nil")
 	})
 
-	t.Run("missing", func(t *testing.T) {
-		err := store.UpdateCallsChannel(&public.CallsChannel{
-			ChannelID: "channelID",
-		})
-		require.EqualError(t, err, "failed to update calls channel")
-	})
-
 	t.Run("existing", func(t *testing.T) {
 		channel := &public.CallsChannel{
 			ChannelID: model.NewId(),
@@ -99,28 +92,20 @@ func testUpdateCallsChannel(t *testing.T, store *Store) {
 }
 
 func testGetCallsChannel(t *testing.T, store *Store) {
-	t.Run("missing", func(t *testing.T) {
-		channel, err := store.GetCallsChannel("channelID", GetCallsChannelOpts{})
-		require.EqualError(t, err, "calls channel not found")
-		require.Nil(t, channel)
-	})
+	channel := &public.CallsChannel{
+		ChannelID: model.NewId(),
+		Props: map[string]any{
+			"test_prop": "test",
+		},
+	}
 
-	t.Run("existing", func(t *testing.T) {
-		channel := &public.CallsChannel{
-			ChannelID: model.NewId(),
-			Props: map[string]any{
-				"test_prop": "test",
-			},
-		}
+	err := store.CreateCallsChannel(channel)
+	require.NoError(t, err)
 
-		err := store.CreateCallsChannel(channel)
-		require.NoError(t, err)
-
-		gotChannel, err := store.GetCallsChannel(channel.ChannelID, GetCallsChannelOpts{FromWriter: true})
-		require.NoError(t, err)
-		require.NotNil(t, gotChannel)
-		require.Equal(t, channel, gotChannel)
-	})
+	gotChannel, err := store.GetCallsChannel(channel.ChannelID, GetCallsChannelOpts{FromWriter: true})
+	require.NoError(t, err)
+	require.NotNil(t, gotChannel)
+	require.Equal(t, channel, gotChannel)
 }
 
 func testGetAllCallsChannels(t *testing.T, store *Store) {

--- a/server/db/calls_jobs_store.go
+++ b/server/db/calls_jobs_store.go
@@ -56,18 +56,9 @@ func (s *Store) UpdateCallJob(job *public.CallJob) error {
 		return fmt.Errorf("failed to prepare query: %w", err)
 	}
 
-	res, err := s.wDB.Exec(q, args...)
+	_, err = s.wDB.Exec(q, args...)
 	if err != nil {
 		return fmt.Errorf("failed to run query: %w", err)
-	}
-
-	count, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-
-	if count != 1 {
-		return fmt.Errorf("failed to update call job")
 	}
 
 	return nil

--- a/server/db/calls_jobs_store_test.go
+++ b/server/db/calls_jobs_store_test.go
@@ -90,18 +90,6 @@ func testUpdateCallJob(t *testing.T, store *Store) {
 		require.EqualError(t, err, "invalid call job: should not be nil")
 	})
 
-	t.Run("missing", func(t *testing.T) {
-		job := &public.CallJob{
-			ID:        model.NewId(),
-			CallID:    model.NewId(),
-			Type:      public.JobTypeRecording,
-			CreatorID: model.NewId(),
-			InitAt:    time.Now().UnixMilli(),
-		}
-		err := store.UpdateCallJob(job)
-		require.EqualError(t, err, "failed to update call job")
-	})
-
 	t.Run("existing", func(t *testing.T) {
 		job := &public.CallJob{
 			ID:        model.NewId(),

--- a/server/db/calls_sessions_store.go
+++ b/server/db/calls_sessions_store.go
@@ -55,18 +55,9 @@ func (s *Store) UpdateCallSession(session *public.CallSession) error {
 		return fmt.Errorf("failed to prepare query: %w", err)
 	}
 
-	res, err := s.wDB.Exec(q, args...)
+	_, err = s.wDB.Exec(q, args...)
 	if err != nil {
 		return fmt.Errorf("failed to run query: %w", err)
-	}
-
-	count, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-
-	if count != 1 {
-		return fmt.Errorf("failed to update call session")
 	}
 
 	return nil

--- a/server/db/calls_store.go
+++ b/server/db/calls_store.go
@@ -78,18 +78,9 @@ func (s *Store) UpdateCall(call *public.Call) error {
 		return fmt.Errorf("failed to prepare query: %w", err)
 	}
 
-	res, err := s.wDB.Exec(q, args...)
+	_, err = s.wDB.Exec(q, args...)
 	if err != nil {
 		return fmt.Errorf("failed to run query: %w", err)
-	}
-
-	count, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-
-	if count != 1 {
-		return fmt.Errorf("failed to update call: unexpected updated rows count %d", count)
 	}
 
 	return nil
@@ -108,18 +99,9 @@ func (s *Store) DeleteCall(callID string) error {
 		return fmt.Errorf("failed to prepare query: %w", err)
 	}
 
-	res, err := s.wDB.Exec(q, args...)
+	_, err = s.wDB.Exec(q, args...)
 	if err != nil {
 		return fmt.Errorf("failed to run query: %w", err)
-	}
-
-	count, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-
-	if count != 1 {
-		return fmt.Errorf("failed to delete call")
 	}
 
 	return nil

--- a/server/db/calls_store_test.go
+++ b/server/db/calls_store_test.go
@@ -107,79 +107,65 @@ func testCreateCall(t *testing.T, store *Store) {
 }
 
 func testDeleteCall(t *testing.T, store *Store) {
-	t.Run("missing", func(t *testing.T) {
-		err := store.DeleteCall("callID")
-		require.EqualError(t, err, "failed to delete call")
-	})
+	call := &public.Call{
+		ID:           model.NewId(),
+		CreateAt:     time.Now().UnixMilli(),
+		ChannelID:    model.NewId(),
+		StartAt:      time.Now().UnixMilli(),
+		PostID:       model.NewId(),
+		ThreadID:     model.NewId(),
+		OwnerID:      model.NewId(),
+		Participants: []string{model.NewId(), model.NewId()},
+		Stats: public.CallStats{
+			ScreenDuration: 45,
+		},
+		Props: public.CallProps{
+			Hosts: []string{"userA", "userB"},
+		},
+	}
 
-	t.Run("existing", func(t *testing.T) {
-		call := &public.Call{
-			ID:           model.NewId(),
-			CreateAt:     time.Now().UnixMilli(),
-			ChannelID:    model.NewId(),
-			StartAt:      time.Now().UnixMilli(),
-			PostID:       model.NewId(),
-			ThreadID:     model.NewId(),
-			OwnerID:      model.NewId(),
-			Participants: []string{model.NewId(), model.NewId()},
-			Stats: public.CallStats{
-				ScreenDuration: 45,
-			},
-			Props: public.CallProps{
-				Hosts: []string{"userA", "userB"},
-			},
-		}
+	err := store.CreateCall(call)
+	require.NoError(t, err)
 
-		err := store.CreateCall(call)
-		require.NoError(t, err)
+	now := time.Now().UnixMilli()
 
-		now := time.Now().UnixMilli()
+	err = store.DeleteCall(call.ID)
+	require.NoError(t, err)
 
-		err = store.DeleteCall(call.ID)
-		require.NoError(t, err)
-
-		call, err = store.GetCall(call.ID, GetCallOpts{FromWriter: true})
-		require.NoError(t, err)
-		require.GreaterOrEqual(t, call.DeleteAt, now)
-	})
+	call, err = store.GetCall(call.ID, GetCallOpts{FromWriter: true})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, call.DeleteAt, now)
 }
 
 func testDeleteCallByChannelID(t *testing.T, store *Store) {
-	t.Run("missing", func(t *testing.T) {
-		err := store.DeleteCall("channelID")
-		require.EqualError(t, err, "failed to delete call")
-	})
+	call := &public.Call{
+		ID:           model.NewId(),
+		CreateAt:     time.Now().UnixMilli(),
+		ChannelID:    model.NewId(),
+		StartAt:      time.Now().UnixMilli(),
+		PostID:       model.NewId(),
+		ThreadID:     model.NewId(),
+		OwnerID:      model.NewId(),
+		Participants: []string{model.NewId(), model.NewId()},
+		Stats: public.CallStats{
+			ScreenDuration: 45,
+		},
+		Props: public.CallProps{
+			Hosts: []string{"userA", "userB"},
+		},
+	}
 
-	t.Run("existing", func(t *testing.T) {
-		call := &public.Call{
-			ID:           model.NewId(),
-			CreateAt:     time.Now().UnixMilli(),
-			ChannelID:    model.NewId(),
-			StartAt:      time.Now().UnixMilli(),
-			PostID:       model.NewId(),
-			ThreadID:     model.NewId(),
-			OwnerID:      model.NewId(),
-			Participants: []string{model.NewId(), model.NewId()},
-			Stats: public.CallStats{
-				ScreenDuration: 45,
-			},
-			Props: public.CallProps{
-				Hosts: []string{"userA", "userB"},
-			},
-		}
+	err := store.CreateCall(call)
+	require.NoError(t, err)
 
-		err := store.CreateCall(call)
-		require.NoError(t, err)
+	now := time.Now().UnixMilli()
 
-		now := time.Now().UnixMilli()
+	err = store.DeleteCallByChannelID(call.ChannelID)
+	require.NoError(t, err)
 
-		err = store.DeleteCallByChannelID(call.ChannelID)
-		require.NoError(t, err)
-
-		call, err = store.GetCall(call.ID, GetCallOpts{FromWriter: true})
-		require.NoError(t, err)
-		require.GreaterOrEqual(t, call.DeleteAt, now)
-	})
+	call, err = store.GetCall(call.ID, GetCallOpts{FromWriter: true})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, call.DeleteAt, now)
 }
 
 func testUpdateCall(t *testing.T, store *Store) {
@@ -187,19 +173,6 @@ func testUpdateCall(t *testing.T, store *Store) {
 		var call *public.Call
 		err := store.UpdateCall(call)
 		require.EqualError(t, err, "invalid call: should not be nil")
-	})
-
-	t.Run("missing", func(t *testing.T) {
-		err := store.UpdateCall(&public.Call{
-			ID:        model.NewId(),
-			CreateAt:  time.Now().UnixMilli(),
-			ChannelID: model.NewId(),
-			StartAt:   time.Now().UnixMilli(),
-			PostID:    model.NewId(),
-			ThreadID:  model.NewId(),
-			OwnerID:   model.NewId(),
-		})
-		require.EqualError(t, err, "failed to update call: unexpected updated rows count 0")
 	})
 
 	t.Run("existing", func(t *testing.T) {


### PR DESCRIPTION
#### Summary

Relying on [`RowsAffected()`](https://pkg.go.dev/database/sql#Result) is just not going to work. Making the operations idempotent so that it doesn't matter if the state is the same. We can look into some optimizations later on.

