### PR TITLE
[MM-59548] Update rtcd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4
 	github.com/mattermost/morph v1.1.0
-	github.com/mattermost/rtcd v0.16.0
+	github.com/mattermost/rtcd v0.16.2
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef
 github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4/go.mod h1:PDPb/iqzJJ5ZvK/m70oDF55AXN/cOvVFj96Yu4e6j+Q=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
-github.com/mattermost/rtcd v0.16.0 h1:oAYUbIYdbXDB7kMpEEKZVrgIvsCKYNAsbL3gNecADls=
-github.com/mattermost/rtcd v0.16.0/go.mod h1:YhKWxm9FXKq+vGiiBFtSh43uGuWdWmEJgzQHHAgtHFI=
+github.com/mattermost/rtcd v0.16.2 h1:vTt/M6+z/PrfnqlVRy1ZoG9QqOHcfjuv3hGYJL5+2lg=
+github.com/mattermost/rtcd v0.16.2/go.mod h1:7q0ULK6tbZryNdlUOzK819cKyFrjjRKifsl3e660rsw=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=


### PR DESCRIPTION
#### Summary

Updating the `rtcd` dependency to fix a regression. See https://github.com/mattermost/rtcd/pull/151.

I'll update the base branch as soon as we have a proper one.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-59548
