### PR TITLE
Fix asset bundling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ export GO111MODULE=on
 export GOBIN ?= $(PWD)/bin
 
 # You can include assets this directory into the bundle. This can be e.g. used to include profile pictures.
-ASSETS_DIR ?= assets
+ASSETS_DIR ?= server/assets
 
 ## Define the default target (make all)
 .PHONY: default

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "description": "Integrates real-time voice communication in Mattermost",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
-  "icon_path": "server/assets/plugin_icon.svg",
+  "icon_path": "assets/plugin_icon.svg",
   "min_server_version": "9.5.0",
   "server": {
     "executables": {


### PR DESCRIPTION
#### Summary
- We made a little mistake in bundling. Instead of splitting the files (png staying in the server pkg so we can embed it, and svg moving to the `/assets` dir) to conform to the makefile, just changed the makefile's asset directory var. Also need to change the `plugin.json` location.
- Will need to cut `v0.28.1` after. I did not delete the `v0.28.0`, but I wanted to just to get the automatic comment. :)

#### Ticket Link
- none