### PR TITLE
[MM-61555] Fix rendering issue with screen sharing player

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,7 +8,7 @@
         "@babel/core": "7.20.12",
         "@babel/eslint-parser": "7.19.1",
         "@mattermost/types": "6.7.0-0",
-        "@playwright/test": "^1.40.1",
+        "@playwright/test": "^1.48.2",
         "@types/node": "^20.10.4",
         "@typescript-eslint/eslint-plugin": "5.49.0",
         "eslint": "8.33.0",
@@ -753,18 +753,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
-      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
+      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.40.1"
+        "playwright": "1.48.2"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@types/eslint": {
@@ -2764,6 +2765,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3961,33 +3963,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
-      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
+      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.40.1"
+        "playwright-core": "1.48.2"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
-      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
+      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5397,12 +5401,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
-      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
+      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
       "dev": true,
       "requires": {
-        "playwright": "1.40.1"
+        "playwright": "1.48.2"
       }
     },
     "@types/eslint": {
@@ -7649,19 +7653,19 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
-      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
+      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.40.1"
+        "playwright-core": "1.48.2"
       }
     },
     "playwright-core": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
-      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
+      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
       "dev": true
     },
     "possible-typed-array-names": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
     "@babel/core": "7.20.12",
     "@babel/eslint-parser": "7.19.1",
     "@mattermost/types": "6.7.0-0",
-    "@playwright/test": "^1.40.1",
+    "@playwright/test": "^1.48.2",
     "@types/node": "^20.10.4",
     "@typescript-eslint/eslint-plugin": "5.49.0",
     "eslint": "8.33.0",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -52,6 +52,8 @@ const config: PlaywrightTestConfig = {
         {
             name: 'webkit',
         },
+
+        // NOTE: https://mattermost.atlassian.net/browse/MM-61558
         // {
         //     name: 'firefox',
         //     use: {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -30,6 +30,12 @@ const config: PlaywrightTestConfig = {
                 '--auto-select-desktop-capture-source="Entire screen"',
                 '--use-file-for-fake-audio-capture=./assets/sample.wav',
             ],
+            firefoxUserPrefs: {
+                'media.navigator.streams.fake': true,
+                'permissions.default.microphone': 1,
+                'permissions.default.camera': 1,
+                'media.navigator.permission.disabled': true,
+            },
         },
 
         // Unfortunately waitForFunction is flaky and randomly returns CSP failures.
@@ -46,6 +52,12 @@ const config: PlaywrightTestConfig = {
         {
             name: 'webkit',
         },
+        // {
+        //     name: 'firefox',
+        //     use: {
+        //         browserName: 'firefox',
+        //     },
+        // },
     ] : [
         {
             name: 'chromium',

--- a/e2e/tests/popout.spec.ts
+++ b/e2e/tests/popout.spec.ts
@@ -420,3 +420,43 @@ test.describe('popout window - reactions', () => {
         await expect(popOut.locator('#calls-popout-emoji-picker')).toBeHidden();
     });
 });
+
+test.describe('popout window - screen sharing', () => {
+    test.use({storageState: userStorages[0]});
+
+    test('player renders correctly', async ({page, context}) => {
+        const devPage = new PlaywrightDevPage(page);
+        await devPage.goto();
+        await devPage.startCall();
+
+        const [popOut] = await Promise.all([
+            context.waitForEvent('page'),
+            page.click('#calls-widget-expand-button'),
+        ]);
+
+        await expect(popOut.locator('#calls-expanded-view')).toBeVisible();
+
+        // Verify screen player is hidden
+        await expect(popOut.locator('#screen-player')).toBeHidden();
+
+        // Start screen sharing
+        await popOut.locator('#calls-popout-screenshare-button').click();
+
+        // Verify screen player is visible
+        await expect(popOut.locator('#screen-player')).toBeVisible();
+
+        // Verify the player is actually showing something
+        const box = await popOut.locator('#screen-player').boundingBox();
+        expect(box?.width).toBeGreaterThan(1000);
+        expect(box?.height).toBeGreaterThan(500);
+
+        // Stop screen sharing
+        await popOut.locator('#calls-popout-screenshare-button').click();
+
+        // Verify screen player is now hidden
+        await expect(popOut.locator('#screen-player')).toBeHidden();
+
+        // Leave call
+        await devPage.leaveCall();
+    });
+});

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -137,9 +137,10 @@ interface State {
 }
 
 const StyledMediaController = styled(MediaController)`
-    height: 100%;
     max-height: calc(100% - 32px);
     background-color: transparent;
+    margin-top: auto;
+    margin-bottom: auto;
 `;
 
 const StyledMediaControlBar = styled(MediaControlBar)`


### PR DESCRIPTION
#### Summary

This is most likely a CSS regression in Firefox (the way flexbox behaves with a child with 100% height). I was only able to reproduce on version 139 so far. Chrome works as expected.

That said, even the Chrome rendering wasn't great since it created an extra gap between the actual player content and the wrapper. This feels better now.

I added an e2e test and ran it on Firefox, but it didn't reproduce the issue since Playwright currently ships Firefox 131. Enabling the whole pipeline on Firefox requires far more work (tracking at https://mattermost.atlassian.net/browse/MM-61558).
 
#### Screenshots

*Before*

![2024-11-06-125509_2560x1080_scrot](https://github.com/user-attachments/assets/d70ba777-5cdd-495d-96bd-d34c25dfe905)

*After*

![2024-11-06-131235_2560x1080_scrot](https://github.com/user-attachments/assets/969e09c7-5b91-45ee-90bb-dc7e917959e5)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61555
