### PR TITLE
Calls v1 prep

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,7 +101,7 @@ jobs:
       DOCKER_NETWORK: playwright_tests
       CONTAINER_SERVER: playwright_tests_server
       IMAGE_CALLS_OFFLOADER: mattermost/calls-offloader:v0.8.0
-      IMAGE_CALLS_RECORDER: mattermost/calls-recorder:v0.7.3
+      IMAGE_CALLS_RECORDER: mattermost/calls-recorder:v0.7.4
       IMAGE_SERVER: mattermostdevelopment/mattermost-enterprise-edition:master
       IMAGE_CURL: curlimages/curl:8.7.1
       CI_NODE_INDEX: ${{ matrix.run_id }}

--- a/go.mod
+++ b/go.mod
@@ -18,13 +18,13 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.9
 	github.com/mattermost/calls-offloader v0.8.0
-	github.com/mattermost/calls-recorder v0.7.3
-	github.com/mattermost/calls-transcriber v0.3.1
+	github.com/mattermost/calls-recorder v0.7.4
+	github.com/mattermost/calls-transcriber v0.4.0
 	github.com/mattermost/logr/v2 v2.0.21
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4
 	github.com/mattermost/morph v1.1.0
-	github.com/mattermost/rtcd v0.16.3-0.20240726081546-8b783d9cd2d4
+	github.com/mattermost/rtcd v0.17.0
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -366,10 +366,10 @@ github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3v
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattermost/calls-offloader v0.8.0 h1:XCAAMR11V/wSlLIJl1DuUQ8PGT8RRwPFbtM4YGZvfLw=
 github.com/mattermost/calls-offloader v0.8.0/go.mod h1:xmVZZfWM9KfTcOp2Zb8XdFRin4JBNcQqg+vcwtTmdPc=
-github.com/mattermost/calls-recorder v0.7.3 h1:WN9J2PjymwyvFhe1xpUNUes6Y4VYrChSBBebH4AZS2g=
-github.com/mattermost/calls-recorder v0.7.3/go.mod h1:I2jcogTW6A3FmD1MaVmxebqzygozpBkKEAvevgVTsvg=
-github.com/mattermost/calls-transcriber v0.3.1 h1:OLeeRJurP1OYiuRi4/fHXUDtiZqsWRNxLsDQ+niAI68=
-github.com/mattermost/calls-transcriber v0.3.1/go.mod h1:fjSGpL5vJ6Xw/CWvQpd3iie1ccGQn6CipZ8XGhppdyw=
+github.com/mattermost/calls-recorder v0.7.4 h1:Qh2KUJXyi5Sr2vjUSqBRWxEcgeboTJqJPcJxlXfdhlg=
+github.com/mattermost/calls-recorder v0.7.4/go.mod h1:I2jcogTW6A3FmD1MaVmxebqzygozpBkKEAvevgVTsvg=
+github.com/mattermost/calls-transcriber v0.4.0 h1:02xQ5JQiwquPdLkD6dMnlEYroUWuTRuwI/NOgaQ8xF8=
+github.com/mattermost/calls-transcriber v0.4.0/go.mod h1:7PQ11l7azyClIVWV5qJJviu2nHySSZdl71yVCGEIGSA=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 h1:Khvh6waxG1cHc4Cz5ef9n3XVCxRWpAKUtqg9PJl5+y8=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
 github.com/mattermost/ldap v3.0.4+incompatible h1:SOeNnz+JNR+foQ3yHkYqijb9MLPhXN2BZP/PdX23VDU=
@@ -380,8 +380,8 @@ github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef
 github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4/go.mod h1:PDPb/iqzJJ5ZvK/m70oDF55AXN/cOvVFj96Yu4e6j+Q=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
-github.com/mattermost/rtcd v0.16.3-0.20240726081546-8b783d9cd2d4 h1:wva3gPvesIiOtUO4/CQyVfVq/kzSFr7EQcV7Lh6ebsY=
-github.com/mattermost/rtcd v0.16.3-0.20240726081546-8b783d9cd2d4/go.mod h1:bpGyHeb+JDkDzbrQheenpbrqfPhphW0jr09Jh+rpmpY=
+github.com/mattermost/rtcd v0.17.0 h1:BZ/lslbvFZxPtT6gp8A1NtjCfThriDafebO0ClMYhm8=
+github.com/mattermost/rtcd v0.17.0/go.mod h1:bpGyHeb+JDkDzbrQheenpbrqfPhphW0jr09Jh+rpmpY=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/lt/go.mod
+++ b/lt/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.50.3
 	github.com/hajimehoshi/go-mp3 v0.3.4
 	github.com/mattermost/mattermost/server/public v0.0.12
-	github.com/mattermost/rtcd v0.16.3-0.20240729135840-0cf4f24d69db
+	github.com/mattermost/rtcd v0.17.0
 	github.com/pion/rtp v1.8.6
 	github.com/pion/webrtc/v3 v3.2.41
 	gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302

--- a/lt/go.sum
+++ b/lt/go.sum
@@ -85,8 +85,8 @@ github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy5
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
 github.com/mattermost/mattermost/server/public v0.0.12 h1:iunc9q4/XkArOrndEUn73uFw6v9TOEXEtp6Nm6Iv218=
 github.com/mattermost/mattermost/server/public v0.0.12/go.mod h1:Bk+atJcELCIk9Yeq5FoqTr+gra9704+X4amrlwlTgSc=
-github.com/mattermost/rtcd v0.16.3-0.20240729135840-0cf4f24d69db h1:qY/jn7EBLoXuBcGcuueAWHEHCQ78/GQObeo6onOhVkg=
-github.com/mattermost/rtcd v0.16.3-0.20240729135840-0cf4f24d69db/go.mod h1:bpGyHeb+JDkDzbrQheenpbrqfPhphW0jr09Jh+rpmpY=
+github.com/mattermost/rtcd v0.17.0 h1:BZ/lslbvFZxPtT6gp8A1NtjCfThriDafebO0ClMYhm8=
+github.com/mattermost/rtcd v0.17.0/go.mod h1:bpGyHeb+JDkDzbrQheenpbrqfPhphW0jr09Jh+rpmpY=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
   "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
   "icon_path": "assets/plugin_icon.svg",
-  "min_server_version": "9.5.0",
+  "min_server_version": "10.0.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",
@@ -332,7 +332,7 @@
   "props": {
     "min_rtcd_version": "v0.17.0",
     "min_offloader_version": "v0.8.0",
-    "calls_recorder_version": "v0.7.3",
+    "calls_recorder_version": "v0.7.4",
     "calls_transcriber_version": "v0.4.0"
   }
 }


### PR DESCRIPTION
#### Summary

We are making MM v10 a requirement for running Calls v1 since it makes it more explicit we are introducing breaking changes (namely Calls being available only in DMs for unlicensed servers).

Also bumping some Calls dependencies in the process as we are wrapping up the release. 
