### PR TITLE
[MM-58293] Add subtext on unmute tooltip

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -161,6 +161,7 @@
   "kSDNX6": "true",
   "kj3s4R": "The host removed you from the call.",
   "kr3shS": "Unable to join call",
+  "ks1Gvx": "Or hold space bar",
   "lKv8ex": "Default",
   "lRSSL4": "You're already in a call in {channel}.",
   "lWsBmL": "Chat unavailable: different team selected. Click here to switch back to {channelName} in {teamName}.",

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -1012,7 +1012,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         const MuteIcon = isMuted && !noInputDevices && !noAudioPermissions ? MutedIcon : UnmutedIcon;
 
         let muteTooltipText = isMuted ? formatMessage({defaultMessage: 'Unmute'}) : formatMessage({defaultMessage: 'Mute'});
-        let muteTooltipSubtext = '';
+        let muteTooltipSubtext = isMuted ? formatMessage({defaultMessage: 'Or hold space bar'}) : '';
 
         if (noInputDevices) {
             muteTooltipText = formatMessage(CallAlertConfigs.missingAudioInput.tooltipText!);

--- a/webapp/src/components/expanded_view/controls_button.tsx
+++ b/webapp/src/components/expanded_view/controls_button.tsx
@@ -49,13 +49,13 @@ export default function ControlsButton(props: Props) {
                     $isDisabled={props.disabled}
                 >
                     <div>{props.tooltipText}</div>
+                    {props.shortcut &&
+                        <Shortcut shortcut={props.shortcut}/>
+                    }
                     {props.tooltipSubtext &&
                         <TooltipSubtext>
                             {props.tooltipSubtext}
                         </TooltipSubtext>
-                    }
-                    {props.shortcut &&
-                        <Shortcut shortcut={props.shortcut}/>
                     }
                 </StyledTooltip>
             }


### PR DESCRIPTION
#### Summary

A minor improvement to the unmute button on the expanded view to include info about the space bar trigger. 

#### Screenshot

![image](https://github.com/mattermost/mattermost-plugin-calls/assets/1832946/82e465a5-6c3e-4ed5-8749-b0c3faa4fdf9)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-58293
