### PR TITLE
Bump e2e timeouts to address flakyness

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,7 +9,7 @@ const config: PlaywrightTestConfig = {
     retries: 1,
     workers: 4,
     fullyParallel: true,
-    timeout: 120 * 1000,
+    timeout: 150 * 1000,
     expect: {
         timeout: 60 * 1000,
         toMatchSnapshot: {

--- a/e2e/tests/join_call.spec.ts
+++ b/e2e/tests/join_call.spec.ts
@@ -146,7 +146,7 @@ test.describe('join call', () => {
     });
 
     test('multiple sessions per user', async () => {
-        test.setTimeout(180000);
+        test.setTimeout(200000);
 
         // start a call
         const sessionAPage = await startCall(userStorages[1]);

--- a/e2e/tests/media.spec.ts
+++ b/e2e/tests/media.spec.ts
@@ -126,7 +126,7 @@ test.describe('screen sharing', () => {
     });
 
     test('av1', async ({page}) => {
-        test.setTimeout(150000);
+        test.setTimeout(180000);
 
         // Enabling AV1
         await apiSetEnableAV1(true);


### PR DESCRIPTION
#### Summary

Some tests are timing out without clear signs of failure other than taking a littler longer to process.