### PR TITLE
Add commit satus write permission to E2E report

### DIFF
--- a/.github/workflows/generate-e2e-report.yml
+++ b/.github/workflows/generate-e2e-report.yml
@@ -76,6 +76,8 @@ jobs:
           echo "You can find the report [here](${{ steps.stats.outputs.S3_REPORT }})" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: e2e-report/send-success-status
+        permissions:
+          statuses: write
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
         with:
           script: |

--- a/.github/workflows/generate-e2e-report.yml
+++ b/.github/workflows/generate-e2e-report.yml
@@ -13,6 +13,8 @@ jobs:
   generate-report:
     runs-on: ubuntu-22.04
     if: github.repository_owner == 'mattermost' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+          statuses: write
     steps:
       - name: e2e-report/checkout-mattermost-plugin-calls-repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -76,8 +78,6 @@ jobs:
           echo "You can find the report [here](${{ steps.stats.outputs.S3_REPORT }})" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: e2e-report/send-success-status
-        permissions:
-          statuses: write
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
         with:
           script: |


### PR DESCRIPTION
#### Summary

Restore permission to write commit status checks to the E2E reporting workflow.

Example job failure: https://github.com/mattermost/mattermost-plugin-calls/actions/runs/12787003506/job/35645267076#step:7:24