### PR TITLE
[MM-45236] Improve auditing of joining sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.0.12
 	github.com/mattermost/morph v1.1.0
-	github.com/mattermost/rtcd v0.15.1-0.20240523213854-a21f616a60c8
+	github.com/mattermost/rtcd v0.15.1-0.20240605123719-d296cbd40950
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.0.12
 	github.com/mattermost/morph v1.1.0
-	github.com/mattermost/rtcd v0.15.1-0.20240605123719-d296cbd40950
+	github.com/mattermost/rtcd v0.16.0
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/mattermost/mattermost/server/public v0.0.12 h1:iunc9q4/XkArOrndEUn73u
 github.com/mattermost/mattermost/server/public v0.0.12/go.mod h1:Bk+atJcELCIk9Yeq5FoqTr+gra9704+X4amrlwlTgSc=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
-github.com/mattermost/rtcd v0.15.1-0.20240605123719-d296cbd40950 h1:uzR8Ih9pyYZ0/7sY2xNwNXtVA9fYf8zszaosMrzJJ3Q=
-github.com/mattermost/rtcd v0.15.1-0.20240605123719-d296cbd40950/go.mod h1:YhKWxm9FXKq+vGiiBFtSh43uGuWdWmEJgzQHHAgtHFI=
+github.com/mattermost/rtcd v0.16.0 h1:oAYUbIYdbXDB7kMpEEKZVrgIvsCKYNAsbL3gNecADls=
+github.com/mattermost/rtcd v0.16.0/go.mod h1:YhKWxm9FXKq+vGiiBFtSh43uGuWdWmEJgzQHHAgtHFI=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/mattermost/mattermost/server/public v0.0.12 h1:iunc9q4/XkArOrndEUn73u
 github.com/mattermost/mattermost/server/public v0.0.12/go.mod h1:Bk+atJcELCIk9Yeq5FoqTr+gra9704+X4amrlwlTgSc=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
-github.com/mattermost/rtcd v0.15.1-0.20240523213854-a21f616a60c8 h1:7Oc+tW+mSWeQH5yKV0YsUPuBKb4ReEHNpMwPJT0PXlw=
-github.com/mattermost/rtcd v0.15.1-0.20240523213854-a21f616a60c8/go.mod h1:YhKWxm9FXKq+vGiiBFtSh43uGuWdWmEJgzQHHAgtHFI=
+github.com/mattermost/rtcd v0.15.1-0.20240605123719-d296cbd40950 h1:uzR8Ih9pyYZ0/7sY2xNwNXtVA9fYf8zszaosMrzJJ3Q=
+github.com/mattermost/rtcd v0.15.1-0.20240605123719-d296cbd40950/go.mod h1:YhKWxm9FXKq+vGiiBFtSh43uGuWdWmEJgzQHHAgtHFI=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -86,6 +86,9 @@ func (p *Plugin) startSession(us *session, senderID string) {
 		CallID:    us.callID,
 		UserID:    us.userID,
 		SessionID: us.connID,
+		Props: map[string]any{
+			"channelID": us.channelID,
+		},
 	}
 	if err := p.rtcServer.InitSession(cfg, func() error {
 		p.LogDebug("rtc session close cb", "sessionID", us.connID)

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -742,6 +742,8 @@ func (p *Plugin) handleJoin(userID, connID, authSessionID string, joinData Calls
 			})
 		}
 
+		p.LogDebug("session has joined call", "userID", userID, "sessionID", connID, "channelID", channelID, "callID", state.Call.ID)
+
 		handlerID := state.Call.Props.NodeID
 		p.LogDebug("got handlerID", "handlerID", handlerID)
 
@@ -757,6 +759,7 @@ func (p *Plugin) handleJoin(userID, connID, authSessionID string, joinData Calls
 					"callID":    us.callID,
 					"userID":    userID,
 					"sessionID": connID,
+					"channelID": channelID,
 				},
 			}
 			if err := p.rtcdManager.Send(msg, state.Call.Props.RTCDHost); err != nil {
@@ -775,6 +778,9 @@ func (p *Plugin) handleJoin(userID, connID, authSessionID string, joinData Calls
 					CallID:    us.callID,
 					UserID:    userID,
 					SessionID: connID,
+					Props: map[string]any{
+						"channelID": us.channelID,
+					},
 				}
 				p.LogDebug("initializing RTC session", "userID", userID, "connID", connID, "channelID", channelID, "callID", us.callID)
 				if err = p.rtcServer.InitSession(cfg, func() error {


### PR DESCRIPTION
#### Summary

PR improves logging of which sessions join calls, including all the most important IDs.

Example:

```
{"timestamp":"2024-06-05 06:44:32.750 -06:00","level":"info","msg":"session has joined call","caller":"app/plugin_api.go:1008","plugin_id":"com.mattermost.calls","origin":"main.(*Plugin).handleJoin.func1 websocket.go:745","userID":"zjm6x7y4n3gjzfj7kw3xp9c9se","sessionID":"5dbfn67ubtr3fkhqb9octcu5iy","channelID":"oi18bftr738ntn35xnyjyed9uh","callID":"g3y3k1to57y85puaccnwgj7ber"}
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45236
