### PR TITLE
chore: use `./` notation for relative file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ Please join the [Developers: Calls](https://community.mattermost.com/core/channe
 
 ## License
 
-See [LICENSE](LICENSE) and [LICENSE.enterprise](server/enterprise/LICENSE) for license rights and limitations.
+See [LICENSE](./LICENSE) and [LICENSE.enterprise](server/enterprise/LICENSE) for license rights and limitations.
 


### PR DESCRIPTION
This PR replaces `LICENSE` with `./LICENSE`, so that the file is linked correctly in environments where the `./` is required.