### PR TITLE
[MM-61166] Ensure full validation of Calls post props

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -319,6 +319,7 @@
   "yO68rk": "Calls are currently running in test mode and only system admins can start them. Reach out directly to your system admin for assistance",
   "yfYHc5": "ICE Host Override",
   "yjQNKt": "Calls are disabled in this channel.",
+  "yx0b7N": "{count, plural, =1 {# transcription} other {# transcriptions}}",
   "zMlIqq": "This setting is disabled as the server is unlicensed and calls are only available in DM channels.",
   "zUH89x": "The call recording will be processed and posted in the call thread. Are you sure you want to stop the recording?",
   "zx0myy": "Participants",

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -80,16 +80,27 @@ const PostType = ({
         }
     };
 
-    const recordings = callProps.recording_files?.length || 0;
+    const recordings = Object.values(callProps.recordings).filter(job => Boolean(job.file_id)).map(job => job.file_id);
+    const transcriptions = Object.values(callProps.transcriptions).filter(job => Boolean(job.file_id)).map(job => job.file_id);
 
-    const recordingsSubMessage = recordings > 0 ? (
-        <RecordingsContainer>
+    const recordingsSubMessage = recordings.length > 0 ? (
+        <ArtifactsContainer>
             <CompassIcon
                 icon='file-video-outline'
                 style={{display: 'inline', fontSize: '16px'}}
             />
-            <span>{formatMessage({defaultMessage: '{count, plural, =1 {# recording} other {# recordings}}'}, {count: recordings})}</span>
-        </RecordingsContainer>
+            <span>{formatMessage({defaultMessage: '{count, plural, =1 {# recording} other {# recordings}}'}, {count: recordings.length})}</span>
+        </ArtifactsContainer>
+    ) : null;
+
+    const transcriptionsSubMessage = recordings.length > 0 ? (
+        <ArtifactsContainer>
+            <CompassIcon
+                icon='file-text-outline'
+                style={{display: 'inline', fontSize: '16px'}}
+            />
+            <span>{formatMessage({defaultMessage: '{count, plural, =1 {# transcription} other {# transcriptions}}'}, {count: transcriptions.length})}</span>
+        </ArtifactsContainer>
     ) : null;
 
     const subMessage = callProps.start_at > 0 && callProps.end_at > 0 ? (
@@ -215,7 +226,7 @@ const PostType = ({
                             <SubMessage>{subMessage}</SubMessage>
                         </MessageWrapper>
                     </Left>
-                    { (recordings > 0 || callActive) && <RowDivider/> }
+                    { (recordings.length > 0 || callActive) && <RowDivider/> }
                     <Right>
                         {callActive &&
                             <>
@@ -231,7 +242,8 @@ const PostType = ({
                                 {button}
                             </>
                         }
-                        {recordingsSubMessage}
+                        {recordings.length > 0 && recordingsSubMessage}
+                        {transcriptions.length > 0 && transcriptionsSubMessage}
                     </Right>
                 </SubMain>
             </Main>
@@ -428,7 +440,7 @@ const Divider = styled.span`
     margin: 0 4px;
 `;
 
-const RecordingsContainer = styled.div`
+const ArtifactsContainer = styled.div`
     display: flex;
     align-items: center;
     font-size: 12px;

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -92,7 +92,7 @@ const PostType = ({
         </RecordingsContainer>
     ) : null;
 
-    const subMessage = callProps.start_at && callProps.end_at ? (
+    const subMessage = callProps.start_at > 0 && callProps.end_at > 0 ? (
         <>
             <span>
                 {formatMessage(
@@ -159,7 +159,7 @@ const PostType = ({
 
     const compactTitle = compactDisplay && !isRHS ? <br/> : <></>;
     const title = callProps.title ? <h3 className='markdown__heading'>{callProps.title}</h3> : compactTitle;
-    const callActive = !callProps.end_at;
+    const callActive = callProps.end_at === 0;
     const inCall = connectedID === post.channel_id;
     const iconAndText = (
         <>
@@ -189,14 +189,14 @@ const PostType = ({
             <Main data-testid={'call-thread'}>
                 <SubMain>
                     <Left>
-                        <CallIndicator $ended={Boolean(callProps.end_at)}>
-                            {!callProps.end_at &&
+                        <CallIndicator $ended={!callActive}>
+                            {callActive &&
                                 <ActiveCallIcon
                                     fill='var(--center-channel-bg)'
                                     style={{width: '20px', height: '20px'}}
                                 />
                             }
-                            {callProps.end_at &&
+                            {!callActive &&
                                 <LeaveCallIcon
                                     fill={'rgba(var(--center-channel-color-rgb), 0.72)'}
                                     style={{width: '24px', height: '20px'}}
@@ -205,10 +205,10 @@ const PostType = ({
                         </CallIndicator>
                         <MessageWrapper>
                             <Message>
-                                {!callProps.end_at &&
+                                {callActive &&
                                     formatMessage({defaultMessage: 'Call started'})
                                 }
-                                {callProps.end_at &&
+                                {!callActive &&
                                     formatMessage({defaultMessage: 'Call ended'})
                                 }
                             </Message>

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -306,6 +306,72 @@ describe('utils', () => {
             expect(props.participants.length).toBe(0);
         });
 
+        test('invalid job data', () => {
+            const callProps = {
+                recordings: {
+                    recA: {
+                        file_id: true,
+                        post_id: null,
+                        tr_id: 45,
+                        rec_id: 45,
+                    },
+                    45: {
+                    },
+                    recB: {
+                        file_id: 'recFileID',
+                    },
+                },
+                transcriptions: {
+                    trA: {
+                        file_id: true,
+                        post_id: null,
+                        tr_id: 45,
+                        rec_id: 45,
+                    },
+                    45: {
+                    },
+                    trB: {
+                        file_id: 'trFileID',
+                    },
+                },
+            };
+
+            const post = {
+                props: callProps as unknown,
+            } as Post;
+
+            const props = getCallPropsFromPost(post);
+
+            expect(props.recordings).toStrictEqual({
+                recA: {
+                    file_id: '',
+                    post_id: '',
+                },
+                45: {
+                    file_id: '',
+                    post_id: '',
+                },
+                recB: {
+                    file_id: 'recFileID',
+                    post_id: '',
+                },
+            });
+            expect(props.transcriptions).toStrictEqual({
+                trA: {
+                    file_id: '',
+                    post_id: '',
+                },
+                45: {
+                    file_id: '',
+                    post_id: '',
+                },
+                trB: {
+                    file_id: 'trFileID',
+                    post_id: '',
+                },
+            });
+        });
+
         test('full props', () => {
             const callProps = {
                 title: 'call title',
@@ -348,9 +414,9 @@ describe('utils', () => {
             expect(props.title).toBe(post.props.title);
             expect(props.start_at).toBe(post.props.start_at);
             expect(props.end_at).toBe(post.props.end_at);
-            expect(props.recordings).toBe(post.props.recordings);
+            expect(props.recordings).toStrictEqual(post.props.recordings);
             expect(props.recording_files).toBe(post.props.recording_files);
-            expect(props.transcriptions).toBe(post.props.transcriptions);
+            expect(props.transcriptions).toStrictEqual(post.props.transcriptions);
             expect(props.participants).toBe(post.props.participants);
         });
     });

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -255,11 +255,12 @@ describe('utils', () => {
 
             const props = getCallPropsFromPost(post);
 
-            expect(props.start_at).toBeUndefined();
-            expect(props.end_at).toBeUndefined();
-            expect(props.recordings.length).toBe(0);
+            expect(props.title).toBe('');
+            expect(props.start_at).toBe(0);
+            expect(props.end_at).toBe(0);
+            expect(props.recordings).toStrictEqual({});
             expect(props.recording_files.length).toBe(0);
-            expect(props.transcriptions.length).toBe(0);
+            expect(props.transcriptions).toStrictEqual({});
             expect(props.participants.length).toBe(0);
         });
 
@@ -270,11 +271,38 @@ describe('utils', () => {
 
             const props = getCallPropsFromPost(post);
 
-            expect(props.start_at).toBeUndefined();
-            expect(props.end_at).toBeUndefined();
-            expect(props.recordings.length).toBe(0);
+            expect(props.title).toBe('');
+            expect(props.start_at).toBe(0);
+            expect(props.end_at).toBe(0);
+            expect(props.recordings).toStrictEqual({});
             expect(props.recording_files.length).toBe(0);
-            expect(props.transcriptions.length).toBe(0);
+            expect(props.transcriptions).toStrictEqual({});
+            expect(props.participants.length).toBe(0);
+        });
+
+        test('invalid props', () => {
+            const callProps = {
+                title: {},
+                start_at: 'invalid',
+                end_at: [],
+                recordings: null,
+                transcriptions: 45,
+                participants: 'invalid',
+                recording_files: 45,
+            };
+
+            const post = {
+                props: callProps as unknown,
+            } as Post;
+
+            const props = getCallPropsFromPost(post);
+
+            expect(props.title).toBe('');
+            expect(props.start_at).toBe(0);
+            expect(props.end_at).toBe(0);
+            expect(props.recordings).toStrictEqual({});
+            expect(props.recording_files.length).toBe(0);
+            expect(props.transcriptions).toStrictEqual({});
             expect(props.participants.length).toBe(0);
         });
 
@@ -333,8 +361,8 @@ describe('utils', () => {
 
             const props = getCallRecordingPropsFromPost(post);
 
-            expect(props.call_post_id).toBeUndefined();
-            expect(props.recording_id).toBeUndefined();
+            expect(props.call_post_id).toBe('');
+            expect(props.recording_id).toBe('');
             expect(props.captions.length).toBe(0);
         });
 
@@ -345,8 +373,26 @@ describe('utils', () => {
 
             const props = getCallRecordingPropsFromPost(post);
 
-            expect(props.call_post_id).toBeUndefined();
-            expect(props.recording_id).toBeUndefined();
+            expect(props.call_post_id).toBe('');
+            expect(props.recording_id).toBe('');
+            expect(props.captions.length).toBe(0);
+        });
+
+        test('invalid props', () => {
+            const recProps = {
+                call_post_id: 45,
+                recording_id: {},
+                captions: 'invalid',
+            };
+
+            const post = {
+                props: recProps as unknown,
+            } as Post;
+
+            const props = getCallRecordingPropsFromPost(post);
+
+            expect(props.call_post_id).toBe('');
+            expect(props.recording_id).toBe('');
             expect(props.captions.length).toBe(0);
         });
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -1,5 +1,5 @@
 import {makeCallsBaseAndBadgeRGB, rgbToCSS} from '@mattermost/calls-common';
-import {CallPostProps, CallRecordingPostProps, SessionState, UserSessionState} from '@mattermost/calls-common/lib/types';
+import {CallJobMetadata, CallPostProps, CallRecordingPostProps, SessionState, UserSessionState} from '@mattermost/calls-common/lib/types';
 import {Channel} from '@mattermost/types/channels';
 import {ClientConfig} from '@mattermost/types/config';
 import {Post} from '@mattermost/types/posts';
@@ -579,13 +579,26 @@ function isValidObject(v: any) {
     return typeof v === 'object' && !Array.isArray(v) && v !== null;
 }
 
+function getJobMetadataMap(obj: {[key: string]: CallJobMetadata}) {
+    const out : {[key: string]: CallJobMetadata} = {};
+    for (const [key, value] of Object.entries(obj)) {
+        out[key] = {
+            file_id: typeof value?.file_id === 'string' ? value.file_id : '',
+            post_id: typeof value?.post_id === 'string' ? value.post_id : '',
+            ...(typeof value?.rec_id === 'string') && {rec_id: value.rec_id},
+            ...(typeof value?.tr_id === 'string') && {tr_id: value.tr_id},
+        };
+    }
+    return out;
+}
+
 export function getCallPropsFromPost(post: Post): CallPostProps {
     return {
         title: typeof post.props?.title === 'string' ? post.props.title : '',
         start_at: typeof post.props?.start_at === 'number' ? post.props.start_at : 0,
         end_at: typeof post.props?.end_at === 'number' ? post.props.end_at : 0,
-        recordings: isValidObject(post.props?.recordings) ? post.props.recordings : {},
-        transcriptions: isValidObject(post.props?.transcriptions) ? post.props.transcriptions : {},
+        recordings: isValidObject(post.props?.recordings) ? getJobMetadataMap(post.props.recordings) : {},
+        transcriptions: isValidObject(post.props?.transcriptions) ? getJobMetadataMap(post.props.transcriptions) : {},
         participants: Array.isArray(post.props?.participants) ? post.props.participants : [],
 
         // DEPRECATED

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -575,25 +575,29 @@ export function notificationsStopRinging() {
     }
 }
 
+function isValidObject(v: any) {
+    return typeof v === 'object' && !Array.isArray(v) && v !== null;
+}
+
 export function getCallPropsFromPost(post: Post): CallPostProps {
     return {
-        title: post.props?.title,
-        start_at: post.props?.start_at,
-        end_at: post.props?.end_at,
-        recordings: post.props?.recordings || [],
-        transcriptions: post.props?.transcriptions || [],
-        participants: post.props?.participants || [],
+        title: typeof post.props?.title === 'string' ? post.props.title : '',
+        start_at: typeof post.props?.start_at === 'number' ? post.props.start_at : 0,
+        end_at: typeof post.props?.end_at === 'number' ? post.props.end_at : 0,
+        recordings: isValidObject(post.props?.recordings) ? post.props.recordings : {},
+        transcriptions: isValidObject(post.props?.transcriptions) ? post.props.transcriptions : {},
+        participants: Array.isArray(post.props?.participants) ? post.props.participants : [],
 
         // DEPRECATED
-        recording_files: post.props?.recording_files || [],
+        recording_files: Array.isArray(post.props?.recording_files) ? post.props.recording_files : [],
     };
 }
 
 export function getCallRecordingPropsFromPost(post: Post): CallRecordingPostProps {
     return {
-        call_post_id: post.props?.call_post_id,
-        recording_id: post.props?.recording_id,
-        captions: post.props?.captions || [],
+        call_post_id: typeof post.props?.call_post_id === 'string' ? post.props.call_post_id : '',
+        recording_id: typeof post.props?.recording_id === 'string' ? post.props.recording_id : '',
+        captions: Array.isArray(post.props?.captions) ? post.props.captions : [],
     };
 }
 


### PR DESCRIPTION
#### Summary

Since props cannot be trusted (i.e., users can alter them at any time on their posts), we must take extra care to ensure that the type of them is what we expect it to be.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61166
