### PR TITLE
Fix e2e pipeline flakyness

### DIFF
--- a/e2e/scripts/run.sh
+++ b/e2e/scripts/run.sh
@@ -58,13 +58,13 @@ docker ps -a
 docker logs "${COMPOSE_PROJECT_NAME}_callsoffloader"
 
 # Print transcriber job logs in case of failure.
-for ID in $(docker ps -a --filter=ancestor="calls-transcriber:master" --format "{{.ID}}")
+for ID in $(docker ps -a --filter=ancestor="calls-transcriber:master" --filter=status="exited" --format "{{.ID}}")
 do
   docker logs $ID
 done
 
 # Print recorder job logs in case of failure.
-for ID in $(docker ps -a --filter=ancestor="calls-recorder:master" --format "{{.ID}}")
+for ID in $(docker ps -a --filter=ancestor="calls-recorder:master" --filter=status="exited" --format "{{.ID}}")
 do
   docker logs $ID
 done


### PR DESCRIPTION
#### Summary

Printing calls-recorder/transcriber logs have been often failing as of late with `Error response from daemon: can not get logs from container which is dead or marked for removal`. 

We only really care about exited containers, which are retained past their execution. Ideally we'd filter by exit code but the `docker ps` filter functionality doesn't seem to support advanced logic such as `exited!=0`.


