### PR TITLE
[MM-61470] Fix rendering of AllowScreenSharing config setting

### DIFF
--- a/e2e/tests/admin_console.spec.ts
+++ b/e2e/tests/admin_console.spec.ts
@@ -78,5 +78,9 @@ test.describe('admin console', () => {
         // Check dropdown input
         await page.getByTestId('PluginSettings.Plugins.com+mattermost+calls.recordingqualitydropdown').selectOption('High');
         await expect(await resizeAndScreenshot(page, 'PluginSettings.Plugins.com+mattermost+calls.recordingquality')).toMatchSnapshot('calls-system-console-recording-quality.png');
+
+        // Ensure AllowScreenSharing defaults to true
+        await expect(page.getByTestId('PluginSettings.Plugins.com+mattermost+calls.allowscreensharingtrue')).toBeChecked();
+        await expect(page.getByTestId('PluginSettings.Plugins.com+mattermost+calls.allowscreensharingfalse')).not.toBeChecked();
     });
 });

--- a/webapp/src/components/admin_console_settings/allow_screen_sharing.tsx
+++ b/webapp/src/components/admin_console_settings/allow_screen_sharing.tsx
@@ -10,8 +10,9 @@ export default function AllowScreenSharing(props: CustomComponentProps) {
         props.onChange(props.id, e.target.value === 'true');
     };
 
+    // This setting has a default of true so we need to handle the unset case.
     // @ts-ignore val is a boolean, but the signature says 'string'. (being defensive here, just in case)
-    const checked = props.value === 'true' || props.value === true;
+    const checked = typeof props.value === 'undefined' || props.value === 'true' || props.value === true;
 
     return (
         <div


### PR DESCRIPTION
#### Summary

When the setting was missing (e.g. new installation), the admin console UI would incorrectly report it as disabled (false) since it was undefined. This could cause confusion, given the default on the server is true (screen sharing is allowed).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61470
