### PR TITLE
[MM-61298] Fix e2e pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -167,8 +167,7 @@ jobs:
         env:
           DOCKER_CLIENT_TIMEOUT: 120
           COMPOSE_HTTP_TIMEOUT: 120
-          ## Should relative to mattermost/server/build/
-          DOCKER_COMPOSE_FILE: gitlab-dc.postgres.yml
+          DOCKER_COMPOSE_FILE: ${{ github.workspace }}/e2e/docker/docker-compose.yaml
           TRANSCRIBER_IMAGE_PATH: ${{ github.workspace }}/calls-transcriber.tar
         run: |
           mkdir -p ${{ github.workspace }}/logs

--- a/e2e/docker/docker-compose.yaml
+++ b/e2e/docker/docker-compose.yaml
@@ -1,0 +1,35 @@
+version: '2.4'
+services:
+  postgres:
+    image: "postgres:11"
+    restart: always
+    tmpfs: /var/lib/postgresql/data
+    networks:
+      default:
+        aliases:
+          - postgres
+    environment:
+      POSTGRES_USER: mmuser
+      POSTGRES_PASSWORD: mostest
+      POSTGRES_DB: mattermost_test
+    command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'
+    volumes:
+     - "./postgres.conf:/etc/postgresql/postgresql.conf"
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-h", "localhost" ]
+      interval: 5s
+      timeout: 10s
+      retries: 3
+
+  start_dependencies:
+    image: mattermost/mattermost-wait-for-dep:latest
+    depends_on:
+      - postgres
+    command: postgres:5432
+    networks:
+      default:
+
+networks:
+  default:
+    name: ${DOCKER_NETWORK}
+    external: true

--- a/e2e/docker/postgres.conf
+++ b/e2e/docker/postgres.conf
@@ -1,0 +1,7 @@
+max_connections = 300
+listen_addresses = '*'
+fsync = off
+full_page_writes = off
+default_text_search_config = 'pg_catalog.english'
+commit_delay=1000
+logging_collector=off

--- a/e2e/scripts/prepare-server.sh
+++ b/e2e/scripts/prepare-server.sh
@@ -6,9 +6,8 @@ docker network create ${DOCKER_NETWORK}
 
 # Start server dependencies
 echo "Starting server dependencies ... "
-docker compose -f ${DOCKER_COMPOSE_FILE} run -d --rm start_dependencies
+DOCKER_NETWORK=${DOCKER_NETWORK} docker compose -f ${DOCKER_COMPOSE_FILE} run -d --rm start_dependencies
 timeout --foreground 90s bash -c "until docker compose -f ${DOCKER_COMPOSE_FILE} exec -T postgres pg_isready ; do sleep 5 ; done"
-docker compose -f ${DOCKER_COMPOSE_FILE} exec -d -T minio sh -c 'mkdir -p /data/mattermost-test'
 
 echo "Pulling ${IMAGE_CALLS_RECORDER} in order to be quickly accessible ... "
 # Pull calls-recorder image to be used by calls-offloader.

--- a/e2e/scripts/prepare-server.sh
+++ b/e2e/scripts/prepare-server.sh
@@ -39,6 +39,3 @@ docker run -d --quiet --user root --name "${COMPOSE_PROJECT_NAME}_callsoffloader
 
 # Check that calls-offloader is up and ready
 docker run --rm --quiet --name "${COMPOSE_PROJECT_NAME}_curl_callsoffloader" --net ${DOCKER_NETWORK} ${IMAGE_CURL} sh -c "until curl -fs http://calls-offloader:4545/version; do echo Waiting for calls-offloader; sleep 5; done; echo calls-offloader is up"
-
-# Check that elasticsearch is ready
-docker run --rm --quiet --name "${COMPOSE_PROJECT_NAME}_curl_elasticsearch" --net ${DOCKER_NETWORK} ${IMAGE_CURL} sh -c "until curl --max-time 5 --output - http://elasticsearch:9200; do echo Waiting for elasticsearch; sleep 5; done; echo elasticsearch is up"


### PR DESCRIPTION
#### Summary

Fixing the e2e pipeline. The only dependency we need is Postgres, so we can spin up that service by ourselves without relying on files from a different repo.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61298