### PR TITLE
Utilize reporting script from default branch

### DIFF
--- a/.github/workflows/generate-e2e-report.yml
+++ b/.github/workflows/generate-e2e-report.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: e2e-report/checkout-mattermost-plugin-calls-repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: e2e-report/download-paywright-report-results
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4


### PR DESCRIPTION
#### Summary

This PR utilizes the `main` branch version of the repository when producing the E2E test report.

The ref to check out doesn't need to be specified, because for `workflow_run` it's the default branch out-of-the-box:
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
- https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4