### PR TITLE
Don't initialize RTC server when using external rtcd service

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -156,50 +156,46 @@ func (p *Plugin) OnActivate() (retErr error) {
 		p.LogDebug("rtcd client manager initialized successfully")
 
 		p.rtcdManager = rtcdManager
+	} else {
+		rtcServerConfig := rtc.ServerConfig{
+			ICEAddressUDP:   cfg.UDPServerAddress,
+			ICEAddressTCP:   cfg.TCPServerAddress,
+			ICEPortUDP:      *cfg.UDPServerPort,
+			ICEPortTCP:      *cfg.TCPServerPort,
+			ICEHostOverride: cfg.ICEHostOverride,
+			ICEServers:      rtc.ICEServers(cfg.getICEServers(false)),
+			TURNConfig: rtc.TURNConfig{
+				CredentialsExpirationMinutes: *cfg.TURNCredentialsExpirationMinutes,
+			},
+			EnableIPv6: *cfg.EnableIPv6,
+		}
+		if *cfg.ServerSideTURN {
+			rtcServerConfig.TURNConfig.StaticAuthSecret = cfg.TURNStaticAuthSecret
+		}
+		if cfg.ICEHostPortOverride != nil {
+			rtcServerConfig.ICEHostPortOverride = rtc.ICEHostPortOverride(fmt.Sprintf("%d", *cfg.ICEHostPortOverride))
+		}
+		rtcServer, err := rtc.NewServer(rtcServerConfig, newLogger(p), p.metrics.RTCMetrics())
+		if err != nil {
+			p.LogError(err.Error())
+			return err
+		}
 
-		go p.clusterEventsHandler()
+		if err := rtcServer.Start(); err != nil {
+			p.LogError(err.Error())
+			return err
+		}
 
-		p.LogDebug("activated", "ClusterID", status.ClusterId)
+		p.rtcServer = rtcServer
 
-		return nil
-	}
-
-	rtcServerConfig := rtc.ServerConfig{
-		ICEAddressUDP:   cfg.UDPServerAddress,
-		ICEAddressTCP:   cfg.TCPServerAddress,
-		ICEPortUDP:      *cfg.UDPServerPort,
-		ICEPortTCP:      *cfg.TCPServerPort,
-		ICEHostOverride: cfg.ICEHostOverride,
-		ICEServers:      rtc.ICEServers(cfg.getICEServers(false)),
-		TURNConfig: rtc.TURNConfig{
-			CredentialsExpirationMinutes: *cfg.TURNCredentialsExpirationMinutes,
-		},
-		EnableIPv6: *cfg.EnableIPv6,
-	}
-	if *cfg.ServerSideTURN {
-		rtcServerConfig.TURNConfig.StaticAuthSecret = cfg.TURNStaticAuthSecret
-	}
-	if cfg.ICEHostPortOverride != nil {
-		rtcServerConfig.ICEHostPortOverride = rtc.ICEHostPortOverride(fmt.Sprintf("%d", *cfg.ICEHostPortOverride))
-	}
-	rtcServer, err := rtc.NewServer(rtcServerConfig, newLogger(p), p.metrics.RTCMetrics())
-	if err != nil {
-		p.LogError(err.Error())
-		return err
-	}
-
-	if err := rtcServer.Start(); err != nil {
-		p.LogError(err.Error())
-		return err
+		go p.wsWriter()
 	}
 
 	p.mut.Lock()
 	p.nodeID = status.ClusterId
-	p.rtcServer = rtcServer
 	p.mut.Unlock()
 
 	go p.clusterEventsHandler()
-	go p.wsWriter()
 
 	p.LogDebug("activated", "ClusterID", status.ClusterId)
 


### PR DESCRIPTION
#### Summary

Partially cherry-picking https://github.com/mattermost/mattermost-plugin-calls/pull/908 to include in a dot release (v0.29.5) since it was a bug to initialize the embedded RTC server when rtcd is in use.
