### PR TITLE
[MM-62090] Include rtcd service in e2e pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,53 @@ jobs:
           compression-level: 0
           retention-days: 1
 
+  build-rtcd-image:
+    runs-on: ubuntu-22.04
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    steps:
+      # Try to fetch branch that matches branch on plugin side.
+      - name: e2e/checkout-rtcd-repo
+        id: try-checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        continue-on-error: true
+        with:
+          repository: mattermost/rtcd
+          path: rtcd
+          ref: ${{  env.BRANCH_NAME  }}
+
+      # Fallback to default branch if the above is missing.
+      - name: e2e/checkout-rtcd-repo-fallback
+        if: steps.try-checkout.outcome == 'failure'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: mattermost/rtcd
+          path: rtcd
+
+      - name: e2e/setup-docker-buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: e2e/build-image
+        working-directory: ./rtcd
+        run: |
+          make docker-build CI=false
+          if [[ ${{steps.try-checkout.outcome}} == 'failure' ]]; then
+            RTCD_IMAGE="rtcd:master"
+          else
+            RTCD_IMAGE="rtcd:dev-$(git log --pretty=format:'%h' -n 1)"
+          fi
+          docker tag "${RTCD_IMAGE}" "rtcd:e2e"
+          docker save --output rtcd.tar "rtcd:e2e"
+
+      - name: e2e/persist-mattermost-rtcd-image
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          name: mattermost-rtcd-image
+          path: ${{ github.workspace }}/rtcd/rtcd.tar
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
   generate-matrix:
     runs-on: ubuntu-22.04
     outputs:
@@ -69,11 +116,13 @@ jobs:
     needs:
       - build-mattermost-plugin-calls
       - generate-matrix
+      - build-rtcd-image
     env:
       COMPOSE_PROJECT_NAME: playwright_tests
       DOCKER_NETWORK: playwright_tests
       CONTAINER_SERVER: playwright_tests_server
       CONTAINER_PROXY: playwright_tests_proxy
+      CONTAINER_RTCD: playwright_tests_rtcd
       IMAGE_CALLS_OFFLOADER: mattermost/calls-offloader:v0.8.0
       IMAGE_CALLS_RECORDER: mattermost/calls-recorder:v0.7.7
       IMAGE_CALLS_TRANSCRIBER: mattermost/calls-transcriber:v0.5.0
@@ -116,6 +165,12 @@ jobs:
           name: mattermost-plugin-calls-package
           path: dist
 
+      - name: e2e/download-rtcd-image
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: mattermost-rtcd-image
+          path: ${{ github.workspace }}
+
       - name: e2e/docker-login
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         # Do not authenticate on Forks
@@ -130,6 +185,7 @@ jobs:
           COMPOSE_HTTP_TIMEOUT: 120
           DOCKER_COMPOSE_FILE: ${{ github.workspace }}/e2e/docker/docker-compose.yaml
           MM_PLUGIN_CALLS_TEST_LICENSE: ${{ secrets.MM_PLUGIN_CALLS_TEST_LICENSE }}
+          RTCD_IMAGE_PATH: ${{ github.workspace }}/rtcd.tar
         run: |
           ${{ github.workspace }}/e2e/scripts/prepare-server.sh
 
@@ -148,6 +204,14 @@ jobs:
         run: |
           ${{ github.workspace }}/e2e/scripts/run.sh
 
+      - name: e2e/test-core
+        env:
+          WORKSPACE: ${{github.workspace}}
+          RUN_ID: ${{matrix.run_id}}
+        id: test-core
+        run: |
+          ${{ github.workspace }}/e2e/scripts/run-core.sh
+
       - name: e2e/persist-report-results
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
@@ -157,7 +221,7 @@ jobs:
           retention-days: 1
 
       - name: e2e/persist-report-logs
-        if: ${{ fromJson(steps.test.outputs.FAILURES) > 0 }}
+        if: ${{ (fromJson(steps.test.outputs.FAILURES) > 0) || (fromJson(steps.test-core.outputs.FAILURES) > 0) }}
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: e2e-playwright-logs-${{ matrix.run_id }}

--- a/e2e/config-patch-core.json
+++ b/e2e/config-patch-core.json
@@ -1,0 +1,9 @@
+{
+  "PluginSettings": {
+    "Plugins": {
+      "com.mattermost.calls": {
+        "rtcdserviceurl": ""
+      }
+    }
+  }
+}

--- a/e2e/scripts/merge-reports.js
+++ b/e2e/scripts/merge-reports.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 // Define the directory and pattern
 const directory = process.cwd();
-const pattern = /^playwright-report-\d+$/;
+const pattern = /^playwright-report-(core-)?\d+$/;
 
 // Function to filter directories based on the pattern
 function filterDirectories(item) {
@@ -23,11 +23,12 @@ fs.readdir(directory, (err, items) => {
   // List to store directory paths
   const inputReportPaths = matchedDirectories.map(item => `${directory}/${item}`);
 
+  console.log(items, matchedDirectories, inputReportPaths);
+
   const config = {
     outputFolderName: "merged-html-report", // default value
     outputBasePath: process.cwd() // default value
   }
 
   mergeHTMLReports(inputReportPaths, config);
-
 });

--- a/e2e/scripts/run-core.sh
+++ b/e2e/scripts/run-core.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+# Copy config patch into server container
+echo "Copying calls config patch into ${CONTAINER_SERVER}1 server container ..."
+docker cp e2e/config-patch-core.json ${CONTAINER_SERVER}1:/mattermost
+
+# Patch config. Needed to disable rtcd.
+echo "Patching calls config ..."
+docker exec \
+	${CONTAINER_SERVER}1 \
+	sh -c "/mattermost/bin/mmctl plugin disable com.mattermost.calls && sleep 2 && /mattermost/bin/mmctl config patch /mattermost/config-patch-core.json && sleep 2 && /mattermost/bin/mmctl plugin enable com.mattermost.calls"
+
+echo "Spawning playwright image ..."
+# run e2e
+# `--network=container` tells this container to share a network stack
+# with the proxy container. This means that `localhost` is the same
+# interface for both. That's relevant because some browser APIs
+# that Calls uses require a 'secure context', which is either HTTPS
+# or localhost.
+# https://docs.docker.com/engine/reference/run/#network-settings
+# https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
+docker run -d --name playwright-e2e-core \
+	--network=container:${CONTAINER_PROXY} \
+	--entrypoint "" \
+	mm-playwright \
+	bash -c "npm ci && npx playwright install && npx playwright test --grep @core --shard=${CI_NODE_INDEX}/${CI_NODE_TOTAL}"
+
+docker logs -f playwright-e2e-core
+
+docker cp playwright-e2e-core:/usr/src/calls-e2e/test-results results/test-results-core-${CI_NODE_INDEX}
+docker cp playwright-e2e-core:/usr/src/calls-e2e/playwright-report results/playwright-report-core-${CI_NODE_INDEX}
+docker cp playwright-e2e-core:/usr/src/calls-e2e/pw-results.json results/pw-results-core-${CI_NODE_INDEX}.json
+
+## Check if we have an early failures in order to upload logs
+NUM_FAILURES=0
+NUM_FAILURES=$((NUM_FAILURES + $(jq '.suites[].suites[].specs[].tests[] | last(.results[]) | select(.status != "passed").status' <"${WORKSPACE}/results/pw-results-core-${RUN_ID}.json" | wc -l)))
+echo "FAILURES=${NUM_FAILURES}" >>${GITHUB_OUTPUT}
+sudo chown -R 1001:1001 "${WORKSPACE}/logs"

--- a/e2e/scripts/run.sh
+++ b/e2e/scripts/run.sh
@@ -59,7 +59,7 @@ docker exec \
 echo "Spawning playwright image ..."
 # run e2e
 # `--network=container` tells this container to share a network stack
-# with the server container. This means that `localhost` is the same
+# with the proxy container. This means that `localhost` is the same
 # interface for both. That's relevant because some browser APIs
 # that Calls uses require a 'secure context', which is either HTTPS
 # or localhost.

--- a/e2e/tests/join_call.spec.ts
+++ b/e2e/tests/join_call.spec.ts
@@ -14,7 +14,9 @@ test.beforeEach(async ({page}) => {
 test.describe('join call', () => {
     test.use({storageState: userStorages[0]});
 
-    test('channel header button', async ({page}) => {
+    test('channel header button', {
+        tag: '@core',
+    }, async ({page}) => {
         // start a call
         const userPage = await startCall(userStorages[1]);
 
@@ -145,7 +147,9 @@ test.describe('join call', () => {
         await userADevPage.leaveCall();
     });
 
-    test('multiple sessions per user', async () => {
+    test('multiple sessions per user', {
+        tag: '@core',
+    }, async () => {
         test.setTimeout(200000);
 
         // start a call

--- a/e2e/tests/media.spec.ts
+++ b/e2e/tests/media.spec.ts
@@ -14,7 +14,9 @@ test.beforeEach(async ({page}) => {
 test.describe('screen sharing', () => {
     test.use({storageState: userStorages[0]});
 
-    test('share screen button', async ({page}) => {
+    test('share screen button', {
+        tag: '@core',
+    }, async ({page}) => {
         const userPage = await startCall(userStorages[1]);
 
         const devPage = new PlaywrightDevPage(page);
@@ -77,7 +79,9 @@ test.describe('screen sharing', () => {
         await userPage.leaveCall();
     });
 
-    test('presenter leaving and joining back', async ({page}) => {
+    test('presenter leaving and joining back', {
+        tag: '@core',
+    }, async ({page}) => {
         const userPage = await startCall(userStorages[1]);
 
         const devPage = new PlaywrightDevPage(page);
@@ -125,7 +129,9 @@ test.describe('screen sharing', () => {
         await userPage.leaveCall();
     });
 
-    test('av1', async ({page}) => {
+    test('av1', {
+        tag: '@core',
+    }, async ({page}) => {
         test.setTimeout(180000);
 
         // Enabling AV1
@@ -275,7 +281,9 @@ test.describe('screen sharing', () => {
 test.describe('sending voice', () => {
     test.use({storageState: userStorages[0]});
 
-    test('unmuting', async ({page}) => {
+    test('unmuting', {
+        tag: '@core',
+    }, async ({page}) => {
         const userPage = await startCall(userStorages[1]);
 
         const devPage = new PlaywrightDevPage(page);
@@ -307,7 +315,9 @@ test.describe('sending voice', () => {
         await userPage.leaveCall();
     });
 
-    test('unmuting after ws reconnect', async ({page}) => {
+    test('unmuting after ws reconnect', {
+        tag: '@core',
+    }, async ({page}) => {
         const userPage = await startCall(userStorages[1]);
 
         const devPage = new PlaywrightDevPage(page);

--- a/e2e/tests/recordings.spec.ts
+++ b/e2e/tests/recordings.spec.ts
@@ -31,7 +31,9 @@ test.describe('call recordings, transcriptions, live-captions', () => {
         }
     });
 
-    test('slash command, popout + buttons', async ({page, context, request}) => {
+    test('slash command, popout + buttons', {
+        tag: '@core',
+    }, async ({page, context, request}) => {
         await apiSetEnableTranscriptions(false);
 
         // start call


### PR DESCRIPTION
#### Summary

PR adds `rtcd` support to our e2e pipeline. The rtcd image is dynamically built from a matching branch name (if it exists) or `master` as fallback. This will help with running the entire pipeline against specific changes on the other side.

I am also tagging a subset of tests to execute in plugin mode (i.e. without rtcd service). These should be fairly quick and will run in addition to the above and help to avoid a potential blind spot.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62090
