### PR TITLE
[MM-59027] Fix: Ringing not stopping after leave or /call end

### DIFF
--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -882,8 +882,6 @@ const incomingCalls = (state: IncomingCallNotification[] = [], action: IncomingC
         return [...state, {...action.data}];
     case REMOVE_INCOMING_CALL:
         return state.filter((ic) => ic.callID !== action.data.callID);
-    case CALL_END:
-        return state.filter((ic) => ic.callID !== action.data.callID);
     default:
         return state;
     }

--- a/webapp/src/websocket_handlers.ts
+++ b/webapp/src/websocket_handlers.ts
@@ -28,6 +28,7 @@ import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 import {generateId} from 'mattermost-redux/utils/helpers';
 import {
+    callEnd,
     incomingCallOnChannel,
     loadCallState,
     loadProfilesByIdsIfMissing,
@@ -50,7 +51,6 @@ import {
 } from 'src/types/types';
 
 import {
-    CALL_END,
     CALL_HOST,
     CALL_LIVE_CAPTIONS_STATE,
     CALL_RECORDING_STATE,
@@ -94,19 +94,7 @@ import {
 // state mutating operations.
 export function handleCallEnd(store: Store, ev: WebSocketMessage<EmptyData>) {
     const channelID = ev.data.channelID || ev.broadcast.channel_id;
-    if (channelIDForCurrentCall(store.getState()) === channelID) {
-        window.callsClient?.disconnect();
-    }
-
-    const callID = calls(store.getState())[channelID]?.ID || '';
-
-    store.dispatch({
-        type: CALL_END,
-        data: {
-            channelID,
-            callID,
-        },
-    });
+    store.dispatch(callEnd(channelID));
 }
 
 // NOTE: it's important this function is kept synchronous in order to guarantee the order of


### PR DESCRIPTION
#### Summary
- When refactoring `CALL_END` I tried to make it do too much (it removed the incoming notification, but that hid that we weren't also removing the ringing). Also, `CALL_END` was being sent in a couple places. 
- Consolidated the call end logic to one function, and it is its job to do all the call cleanup.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-59027