### PR TITLE
Run e2e tests on tags and main branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,11 @@
 name: E2E Testing
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
 
 concurrency:


### PR DESCRIPTION
#### Summary

Just noticed we were not running these on merging to `main`. I think we should, and on tags (releases) as well.
 
