### PR TITLE
[MM-61538] Fix incoming call banner tooltip placement in global widget

### DIFF
--- a/webapp/src/components/incoming_calls/call_incoming_condensed.tsx
+++ b/webapp/src/components/incoming_calls/call_incoming_condensed.tsx
@@ -69,7 +69,7 @@ export const CallIncomingCondensed = ({call, onWidget = false, joinButtonBorder 
                     border={false}
                 />
                 <OverlayTrigger
-                    placement='top'
+                    placement={onWidget && window.desktop ? 'bottom' : 'top'}
                     overlay={
                         <Tooltip id='tooltip-invite-message'>
                             {tooltip}


### PR DESCRIPTION
#### Summary

Fixing a tooltip placement issue that caused it to be out of the bounds of our global widget window.

#### Screenshot

*Before*

![image](https://github.com/user-attachments/assets/d9a0eb8b-6dd0-45a2-8ffa-9e317ae32381)

*After*

![image](https://github.com/user-attachments/assets/498babc7-2f27-4b52-90cc-438a4a54c65e)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61538

