### PR TITLE
Fix pop out height

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -823,7 +823,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                     ...this.style.screenContainer,
 
                     // Account for when we display an alert banner.
-                    maxHeight: `calc(100vh - ${this.shouldRenderAlertBanner() ? 180 : 140}px)`,
+                    maxHeight: `calc(100vh - ${this.shouldRenderAlertBanner() ? 164 : 124}px)`,
                 }}
             >
                 <StyledMediaController


### PR DESCRIPTION
#### Summary

A small UX regression due to the sizing changes in https://github.com/mattermost/mattermost-plugin-calls/pull/715 which we weren't accounting for in case of screen sharing.

#### Screenshots

*Before*

![2024-05-14-162608_2560x1080_scrot](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/ae405001-371a-4553-8851-1c82bc9a8e90)

*After*

![2024-05-14-162456_2560x1080_scrot](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/551764d3-2a4f-4d48-b72a-8c75eabf00b7)

