### PR TITLE
[MM-61228] Surface transcriptions in call post

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -319,6 +319,7 @@
   "yO68rk": "Calls are currently running in test mode and only system admins can start them. Reach out directly to your system admin for assistance",
   "yfYHc5": "ICE Host Override",
   "yjQNKt": "Calls are disabled in this channel.",
+  "yx0b7N": "{count, plural, =1 {# transcription} other {# transcriptions}}",
   "zMlIqq": "This setting is disabled as the server is unlicensed and calls are only available in DM channels.",
   "zUH89x": "The call recording will be processed and posted in the call thread. Are you sure you want to stop the recording?",
   "zx0myy": "Participants",

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -80,16 +80,27 @@ const PostType = ({
         }
     };
 
-    const recordings = callProps.recording_files?.length || 0;
+    const recordings = Object.values(callProps.recordings).filter(job => Boolean(job.file_id)).map(job => job.file_id);
+    const transcriptions = Object.values(callProps.transcriptions).filter(job => Boolean(job.file_id)).map(job => job.file_id);
 
-    const recordingsSubMessage = recordings > 0 ? (
-        <RecordingsContainer>
+    const recordingsSubMessage = recordings.length > 0 ? (
+        <ArtifactsContainer>
             <CompassIcon
                 icon='file-video-outline'
                 style={{display: 'inline', fontSize: '16px'}}
             />
-            <span>{formatMessage({defaultMessage: '{count, plural, =1 {# recording} other {# recordings}}'}, {count: recordings})}</span>
-        </RecordingsContainer>
+            <span>{formatMessage({defaultMessage: '{count, plural, =1 {# recording} other {# recordings}}'}, {count: recordings.length})}</span>
+        </ArtifactsContainer>
+    ) : null;
+
+    const transcriptionsSubMessage = recordings.length > 0 ? (
+        <ArtifactsContainer>
+            <CompassIcon
+                icon='file-text-outline'
+                style={{display: 'inline', fontSize: '16px'}}
+            />
+            <span>{formatMessage({defaultMessage: '{count, plural, =1 {# transcription} other {# transcriptions}}'}, {count: transcriptions.length})}</span>
+        </ArtifactsContainer>
     ) : null;
 
     const subMessage = callProps.start_at > 0 && callProps.end_at > 0 ? (
@@ -215,7 +226,7 @@ const PostType = ({
                             <SubMessage>{subMessage}</SubMessage>
                         </MessageWrapper>
                     </Left>
-                    { (recordings > 0 || callActive) && <RowDivider/> }
+                    { (recordings.length > 0 || callActive) && <RowDivider/> }
                     <Right>
                         {callActive &&
                             <>
@@ -231,7 +242,8 @@ const PostType = ({
                                 {button}
                             </>
                         }
-                        {recordingsSubMessage}
+                        {recordings.length > 0 && recordingsSubMessage}
+                        {transcriptions.length > 0 && transcriptionsSubMessage}
                     </Right>
                 </SubMain>
             </Main>
@@ -428,7 +440,7 @@ const Divider = styled.span`
     margin: 0 4px;
 `;
 
-const RecordingsContainer = styled.div`
+const ArtifactsContainer = styled.div`
     display: flex;
     align-items: center;
     font-size: 12px;

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -306,6 +306,72 @@ describe('utils', () => {
             expect(props.participants.length).toBe(0);
         });
 
+        test('invalid job data', () => {
+            const callProps = {
+                recordings: {
+                    recA: {
+                        file_id: true,
+                        post_id: null,
+                        tr_id: 45,
+                        rec_id: 45,
+                    },
+                    45: {
+                    },
+                    recB: {
+                        file_id: 'recFileID',
+                    },
+                },
+                transcriptions: {
+                    trA: {
+                        file_id: true,
+                        post_id: null,
+                        tr_id: 45,
+                        rec_id: 45,
+                    },
+                    45: {
+                    },
+                    trB: {
+                        file_id: 'trFileID',
+                    },
+                },
+            };
+
+            const post = {
+                props: callProps as unknown,
+            } as Post;
+
+            const props = getCallPropsFromPost(post);
+
+            expect(props.recordings).toStrictEqual({
+                recA: {
+                    file_id: '',
+                    post_id: '',
+                },
+                45: {
+                    file_id: '',
+                    post_id: '',
+                },
+                recB: {
+                    file_id: 'recFileID',
+                    post_id: '',
+                },
+            });
+            expect(props.transcriptions).toStrictEqual({
+                trA: {
+                    file_id: '',
+                    post_id: '',
+                },
+                45: {
+                    file_id: '',
+                    post_id: '',
+                },
+                trB: {
+                    file_id: 'trFileID',
+                    post_id: '',
+                },
+            });
+        });
+
         test('full props', () => {
             const callProps = {
                 title: 'call title',
@@ -348,9 +414,9 @@ describe('utils', () => {
             expect(props.title).toBe(post.props.title);
             expect(props.start_at).toBe(post.props.start_at);
             expect(props.end_at).toBe(post.props.end_at);
-            expect(props.recordings).toBe(post.props.recordings);
+            expect(props.recordings).toStrictEqual(post.props.recordings);
             expect(props.recording_files).toBe(post.props.recording_files);
-            expect(props.transcriptions).toBe(post.props.transcriptions);
+            expect(props.transcriptions).toStrictEqual(post.props.transcriptions);
             expect(props.participants).toBe(post.props.participants);
         });
     });

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -1,5 +1,5 @@
 import {makeCallsBaseAndBadgeRGB, rgbToCSS} from '@mattermost/calls-common';
-import {CallPostProps, CallRecordingPostProps, SessionState, UserSessionState} from '@mattermost/calls-common/lib/types';
+import {CallJobMetadata, CallPostProps, CallRecordingPostProps, SessionState, UserSessionState} from '@mattermost/calls-common/lib/types';
 import {Channel} from '@mattermost/types/channels';
 import {ClientConfig} from '@mattermost/types/config';
 import {Post} from '@mattermost/types/posts';
@@ -579,13 +579,26 @@ function isValidObject(v: any) {
     return typeof v === 'object' && !Array.isArray(v) && v !== null;
 }
 
+function getJobMetadataMap(obj: {[key: string]: CallJobMetadata}) {
+    const out : {[key: string]: CallJobMetadata} = {};
+    for (const [key, value] of Object.entries(obj)) {
+        out[key] = {
+            file_id: typeof value?.file_id === 'string' ? value.file_id : '',
+            post_id: typeof value?.post_id === 'string' ? value.post_id : '',
+            ...(typeof value?.rec_id === 'string') && {rec_id: value.rec_id},
+            ...(typeof value?.tr_id === 'string') && {tr_id: value.tr_id},
+        };
+    }
+    return out;
+}
+
 export function getCallPropsFromPost(post: Post): CallPostProps {
     return {
         title: typeof post.props?.title === 'string' ? post.props.title : '',
         start_at: typeof post.props?.start_at === 'number' ? post.props.start_at : 0,
         end_at: typeof post.props?.end_at === 'number' ? post.props.end_at : 0,
-        recordings: isValidObject(post.props?.recordings) ? post.props.recordings : {},
-        transcriptions: isValidObject(post.props?.transcriptions) ? post.props.transcriptions : {},
+        recordings: isValidObject(post.props?.recordings) ? getJobMetadataMap(post.props.recordings) : {},
+        transcriptions: isValidObject(post.props?.transcriptions) ? getJobMetadataMap(post.props.transcriptions) : {},
         participants: Array.isArray(post.props?.participants) ? post.props.participants : [],
 
         // DEPRECATED


### PR DESCRIPTION
#### Summary

- Surfacing the presence of transcriptions (same as we do for recordings) in call root post.
- Added proper type validation of the job metadata object.
- Remove usage of deprecated `recording_files` prop. The `recordings` object should be used instead.

As a next step, I'll try looking into mobile since we don't have this UX feature on that side at all.

#### Screenshot

![image](https://github.com/user-attachments/assets/cbd67ec2-92e6-4dfa-abd3-1c03290a0d32)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61228