### PR TITLE
[MM-58125] Fix Client4 initiated requests when running under subpath

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -3,6 +3,7 @@
 import {CallChannelState} from '@mattermost/calls-common/lib/types';
 import WebSocketClient from '@mattermost/client/websocket';
 import type {DesktopAPI} from '@mattermost/desktop-api';
+import {Client4} from 'mattermost-redux/client';
 import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
@@ -266,7 +267,11 @@ export default class Plugin {
     private initialize(registry: PluginRegistry, store: Store) {
         // Setting the base URL if present, in case MM is running under a subpath.
         if (window.basename) {
+            // If present, we need to set the basename on both the client we use (RestClient)
+            // and the default one (Client4) used by internal Redux actions. Not doing so
+            // would break Calls widget on installations served under a subpath.
             RestClient.setUrl(window.basename);
+            Client4.setUrl(window.basename);
         }
 
         // Register root DOM element for Calls. This is where the widget will render.


### PR DESCRIPTION
#### Summary

PR fixes some other issues with fetching assets when MM is running under a subpath. It's the same fix as https://github.com/mattermost/mattermost-plugin-calls/pull/663 but ported to the webapp side.

I am not sure what happened here since you raised this exact point in https://github.com/mattermost/mattermost-plugin-calls/pull/663#pullrequestreview-1946394499 which I thought I addressed as there was no harm in doing it on both sides but in the end I obviously didn't :man_facepalming: 

Fixes https://github.com/mattermost/mattermost-plugin-calls/issues/722

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-58125
