### PR TITLE
[MM-60252] Fix failure to negotiate tracks after ws reconnect

### DIFF
--- a/server/rtcd.go
+++ b/server/rtcd.go
@@ -652,10 +652,16 @@ func (m *rtcdClientManager) handleClientMsg(msg rtcd.ClientMessage) error {
 	}
 
 	m.ctx.LogDebug("relaying ws message", "sessionID", rtcMsg.SessionID, "userID", rtcMsg.UserID)
+
+	us := m.ctx.getSessionByOriginalID(rtcMsg.SessionID)
+	if us == nil {
+		return fmt.Errorf("failed to find session by originalConnID: %s", rtcMsg.SessionID)
+	}
+
 	m.ctx.publishWebSocketEvent(wsEventSignal, map[string]interface{}{
 		"data":   string(rtcMsg.Data),
 		"connID": rtcMsg.SessionID,
-	}, &WebSocketBroadcast{ConnectionID: rtcMsg.SessionID, ReliableClusterSend: true})
+	}, &WebSocketBroadcast{ConnectionID: us.connID, ReliableClusterSend: true})
 
 	return nil
 }


### PR DESCRIPTION
#### Summary

In https://github.com/mattermost/mattermost-plugin-calls/pull/821/files#diff-d42de9238c805b64e9ba33d375fc6a246ff6e08feeecb4f1a0f54285cc7e4261 I inadvertently introduced a regression in case of websocket reconnect to a different HA node. 

Since this case causes a new connection to be created, we cannot use the original connection ID to forward subsequent messages. This worked fine before because we'd be broadcasting them to all connections belonging to the user but that's not ideal, so the solution here is to find the right connection ID that maps to the original one.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60252
