### PR TITLE
[MM-58773] Fix broken notifications test

### DIFF
--- a/e2e/page.ts
+++ b/e2e/page.ts
@@ -29,6 +29,7 @@ export default class PlaywrightDevPage {
 
     async goto() {
         await this.page.goto(`${baseURL}/${defaultTeam}/channels/${getChannelNamesForTest()[0]}`);
+        await this.page.waitForTimeout(0);
     }
 
     async goToChannel(name: string) {

--- a/e2e/page.ts
+++ b/e2e/page.ts
@@ -29,7 +29,6 @@ export default class PlaywrightDevPage {
 
     async goto() {
         await this.page.goto(`${baseURL}/${defaultTeam}/channels/${getChannelNamesForTest()[0]}`);
-        await this.page.waitForTimeout(0);
     }
 
     async goToChannel(name: string) {

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -103,7 +103,6 @@ test.describe('notifications', () => {
     test('dm channel, global desktop none', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'none'});
         await page.reload();
-        await page.waitForTimeout(0);
         const devPage = new PlaywrightDevPage(page);
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
@@ -130,7 +129,6 @@ test.describe('notifications', () => {
     test('dm channel, global sound false', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'mentions', calls_desktop_sound: 'false'});
         await page.reload();
-        await page.waitForTimeout(0);
         const devPage = new PlaywrightDevPage(page);
         await page.reload();
         await page.evaluate(() => {
@@ -196,10 +194,8 @@ test.describe('notifications', () => {
     test('gm channel, global desktop none', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'none'});
         await page.reload();
-        await page.waitForTimeout(0);
         const devPage = new PlaywrightDevPage(page);
         await devPage.goto();
-        await page.waitForTimeout(0);
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eNotificationsSoundedAt = [];
@@ -224,9 +220,7 @@ test.describe('notifications', () => {
     test('gm channel, global desktop sound false', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'mentions', calls_desktop_sound: 'false'});
         await page.reload();
-        await page.waitForTimeout(0);
         const devPage = new PlaywrightDevPage(page);
-        await page.waitForTimeout(0);
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eNotificationsSoundedAt = [];
@@ -637,7 +631,6 @@ test.describe('notifications', () => {
 
         await apiPutStatus(request, 'dnd');
         await page.reload();
-        await page.waitForTimeout(0);
 
         // we need to be 'hidden' so that our desktop notifications are sent
         const devPage = new PlaywrightDevPage(page);
@@ -674,7 +667,6 @@ test.describe('notifications', () => {
         });
         const devPage = new PlaywrightDevPage(page);
         await page.reload();
-        await page.waitForTimeout(0);
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eDesktopNotificationsSent = [];

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -42,7 +42,6 @@ test.beforeEach(async ({page, request}, info) => {
         {mark_unread: 'all', desktop: 'default', desktop_sound: 'on'},
     );
     await devPage.goto();
-    await page.waitForTimeout(2000);
 });
 
 test.afterEach(async ({page, request}) => {
@@ -103,8 +102,9 @@ test.describe('notifications', () => {
 
     test('dm channel, global desktop none', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'none'});
+        await page.reload();
+        await page.waitForTimeout(0);
         const devPage = new PlaywrightDevPage(page);
-        await devPage.goto();
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eNotificationsSoundedAt = [];
@@ -129,8 +129,10 @@ test.describe('notifications', () => {
 
     test('dm channel, global sound false', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'mentions', calls_desktop_sound: 'false'});
+        await page.reload();
+        await page.waitForTimeout(0);
         const devPage = new PlaywrightDevPage(page);
-        await devPage.goto();
+        await page.reload();
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eNotificationsSoundedAt = [];
@@ -193,7 +195,8 @@ test.describe('notifications', () => {
 
     test('gm channel, global desktop none', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'none'});
-        await page.waitForTimeout(2000);
+        await page.reload();
+        await page.waitForTimeout(0);
         const devPage = new PlaywrightDevPage(page);
         await devPage.goto();
         await page.waitForTimeout(0);
@@ -220,7 +223,8 @@ test.describe('notifications', () => {
 
     test('gm channel, global desktop sound false', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'mentions', calls_desktop_sound: 'false'});
-        await page.waitForTimeout(2000);
+        await page.reload();
+        await page.waitForTimeout(0);
         const devPage = new PlaywrightDevPage(page);
         await page.waitForTimeout(0);
         await page.evaluate(() => {
@@ -632,11 +636,11 @@ test.describe('notifications', () => {
         });
 
         await apiPutStatus(request, 'dnd');
-        await page.waitForTimeout(2000);
+        await page.reload();
+        await page.waitForTimeout(0);
 
         // we need to be 'hidden' so that our desktop notifications are sent
         const devPage = new PlaywrightDevPage(page);
-        await page.waitForTimeout(0);
         await devPage.hideDocument(true);
 
         const user1 = await startDMWith(userStorages[1], usernames[0]);
@@ -669,7 +673,8 @@ test.describe('notifications', () => {
             auto_responder_message: 'ooo',
         });
         const devPage = new PlaywrightDevPage(page);
-        await devPage.goto();
+        await page.reload();
+        await page.waitForTimeout(0);
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eDesktopNotificationsSent = [];

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -42,7 +42,7 @@ test.beforeEach(async ({page, request}, info) => {
         {mark_unread: 'all', desktop: 'default', desktop_sound: 'on'},
     );
     await devPage.goto();
-    await page.waitForTimeout(0);
+    await page.waitForTimeout(1000);
 });
 
 test.afterEach(async ({page, request}) => {

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -42,7 +42,7 @@ test.beforeEach(async ({page, request}, info) => {
         {mark_unread: 'all', desktop: 'default', desktop_sound: 'on'},
     );
     await devPage.goto();
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(2000);
 });
 
 test.afterEach(async ({page, request}) => {
@@ -193,8 +193,10 @@ test.describe('notifications', () => {
 
     test('gm channel, global desktop none', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'none'});
+        await page.waitForTimeout(2000);
         const devPage = new PlaywrightDevPage(page);
         await devPage.goto();
+        await page.waitForTimeout(0);
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eNotificationsSoundedAt = [];
@@ -218,7 +220,9 @@ test.describe('notifications', () => {
 
     test('gm channel, global desktop sound false', async ({page, request}) => {
         await apiPatchNotifyProps(request, {desktop: 'mentions', calls_desktop_sound: 'false'});
+        await page.waitForTimeout(2000);
         const devPage = new PlaywrightDevPage(page);
+        await page.waitForTimeout(0);
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eNotificationsSoundedAt = [];
@@ -628,9 +632,11 @@ test.describe('notifications', () => {
         });
 
         await apiPutStatus(request, 'dnd');
+        await page.waitForTimeout(2000);
 
         // we need to be 'hidden' so that our desktop notifications are sent
         const devPage = new PlaywrightDevPage(page);
+        await page.waitForTimeout(0);
         await devPage.hideDocument(true);
 
         const user1 = await startDMWith(userStorages[1], usernames[0]);

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -130,7 +130,6 @@ test.describe('notifications', () => {
         await apiPatchNotifyProps(request, {desktop: 'mentions', calls_desktop_sound: 'false'});
         await page.reload();
         const devPage = new PlaywrightDevPage(page);
-        await page.reload();
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eNotificationsSoundedAt = [];
@@ -665,8 +664,8 @@ test.describe('notifications', () => {
             auto_responder_active: 'true',
             auto_responder_message: 'ooo',
         });
-        const devPage = new PlaywrightDevPage(page);
         await page.reload();
+        const devPage = new PlaywrightDevPage(page);
         await page.evaluate(() => {
             window.e2eDesktopNotificationsRejected = [];
             window.e2eDesktopNotificationsSent = [];

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -42,6 +42,7 @@ test.beforeEach(async ({page, request}, info) => {
         {mark_unread: 'all', desktop: 'default', desktop_sound: 'on'},
     );
     await devPage.goto();
+    await page.waitForTimeout(0);
 });
 
 test.afterEach(async ({page, request}) => {

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -456,7 +456,7 @@ export const removeIncomingCallNotification = (callID: string): ActionFuncAsync 
 };
 
 export const ringForCall = (callID: string, sound: string) => {
-    return async (dispatch: DispatchFunc) => {
+    return (dispatch: DispatchFunc) => {
         notificationSounds?.ring(sound);
 
         // window.e2eNotificationsSoundedAt is added when running the e2e tests


### PR DESCRIPTION
#### Summary
- Actual broken test, bisected the problem to a change in how mattermost mounts react components: https://github.com/mattermost/mattermost/pull/27192
- Looks like the e2e test wasn't detecting a real break, I think it just runs too quickly. So: 1) ensuring that patching is applied by reloading after (kind of unrelated to the above PR but might have been contributing to flakiness in the past), and 2) adding a timeout of 0 to flush the event loop of the page (allowing react to fully load), and that fixes it.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-58773