### PR TITLE
Bump e2e timeout

### DIFF
--- a/e2e/tests/media.spec.ts
+++ b/e2e/tests/media.spec.ts
@@ -126,6 +126,8 @@ test.describe('screen sharing', () => {
     });
 
     test('av1', async ({page}) => {
+        test.setTimeout(150000);
+
         // Enabling AV1
         await apiSetEnableAV1(true);
 


### PR DESCRIPTION
#### Summary

AV1 test has been a bit flaky, timing out during cleanup.

