### PR TITLE
[MM-60010] Fix recording state cleared when session for same participant leaves

### DIFF
--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -38,7 +38,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme, Theme} from 'mattermost-redux/selectors/entities/preferences';
 import configureStore from 'mattermost-redux/store';
 import {ActionFuncAsync} from 'mattermost-redux/types/actions';
-import {getCallActive, getCallsConfig, setClientConnecting} from 'plugin/actions';
+import {getCallActive, getCallsConfig, localSessionClose, setClientConnecting} from 'plugin/actions';
 import CallsClient from 'plugin/client';
 import {
     logDebug,
@@ -116,6 +116,9 @@ function connectCall(
 
         window.callsClient.on('close', (err?: Error) => {
             store.dispatch(setClientConnecting(false));
+            if (window.callsClient) {
+                store.dispatch(localSessionClose(window.callsClient.channelID));
+            }
             if (closeCb) {
                 closeCb(err);
             }

--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -56,4 +56,5 @@ export const RECEIVED_CALLS_USER_PREFERENCES = pluginId + '_received_calls_user_
 export const DESKTOP_WIDGET_CONNECTED = pluginId + '_desktop_widget_connected';
 
 export const CLIENT_CONNECTING = pluginId + '_client_connecting';
+export const LOCAL_SESSION_CLOSE = pluginId + '_local_session_close';
 

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -62,6 +62,7 @@ import {
     HIDE_SCREEN_SOURCE_MODAL,
     HIDE_SWITCH_CALL_MODAL,
     LIVE_CAPTIONS_ENABLED,
+    LOCAL_SESSION_CLOSE,
     RECEIVED_CALLS_CONFIG,
     RECORDINGS_ENABLED,
     REMOVE_INCOMING_CALL,
@@ -415,7 +416,6 @@ export const userLeft = (channelID: string, userID: string, sessionID: string) =
                 channelID,
                 userID,
                 session_id: sessionID,
-                currentUserID: getCurrentUserId(getState()),
             },
         });
 
@@ -687,4 +687,13 @@ export const selectRHSPost = (postID: string): ActionFuncAsync => {
         }
         return {};
     };
+};
+
+export const localSessionClose = (channelID: string) => (dispatch: Dispatch) => {
+    dispatch({
+        type: LOCAL_SESSION_CLOSE,
+        data: {
+            channelID,
+        },
+    });
 };

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -25,6 +25,7 @@ import {
     getCallsStats,
     incomingCallOnChannel,
     loadProfilesByIdsIfMissing,
+    localSessionClose,
     selectRHSPost,
     setClientConnecting,
     showScreenSourceModal,
@@ -599,6 +600,7 @@ export default class Plugin {
                         if (err) {
                             store.dispatch(displayCallErrorModal(err, window.callsClient.channelID));
                         }
+                        store.dispatch(localSessionClose(window.callsClient.channelID));
                         window.callsClient.destroy();
                         delete window.callsClient;
                         delete window.currentCallData;

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -36,6 +36,7 @@ import {
     LIVE_CAPTION,
     LIVE_CAPTION_TIMEOUT_EVENT,
     LIVE_CAPTIONS_ENABLED,
+    LOCAL_SESSION_CLOSE,
     RECEIVED_CALLS_CONFIG,
     RECEIVED_CALLS_USER_PREFERENCES,
     RECEIVED_CHANNEL_STATE,
@@ -532,12 +533,10 @@ export type callsJobState = {
     [callID: string]: CallJobState;
 }
 
-type userDisconnectedAction = {
+type localSessionCloseAction = {
     type: string;
     data: {
         channelID: string;
-        userID: string;
-        currentUserID: string;
     };
 }
 
@@ -557,18 +556,15 @@ type disclaimerDismissedAction = {
     };
 }
 
-const recordings = (state: callsJobState = {}, action: jobStateAction | userDisconnectedAction | disclaimerDismissedAction) => {
+const recordings = (state: callsJobState = {}, action: jobStateAction | localSessionCloseAction | disclaimerDismissedAction) => {
     switch (action.type) {
     case UNINIT:
         return {};
-    case USER_LEFT: {
-        const theAction = action as userDisconnectedAction;
-        if (theAction.data.currentUserID === theAction.data.userID) {
-            const nextState = {...state};
-            delete nextState[theAction.data.channelID];
-            return nextState;
-        }
-        return state;
+    case LOCAL_SESSION_CLOSE: {
+        const theAction = action as localSessionCloseAction;
+        const nextState = {...state};
+        delete nextState[theAction.data.channelID];
+        return nextState;
     }
     case CALL_RECORDING_STATE: {
         const theAction = action as jobStateAction;


### PR DESCRIPTION
#### Summary

Found an interesting edge case when testing the new recorder image. If a user is connected more than once to the same call (multi sessions), then any of their sessions leaving would cause the recording state to be reset for all of them.

I tried to fix this in a couple of different ways (i.e., persisting the previous call sessionID or just avoiding clearing the state), but they all come with some tradeoffs, so I eventually decided that having a more explicit redux action to track the local client closing may be the cleanest option.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60010
