### PR TITLE
[MM-62178] Fix signaling after WS reconnect in non-RTCD HA

### DIFF
--- a/server/cluster_message.go
+++ b/server/cluster_message.go
@@ -13,7 +13,10 @@ import (
 )
 
 type clusterMessage struct {
-	ConnID        string           `json:"conn_id,omitempty"`
+	ConnID string `json:"conn_id,omitempty"`
+	// NewConnID is used by clusterMessageTypeReconnect to inform other nodes
+	// about the new WS connection ID in case it changed.
+	NewConnID     string           `json:"new_conn_id,omitempty"`
 	UserID        string           `json:"user_id,omitempty"`
 	ChannelID     string           `json:"channel_id,omitempty"`
 	CallID        string           `json:"call_id,omitempty"`


### PR DESCRIPTION
#### Summary

Our new HA-capable e2e tests have surfaced a bug causing signaling issues for sessions reconnecting in a non-RTCD HA deployment.

The optimal path would still be to pull the trigger on https://mattermost.atlassian.net/browse/MM-53376, but we'll have to defer it to the next major version bump (MM v11 / Calls v2).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62178