### PR TITLE
Fix self join sound in case of multi sessions

### DIFF
--- a/webapp/src/websocket_handlers.ts
+++ b/webapp/src/websocket_handlers.ts
@@ -87,6 +87,7 @@ import {Store} from './types/mattermost-webapp';
 import {
     followThread,
     getCallsClient,
+    getCallsClientSessionID,
     getUserDisplayName,
     notificationsStopRinging,
     playSound,
@@ -179,9 +180,9 @@ export function handleUserJoined(store: Store, ev: WebSocketMessage<UserJoinedDa
     const sessionID = ev.data.session_id;
 
     if (window.callsClient?.channelID === channelID) {
-        if (userID === currentUserID) {
+        if (sessionID === getCallsClientSessionID()) {
             playSound('join_self');
-        } else if (shouldPlayJoinUserSound(store.getState())) {
+        } else if (userID !== currentUserID && shouldPlayJoinUserSound(store.getState())) {
             playSound('join_user');
         }
     }


### PR DESCRIPTION
#### Summary

Joining from both mobile web today, I realized that on web, you get the "self joined" sound when connecting from mobile, which is weird. We should check against the session ID to be more precise rather than user ID.

