### PR TITLE
[MM-57965] fix Websocket reconnect handler

### DIFF
--- a/e2e/types.ts
+++ b/e2e/types.ts
@@ -7,6 +7,7 @@ declare global {
         e2eNotificationsSoundedAt?: number[],
         e2eNotificationsSoundStoppedAt?: number[],
         e2eRingLength?: number,
+        plugins: any,
 
         // Desktop Mocking
         desktop: any,

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -146,9 +146,11 @@ import {
 
 export default class Plugin {
     private unsubscribers: (() => void)[];
+    private wsClient: WebSocketClient | null;
 
     constructor() {
         this.unsubscribers = [];
+        this.wsClient = null;
     }
 
     private registerReconnectHandler(registry: PluginRegistry, _store: Store, handler: () => void) {
@@ -807,6 +809,7 @@ export default class Plugin {
         // WebSocket client through the provided hook. Just lovely.
         registry.registerGlobalComponent(() => {
             const client = window.ProductApi.useWebSocketClient();
+            this.wsClient = client;
 
             useEffect(() => {
                 logDebug('registering ws reconnect handler');

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -109,6 +109,7 @@ import {JOIN_CALL, keyToAction} from './shortcuts';
 import {DesktopNotificationArgs, PluginRegistry, Store, WebAppUtils} from './types/mattermost-webapp';
 import {
     followThread,
+    getCallsClient,
     getChannelURL,
     getPluginPath,
     getProfilesForSessions,
@@ -812,7 +813,7 @@ export default class Plugin {
                 // eslint-disable-next-line max-nested-callbacks
                 this.registerReconnectHandler(registry, store, () => {
                     logDebug('websocket reconnect handler');
-                    if (!window.callsClient) {
+                    if (!getCallsClient()) {
                         logDebug('resetting state');
                         store.dispatch({
                             type: UNINIT,


### PR DESCRIPTION
#### Summary
- The `websocket reconnect handler` was causing the state to be reset every minute or so when the window is in the background. So if you're on a call and you put the expanded view in the background, it would be blank when you come back after a reset.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-57965