### PR TITLE
fix: Generate status check before the report generation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,8 +18,31 @@ env:
   PARALLELISM: 10
 
 jobs:
+  generate-pending-report-status-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: e2e/generate-report-status-check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
+        with:
+          script: |
+            try {
+              await github.rest.repos.createCommitStatus({
+                owner: 'mattermost',
+                repo: 'mattermost-plugin-calls',
+                sha: '${{ github.event.pull_request.head.sha || github.sha }}',
+                context: 'e2e/report-summary',
+                description: 'E2E tests are running',
+                state: 'pending',
+                target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+              });
+            } catch (err) {
+              core.setFailed(`Action failed with error: ${err}`);
+            }
+
   build-mattermost-plugin-calls:
     runs-on: ubuntu-22.04
+    needs:
+      - generate-pending-report-status-check
     steps:
       - name: e2e/checkout-mattermost-plugin-calls-repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -194,3 +217,27 @@ jobs:
           path: ${{ github.workspace }}/logs
           compression-level: 0
           retention-days: 5
+
+  generate-failed-report-status-check:
+    runs-on: ubuntu-22.04
+    if: failure() || cancelled()
+    needs:
+      - e2e-playwright-test
+    steps:
+      - name: e2e/generate-failed-report-status-check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
+        with:
+          script: |
+            try {
+              await github.rest.repos.createCommitStatus({
+                owner: 'mattermost',
+                repo: 'mattermost-plugin-calls',
+                sha: '${{ github.event.pull_request.head.sha || github.sha }}',
+                context: 'e2e/report-summary',
+                description: 'E2E tests failed before the report generation',
+                state: 'failure',
+                target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+              });
+            } catch (err) {
+              core.setFailed(`Action failed with error: ${err}`);
+            }

--- a/.github/workflows/generate-e2e-report.yml
+++ b/.github/workflows/generate-e2e-report.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
           path: e2e-playwright-results
           pattern: e2e-playwright-results-*
           merge-multiple: true

--- a/.github/workflows/generate-e2e-report.yml
+++ b/.github/workflows/generate-e2e-report.yml
@@ -10,10 +10,7 @@ on:
 jobs:
   generate-report:
     runs-on: ubuntu-22.04
-    if: |
-      github.repository_owner == 'mattermost' && 
-      github.event.workflow_run.event == 'pull_request' && 
-      github.event.workflow_run.conclusion == 'success'
+    if: github.repository_owner == 'mattermost' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: e2e-report/checkout-mattermost-plugin-calls-repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -74,7 +71,7 @@ jobs:
           echo "We had ${{ steps.stats.outputs.SUCCESSES }} successes" >> "${GITHUB_STEP_SUMMARY}"
           echo "You can find the report [here](${{ steps.stats.outputs.S3_REPORT }})" >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: e2e-report/block-PR-upon-failure-with-report-URL
+      - name: e2e-report/send-failure-status
         if: ${{ fromJson(steps.stats.outputs.FAILURES) > 0 }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
         with:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Generate pending status check before the report generation in order to avoid a false positive success from the E2E tests execution
- Remove the pull request condition in order to run also on master

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-7757
