### PR TITLE
Remove CGO dependency for load-test main binary

### DIFF
--- a/lt/cmd/speech/main.go
+++ b/lt/cmd/speech/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/polly"
 
+	"gopkg.in/hraban/opus.v2"
+
 	"github.com/mattermost/mattermost-plugin-calls/lt/client"
 )
 
@@ -82,7 +84,9 @@ func performScript(filename string) error {
 			TeamID:       teamID,
 			PollySession: svc,
 			PollyVoiceID: aws.String(script.voiceIDs[i]),
-		})
+		}, client.WithOpusEncoderFactory(func() (client.OpusEncoder, error) {
+			return opus.NewEncoder(24000, 1, opus.AppVoIP)
+		}))
 		userClients = append(userClients, user)
 
 		userWg.Add(1)


### PR DESCRIPTION
#### Summary

PR removes the CGO dependency from our main load-test command (i.e. `./lt/cmd/lt`) since it has caused a bit of pain for our customers as it requires some extra system dependencies which are not always straightforward to install. Given the opus encoder is only used by the `speech` command, we can extract it over there through the use of a common interface.
