### PR TITLE
fix: Remove status check posting from e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,31 +18,8 @@ env:
   PARALLELISM: 10
 
 jobs:
-  generate-pending-report-status-check:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: e2e/generate-report-status-check
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
-        with:
-          script: |
-            try {
-              await github.rest.repos.createCommitStatus({
-                owner: 'mattermost',
-                repo: 'mattermost-plugin-calls',
-                sha: '${{ github.event.pull_request.head.sha || github.sha }}',
-                context: 'e2e/report-summary',
-                description: 'E2E tests are running',
-                state: 'pending',
-                target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-              });
-            } catch (err) {
-              core.setFailed(`Action failed with error: ${err}`);
-            }
-
   build-mattermost-plugin-calls:
     runs-on: ubuntu-22.04
-    needs:
-      - generate-pending-report-status-check
     steps:
       - name: e2e/checkout-mattermost-plugin-calls-repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -217,27 +194,3 @@ jobs:
           path: ${{ github.workspace }}/logs
           compression-level: 0
           retention-days: 5
-
-  generate-failed-report-status-check:
-    runs-on: ubuntu-22.04
-    if: failure() || cancelled()
-    needs:
-      - e2e-playwright-test
-    steps:
-      - name: e2e/generate-failed-report-status-check
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
-        with:
-          script: |
-            try {
-              await github.rest.repos.createCommitStatus({
-                owner: 'mattermost',
-                repo: 'mattermost-plugin-calls',
-                sha: '${{ github.event.pull_request.head.sha || github.sha }}',
-                context: 'e2e/report-summary',
-                description: 'E2E tests failed before the report generation',
-                state: 'failure',
-                target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-              });
-            } catch (err) {
-              core.setFailed(`Action failed with error: ${err}`);
-            }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We do not need to trigger the e2e report summary status check . 
We can post it after the report is generated

Fixes: https://github.com/mattermost/mattermost-plugin-calls/pull/794#issuecomment-2186422441

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

