### PR TITLE
Fix docker login step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,7 +158,7 @@ jobs:
       - name: e2e/docker-login
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         # Do not authenticate on Forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: "! github.event.pull_request.head.repo.fork "
         with:
           username: ${{ secrets.DOCKERHUB_DEV_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,7 +158,7 @@ jobs:
       - name: e2e/docker-login
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         # Do not authenticate on Forks
-        if: "! github.event.pull_request.head.repo.fork "
+        if: "github.event.repository.full_name == github.repository"
         with:
           username: ${{ secrets.DOCKERHUB_DEV_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}


### PR DESCRIPTION
#### Summary

I think the existing check was overly strict since it's only running on PRs. In fact,  `main` branch is [now failing](https://github.com/mattermost/mattermost-plugin-calls/actions/runs/11331363665/job/31511439495) due to rate limiting.
