### PR TITLE
fix: Always send a success status check when e2e tests are done

### DIFF
--- a/.github/workflows/generate-e2e-report.yml
+++ b/.github/workflows/generate-e2e-report.yml
@@ -72,27 +72,7 @@ jobs:
           echo "We had ${{ steps.stats.outputs.SUCCESSES }} successes" >> "${GITHUB_STEP_SUMMARY}"
           echo "You can find the report [here](${{ steps.stats.outputs.S3_REPORT }})" >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: e2e-report/send-failure-status
-        if: ${{ fromJson(steps.stats.outputs.FAILURES) > 0 }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
-        with:
-          script: |
-            try {
-              await github.rest.repos.createCommitStatus({
-                owner: 'mattermost',
-                repo: 'mattermost-plugin-calls',
-                sha: '${{ github.event.workflow_run.head_sha }}',
-                context: 'e2e/report-summary',
-                description: '${{ steps.stats.outputs.FAILURES }}/${{ steps.stats.outputs.TOTAL }} E2E tests failed',
-                state: 'failure',
-                target_url: '${{ steps.stats.outputs.S3_REPORT }}'
-              });
-            } catch (err) {
-              core.setFailed(`Action failed with error: ${err}`);
-            }
-
       - name: e2e-report/send-success-status
-        if: ${{ fromJson(steps.stats.outputs.FAILURES) == 0 }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
         with:
           script: |


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Send a success status on e2e tests no matter failures. Let the reviewer judge if it's flaky tests or not while not blocking the merge

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

