### PR TITLE
[MM-59072] Don't require user ID in caption message

### DIFF
--- a/server/public/job.go
+++ b/server/public/job.go
@@ -61,7 +61,6 @@ type Transcriptions []Transcription
 
 type CaptionMsg struct {
 	SessionID     string  `json:"session_id"`
-	UserID        string  `json:"user_id"`
 	Text          string  `json:"text"`
 	NewAudioLenMs float64 `json:"new_audio_len_ms"`
 }


### PR DESCRIPTION
#### Summary

While working on https://github.com/mattermost/calls-transcriber/pull/27, I realized that any connected client could craft a WebSocket message to display arbitrary captions from any other user connected to the call. 

The UserID field was also redundant since we can easily find that information from the call session object.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-59072