### PR TITLE
[MM-53491] Fix rendering of active call icon in sidebar's channel link

### DIFF
--- a/webapp/src/components/channel_link_label/component.tsx
+++ b/webapp/src/components/channel_link_label/component.tsx
@@ -47,14 +47,17 @@ const ChannelLinkLabel = (props: Props) => {
                     {
                         display: 'flex',
                         alignItems: 'center',
-                        marginLeft: 'auto',
+                        justifyContent: 'center',
                         height: 'auto',
+                        minWidth: '20px',
+                        marginLeft: 'auto',
+                        marginRight: '4px',
                     }
                 }
             >
                 <ActiveCallIcon
                     fill={props.theme.sidebarText}
-                    style={{width: '12px', height: '12px'}}
+                    style={{minWidth: '12px', maxWidth: '12px', minHeight: '12px', maxHeight: '12px'}}
                 />
             </span>
         </OverlayTrigger>


### PR DESCRIPTION
#### Summary

PR fixes some outstanding issues with the rendering of the active call icon in the sidebar. This requires some webapp changes to work in all cases (see related PR).

#### Design

https://www.figma.com/design/KAdDampXIcjzQ8oWMs7LpZ/MM-53491-Calls%3A-Rendering-of-LHS-active-call-icon?node-id=1-7&m=dev

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53491

#### Related PR

https://github.com/mattermost/mattermost/pull/27172