### PR TITLE
Bump Postgres to v13

### DIFF
--- a/e2e/docker/docker-compose.yaml
+++ b/e2e/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   postgres:
-    image: "postgres:11"
+    image: "postgres:13"
     restart: always
     tmpfs: /var/lib/postgresql/data
     networks:

--- a/server/testutils/containers.go
+++ b/server/testutils/containers.go
@@ -21,7 +21,7 @@ const (
 	DBPass         = "mostest"
 	DBNetworkAlias = "db"
 
-	PostgresImage = "postgres:11"
+	PostgresImage = "postgres:13"
 	PostgrePort   = 5432
 
 	MySQLImage = "mysql/mysql-server:8.0.32"


### PR DESCRIPTION
#### Summary

Updating the testing pipelines to use the new version.

Relates to https://github.com/mattermost/mattermost/pull/30039

