### PR TITLE
Fix fetching call state in popout

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -591,6 +591,20 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         }
     }
 
+    requestCallState = () => {
+        const callsClient = getCallsClient();
+        if (!callsClient) {
+            logErr('callsClient should be defined');
+            return;
+        }
+
+        // On WebSocket connect we request the call state. This avoids
+        // making a potentially racy HTTP call and should guarantee
+        // a consistent state.
+        logDebug('requesting call state through ws');
+        this.context.sendMessage('custom_com.mattermost.calls_call_state', {channelID: callsClient.channelID});
+    };
+
     public componentDidMount() {
         const callsClient = getCallsClient();
         if (!callsClient) {
@@ -598,11 +612,17 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             return;
         }
 
-        // On mount we request the call state through websocket. This avoids
-        // making a potentially racy HTTP call and should guarantee
-        // a consistent state.
-        logDebug('requesting call state through ws');
-        this.context.sendMessage('custom_com.mattermost.calls_call_state', {channelID: callsClient.channelID});
+        if (!this.context) {
+            logErr('context should be defined');
+            return;
+        }
+
+        if (this.context?.conn?.readyState === WebSocket.OPEN) {
+            this.requestCallState();
+        } else {
+            logDebug('ws not connected still, adding listener');
+            this.context.addFirstConnectListener(this.requestCallState);
+        }
 
         // keyboard shortcuts
         window.addEventListener('keydown', this.handleKBShortcuts, true);
@@ -707,6 +727,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         window.removeEventListener('keyup', this.handleKeyUp, true);
         window.removeEventListener('blur', this.handleBlur, true);
         this.#unlockNavigation?.();
+        this.context?.removeFirstConnectListener(this.requestCallState);
     }
 
     dismissRecordingPrompt = () => {


### PR DESCRIPTION
#### Summary

Unfortunately in https://github.com/mattermost/mattermost-plugin-calls/pull/681 we traded a race for another one. The ws client may still be initializing when the popout opens which would make our request a no-op and the state would be permanently missing as a consequence. We add a check for that.

