### PR TITLE
Prepare v1.2.0 release

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,7 +102,7 @@ jobs:
       DOCKER_NETWORK: playwright_tests
       CONTAINER_SERVER: playwright_tests_server
       IMAGE_CALLS_OFFLOADER: mattermost/calls-offloader:v0.8.0
-      IMAGE_CALLS_RECORDER: mattermost/calls-recorder:v0.7.5
+      IMAGE_CALLS_RECORDER: mattermost/calls-recorder:v0.7.6
       IMAGE_SERVER: mattermostdevelopment/mattermost-enterprise-edition:master
       IMAGE_CURL: curlimages/curl:8.7.1
       CI_NODE_INDEX: ${{ matrix.run_id }}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4
 	github.com/mattermost/morph v1.1.0
-	github.com/mattermost/rtcd v0.17.2-0.20241009214839-a44d499cefcc
+	github.com/mattermost/rtcd v0.17.2-0.20241010232710-2137f0c5b45f
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef
 github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4/go.mod h1:PDPb/iqzJJ5ZvK/m70oDF55AXN/cOvVFj96Yu4e6j+Q=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
-github.com/mattermost/rtcd v0.17.2-0.20241009214839-a44d499cefcc h1:KTdzXsjcrnawYH2uNwLW8WVe0vyYmuC8ckpR83Cj7Sg=
-github.com/mattermost/rtcd v0.17.2-0.20241009214839-a44d499cefcc/go.mod h1:FVyFLa+7dWImCZ+0g9xoc/1fMRKMuXs6yAZP1mDKBIg=
+github.com/mattermost/rtcd v0.17.2-0.20241010232710-2137f0c5b45f h1:YyomRPBCg57bEeDy8FZHOl3wvxy3jfaACyq+fmNCMaw=
+github.com/mattermost/rtcd v0.17.2-0.20241010232710-2137f0c5b45f/go.mod h1:FVyFLa+7dWImCZ+0g9xoc/1fMRKMuXs6yAZP1mDKBIg=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/lt/go.mod
+++ b/lt/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.50.3
 	github.com/hajimehoshi/go-mp3 v0.3.4
 	github.com/mattermost/mattermost/server/public v0.0.12
-	github.com/mattermost/rtcd v0.17.2-0.20241009214839-a44d499cefcc
+	github.com/mattermost/rtcd v0.17.2-0.20241010232710-2137f0c5b45f
 	github.com/pion/rtp v1.8.6
 	github.com/pion/webrtc/v3 v3.2.41
 	gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302

--- a/lt/go.sum
+++ b/lt/go.sum
@@ -85,8 +85,8 @@ github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy5
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
 github.com/mattermost/mattermost/server/public v0.0.12 h1:iunc9q4/XkArOrndEUn73uFw6v9TOEXEtp6Nm6Iv218=
 github.com/mattermost/mattermost/server/public v0.0.12/go.mod h1:Bk+atJcELCIk9Yeq5FoqTr+gra9704+X4amrlwlTgSc=
-github.com/mattermost/rtcd v0.17.2-0.20241009214839-a44d499cefcc h1:KTdzXsjcrnawYH2uNwLW8WVe0vyYmuC8ckpR83Cj7Sg=
-github.com/mattermost/rtcd v0.17.2-0.20241009214839-a44d499cefcc/go.mod h1:FVyFLa+7dWImCZ+0g9xoc/1fMRKMuXs6yAZP1mDKBIg=
+github.com/mattermost/rtcd v0.17.2-0.20241010232710-2137f0c5b45f h1:YyomRPBCg57bEeDy8FZHOl3wvxy3jfaACyq+fmNCMaw=
+github.com/mattermost/rtcd v0.17.2-0.20241010232710-2137f0c5b45f/go.mod h1:FVyFLa+7dWImCZ+0g9xoc/1fMRKMuXs6yAZP1mDKBIg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/plugin.json
+++ b/plugin.json
@@ -696,7 +696,7 @@
   "props": {
     "min_rtcd_version": "v0.17.0",
     "min_offloader_version": "v0.8.0",
-    "calls_recorder_version": "v0.7.5",
+    "calls_recorder_version": "v0.7.6",
     "calls_transcriber_version": "v0.4.0"
   }
 }

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@mattermost/calls-common": "github:mattermost/calls-common#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
+        "@mattermost/calls-common": "github:mattermost/calls-common#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
         "@mattermost/compass-icons": "0.1.31",
         "@msgpack/msgpack": "2.7.1",
         "bootstrap": "3.4.1",
@@ -3088,8 +3088,8 @@
     },
     "node_modules/@mattermost/calls-common": {
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
-      "integrity": "sha512-jze9YO7n9c8AgaE2FOMzj8g2ieqczNfCzah7W6TeQtC0Ufhe3jcGG99DNtrB3tHeiBsp/ZlrvBXCVpA/oQR6YA==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
+      "integrity": "sha512-aZIYwtgRVj8tdWJUPtAr4TPNa6tNM3lnRkC74CkSsFCpwZ1miwov0B4TLYG4Srj1rTgUqUwG3gQz4o5JHJ2fuQ==",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",
         "fflate": "^0.8.2"

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -18,7 +18,7 @@
     "extract": "formatjs extract 'src/**/*.{ts,tsx}' --ignore 'src/**/*.d.ts' --out-file i18n/temp.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' && formatjs compile 'i18n/temp.json' --out-file i18n/en.json && rm i18n/temp.json"
   },
   "dependencies": {
-    "@mattermost/calls-common": "github:mattermost/calls-common#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
+    "@mattermost/calls-common": "github:mattermost/calls-common#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
     "@mattermost/compass-icons": "0.1.31",
     "@msgpack/msgpack": "2.7.1",
     "bootstrap": "3.4.1",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "0.26.12",
-        "@mattermost/calls-common": "github:mattermost/calls-common#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
+        "@mattermost/calls-common": "github:mattermost/calls-common#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
         "@msgpack/msgpack": "2.7.1",
         "@redux-devtools/extension": "3.2.3",
         "core-js": "3.26.1",
@@ -8239,8 +8239,8 @@
     },
     "node_modules/@mattermost/calls-common": {
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
-      "integrity": "sha512-jze9YO7n9c8AgaE2FOMzj8g2ieqczNfCzah7W6TeQtC0Ufhe3jcGG99DNtrB3tHeiBsp/ZlrvBXCVpA/oQR6YA==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
+      "integrity": "sha512-aZIYwtgRVj8tdWJUPtAr4TPNa6tNM3lnRkC74CkSsFCpwZ1miwov0B4TLYG4Srj1rTgUqUwG3gQz4o5JHJ2fuQ==",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",
         "fflate": "^0.8.2"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "0.26.12",
-    "@mattermost/calls-common": "github:mattermost/calls-common#8d2b13bd2f10847a4be461dd4225fef2ade06ab9",
+    "@mattermost/calls-common": "github:mattermost/calls-common#07607cf603f1e3f0c86ae248b2332e8da17f9cf8",
     "@msgpack/msgpack": "2.7.1",
     "@redux-devtools/extension": "3.2.3",
     "core-js": "3.26.1",

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -26,7 +26,7 @@ export const insecureContextErr = new Error('insecure context');
 export const userRemovedFromChannelErr = new Error('user was removed from channel');
 export const userLeftChannelErr = new Error('user has left channel');
 
-const rtcMonitorInterval = 4000;
+const rtcMonitorInterval = 10000;
 
 export default class CallsClient extends EventEmitter {
     public channelID: string;


### PR DESCRIPTION
#### Summary

Updating the various dependencies. The only significant change here is I am bumping `rtcMonitorInterval` from 4s to 10s as it results in much higher quality stats (less variance) and possibly avoid more false positives with call quality detection.
