### PR TITLE
[MM-62064] Leave nodeID empty when using RTCD service

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -147,6 +147,10 @@ func (p *Plugin) OnActivate() (retErr error) {
 		}()
 	}
 
+	// rtcServer and rtcdManager are mutually exclusive throughout the entire lifetime of the plugin.
+	// Which one is used is decided here, during activation.
+	// We first check if RTCD is configured and allowed by the license. If so
+	// we try to initialize its connection and fail to start the plugin if that errors.
 	if rtcdURL := cfg.getRTCDURL(); rtcdURL != "" && p.licenseChecker.RTCDAllowed() {
 		rtcdManager, err := p.newRTCDClientManager(rtcdURL)
 		if err != nil {
@@ -189,15 +193,22 @@ func (p *Plugin) OnActivate() (retErr error) {
 			return err
 		}
 
+		// NodeID is set only when using the embedded service (no RTCD) since it's used to track which node is hosting
+		// a call and coordinate between nodes they may own the WS connection for other sessions in that same call.
+		// When RTCD is in place, there isn't a node hosting a call since this task is completely delegated to the RTCD side.
+		// Hence, in that case this field should be left empty.
+		p.nodeID = status.ClusterId
+
 		p.rtcServer = rtcServer
 
+		// The wsWriter routine is only necessary when running the embedded RTC server since
+		// it's a listener on rtcServer.ReceiveCh used to forward RTC messages (e.g. signaling)
+		// back to the client through the WS connection. The RTCD handler has a separate way to
+		// do this (see clientReader method).
 		go p.wsWriter()
 	}
 
-	p.mut.Lock()
-	p.nodeID = status.ClusterId
-	p.mut.Unlock()
-
+	// Cluster events need to be handled regardless of whether the embedded RTC service or RTCD are in use.
 	go p.clusterEventsHandler()
 
 	p.LogDebug("activated", "ClusterID", status.ClusterId)


### PR DESCRIPTION
#### Summary

This is slightly embarrassing. I introduced a regression in https://github.com/mattermost/mattermost-plugin-calls/pull/908 because I cannot read my own code. The second statement in that PR (that we'd be starting up the embedded RTC server regardless of whether RTCD is used) is wrong as [there was a `return` statement](https://github.com/mattermost/mattermost-plugin-calls/blob/dbd50f9953281824dd59fcc894d1efde8e4f2689/server/activate.go#L165) in the block so that change wasn't required at all.

And while making that change, I forgot the importance of setting `p.nodeID` , which should only be done when RTCD is not in use. 

Unfortunately, e2e tests couldn't spot this since they run in a non-HA (created https://mattermost.atlassian.net/browse/MM-62065). I ran some basic manual test in HA myself but didn't test multiple users joining a call.

In practice, this means we'll need to prepare a couple more dot releases (1.3.2 and 0.29.6) to remedy the previous mistake, along with backports to respective MM versions.

@DHaussermann For QA, I'd like to ensure we can connect at least a couple of people to the same call in a HA installation, and ensure they can communicate both ways. Repeating this a couple of times may be beneficial since it's always possible they'd connect to the same HA node which is a case not affected by the issue we are fixing here.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62064
