### PR TITLE
[MM-61786] Reduce number of open file descriptors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4
 	github.com/mattermost/morph v1.1.0
-	github.com/mattermost/rtcd v0.18.0
+	github.com/mattermost/rtcd v0.18.1-0.20241120195457-0b6a54eba853
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3
 	github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4
 	github.com/mattermost/morph v1.1.0
-	github.com/mattermost/rtcd v0.18.1-0.20241120195457-0b6a54eba853
+	github.com/mattermost/rtcd v0.18.1-0.20241122194949-fc76bf6a2f16
 	github.com/mattermost/squirrel v0.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rudderlabs/analytics-go v3.3.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,8 @@ github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef
 github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4/go.mod h1:PDPb/iqzJJ5ZvK/m70oDF55AXN/cOvVFj96Yu4e6j+Q=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
-github.com/mattermost/rtcd v0.18.1-0.20241120195457-0b6a54eba853 h1:hkrniAmKlKa46Y/BEkg7oZ3WRSVRMlAWczlMPY4Rcho=
-github.com/mattermost/rtcd v0.18.1-0.20241120195457-0b6a54eba853/go.mod h1:FVyFLa+7dWImCZ+0g9xoc/1fMRKMuXs6yAZP1mDKBIg=
+github.com/mattermost/rtcd v0.18.1-0.20241122194949-fc76bf6a2f16 h1:3LonE6UDF+GT4LjC1hqPL1xLBORoHdxeid1VNmmZkIE=
+github.com/mattermost/rtcd v0.18.1-0.20241122194949-fc76bf6a2f16/go.mod h1:FVyFLa+7dWImCZ+0g9xoc/1fMRKMuXs6yAZP1mDKBIg=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,8 @@ github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef
 github.com/mattermost/mattermost/server/public v0.1.5-0.20240613070149-4b0ae20ef7b4/go.mod h1:PDPb/iqzJJ5ZvK/m70oDF55AXN/cOvVFj96Yu4e6j+Q=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
-github.com/mattermost/rtcd v0.18.0 h1:Wxbl8r8cq8hD4ufg0XUGXM8lHPzxNW73fw4SngCuJ+A=
-github.com/mattermost/rtcd v0.18.0/go.mod h1:FVyFLa+7dWImCZ+0g9xoc/1fMRKMuXs6yAZP1mDKBIg=
+github.com/mattermost/rtcd v0.18.1-0.20241120195457-0b6a54eba853 h1:hkrniAmKlKa46Y/BEkg7oZ3WRSVRMlAWczlMPY4Rcho=
+github.com/mattermost/rtcd v0.18.1-0.20241120195457-0b6a54eba853/go.mod h1:FVyFLa+7dWImCZ+0g9xoc/1fMRKMuXs6yAZP1mDKBIg=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
 github.com/mattermost/squirrel v0.2.0/go.mod h1:NPPtk+CdpWre4GxMGoOpzEVFVc0ZoEFyJBZGCtn9nSU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -678,8 +679,9 @@ func TestHandleJoin(t *testing.T) {
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 	rtcServer, err := rtc.NewServer(rtc.ServerConfig{
-		ICEPortUDP: 33443,
-		ICEPortTCP: 33443,
+		ICEPortUDP:      33443,
+		ICEPortTCP:      33443,
+		UDPSocketsCount: runtime.NumCPU(),
 	}, newLogger(&p), p.metrics.RTCMetrics())
 	require.NoError(t, err)
 


### PR DESCRIPTION
#### Summary

Two changes on this side:

- Using the new `UDPSocketsCount` setting to limit the number of listening UDP sockets created by the embedded RTC server. In this mode, scaling isn't a goal, so we reduce them to NumCPU.
- I can't exactly recall what led to the existing activation sequence, but we'd be starting up the embedded RTC server regardless of whether RTCD is used. This seems wrong as it causes us to use unnecessary resources on the Mattermost side (e.g. opening sockets that will never be used).

#### Related PR

https://github.com/mattermost/rtcd/pull/162

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61786
