### PR TITLE
[MM-59062] Include SKUs in new telemetry event payload

### DIFF
--- a/server/telemetry/telemetry.go
+++ b/server/telemetry/telemetry.go
@@ -13,7 +13,7 @@ type ClientConfig struct {
 	WriteKey     string
 	DataplaneURL string
 	DiagnosticID string
-	DefaultProps map[string]interface{}
+	DefaultProps map[string]any
 }
 
 func (c *ClientConfig) isValid() error {
@@ -48,9 +48,9 @@ func NewClient(config ClientConfig) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) Track(event string, props map[string]interface{}) error {
+func (c *Client) Track(event string, props map[string]any, ctx *analytics.Context) error {
 	if props == nil {
-		props = map[string]interface{}{}
+		props = map[string]any{}
 	}
 
 	for k, v := range c.config.DefaultProps {
@@ -61,6 +61,7 @@ func (c *Client) Track(event string, props map[string]interface{}) error {
 		Event:      event,
 		UserId:     c.config.DiagnosticID,
 		Properties: props,
+		Context:    ctx,
 	}); err != nil {
 		return fmt.Errorf("telemetry: failed to track event: %w", err)
 	}


### PR DESCRIPTION
#### Summary

In preparation for the packaging changes scheduled for Calls v1 (MM v10), we are updating the telemetry event payload format to include SKUs for any event generated from licensed functionalities.

/cc @esethna 

#### Example Payload

```json
{
    "messageId": "44100f37-170d-48e8-8fa7-f932baa8f324",
    "sentAt": "2024-06-25T10:11:20.69004022+02:00",
    "batch": [
        {
            "type": "track",
            "messageId": "d3c2644a-1519-4c9d-976f-3921555b06ca",
            "anonymousId": "3n51obp8tjrkdboifsk79wamar",
            "userId": "3n51obp8tjrkdboifsk79wamar",
            "event": "user_start_recording",
            "timestamp": "2024-06-25T10:11:17.327382729+02:00",
            "context": {
                "feature": {
                    "name": "Calls",
                    "skus": [
                        "enterprise"
                    ]
                }
            },
            "properties": {
                "ActualUserID": "zjm6x7y4n3gjzfj7kw3xp9c9se",
                "ClientType": "web",
                "PluginBuild": "dfb441fc2c1db244527692ea1493fd8b22cdcd02",
                "PluginVersion": "0.28.1+dfb441fc",
                "ServerVersion": "9.10.0",
                "Source": "expanded_view",
                "initiator": "button"
            }
        },
        {
            "type": "track",
            "messageId": "4dc1dc40-468a-4a7c-ba9f-9b02e229c3fa",
            "anonymousId": "3n51obp8tjrkdboifsk79wamar",
            "userId": "3n51obp8tjrkdboifsk79wamar",
            "event": "call_user_joined",
            "timestamp": "2024-06-25T10:11:20.149452269+02:00",
            "context": {
                "feature": {
                    "name": "Calls",
                    "skus": null
                }
            },
            "properties": {
                "CallID": "g5xzsa5gmb8ptb9u6hijrkpmry",
                "ChannelID": "oi18bftr738ntn35xnyjyed9uh",
                "ParticipantID": "9oqmwbcyhjb9urmg8tduwhypee",
                "PluginBuild": "dfb441fc2c1db244527692ea1493fd8b22cdcd02",
                "PluginVersion": "0.28.1+dfb441fc",
                "ServerVersion": "9.10.0"
            }
        }
    ],
    "context": {
        "library": {
            "name": "analytics-go",
            "version": "3.3.0"
        }
    }
}
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-59062

