### PR TITLE
Fix dates flakiness in calls stats

### DIFF
--- a/server/db/utils.go
+++ b/server/db/utils.go
@@ -105,3 +105,14 @@ func getQueryPlaceholder(driverName string) sq.PlaceholderFormat {
 	}
 	return sq.Question
 }
+
+func genLast12MonthsMap(now time.Time) map[string]int64 {
+	// To avoid skews due to how AddDate works, we always normalize to the first day of the current month.
+	date := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	m := make(map[string]int64, 12)
+	for i := 0; i < 12; i++ {
+		m[date.AddDate(0, -i, 0).Format("2006-01")] = 0
+	}
+
+	return m
+}

--- a/server/db/utils_test.go
+++ b/server/db/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost-plugin-calls/server/testutils"
 
@@ -84,5 +85,21 @@ func TestSetupConn(t *testing.T) {
 				require.Equal(t, 45, db.Stats().MaxOpenConnections)
 			})
 		})
+	}
+}
+
+func TestGenLast12MonthsMap(t *testing.T) {
+	daysInMonth := func(m time.Month, year int) int {
+		return time.Date(year, m+1, 0, 0, 0, 0, 0, time.UTC).Day()
+	}
+
+	for year := 2023; year < 4545; year++ {
+		for month := time.January; month < time.December; month++ {
+			for i := 0; i < daysInMonth(month, year); i++ {
+				d := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+				m := genLast12MonthsMap(d)
+				require.Len(t, m, 12)
+			}
+		}
 	}
 }


### PR DESCRIPTION
#### Summary

Working with time is hard enough. Working with dates is just brutal.

PR tries to fix some flakiness caught in CI tests on this day (Jul 30th). The way `time.AddDate` works made it possible to get duplicate months due to normalization. Now we are ensuring to always use the first day of the month rather than the current one which should guarantee no duplicates are added (added a test).

