### PR TITLE
[MM-63373] Replace usage of `SELECT *`

### DIFF
--- a/server/db/calls_channels_store.go
+++ b/server/db/calls_channels_store.go
@@ -14,6 +14,8 @@ import (
 	sq "github.com/mattermost/squirrel"
 )
 
+var callsChannelsColumns = []string{"ChannelID", "Enabled", "Props"}
+
 func (s *Store) CreateCallsChannel(channel *public.CallsChannel) error {
 	s.metrics.IncStoreOp("CreateCallsChannel")
 	defer func(start time.Time) {
@@ -26,7 +28,7 @@ func (s *Store) CreateCallsChannel(channel *public.CallsChannel) error {
 
 	qb := getQueryBuilder(s.driverName).
 		Insert("calls_channels").
-		Columns("ChannelID", "Enabled", "Props").
+		Columns(callsChannelsColumns...).
 		Values(channel.ChannelID, channel.Enabled, s.newJSONValueWrapper(channel.Props))
 
 	q, args, err := qb.ToSql()
@@ -50,7 +52,7 @@ func (s *Store) GetCallsChannel(channelID string, opts GetCallsChannelOpts) (*pu
 		s.metrics.ObserveStoreMethodsTime("GetCallsChannel", time.Since(start).Seconds())
 	}(time.Now())
 
-	qb := getQueryBuilder(s.driverName).Select("*").
+	qb := getQueryBuilder(s.driverName).Select(callsChannelsColumns...).
 		From("calls_channels").
 		Where(sq.Eq{"ChannelID": channelID})
 
@@ -80,7 +82,7 @@ func (s *Store) GetAllCallsChannels(opts GetCallsChannelOpts) ([]*public.CallsCh
 	// TODO: consider implementing paging
 	// This should be fine for now as we wouldn't expect to have more than a few
 	// channels with calls explicitly enabled/disabled.
-	qb := getQueryBuilder(s.driverName).Select("*").From("calls_channels")
+	qb := getQueryBuilder(s.driverName).Select(callsChannelsColumns...).From("calls_channels")
 
 	q, args, err := qb.ToSql()
 	if err != nil {

--- a/server/db/calls_jobs_store.go
+++ b/server/db/calls_jobs_store.go
@@ -14,6 +14,8 @@ import (
 	sq "github.com/mattermost/squirrel"
 )
 
+var callsJobsColumns = []string{"ID", "CallID", "Type", "CreatorID", "InitAt", "StartAt", "EndAt", "Props"}
+
 func (s *Store) CreateCallJob(job *public.CallJob) error {
 	s.metrics.IncStoreOp("CreateCallJob")
 	defer func(start time.Time) {
@@ -26,7 +28,7 @@ func (s *Store) CreateCallJob(job *public.CallJob) error {
 
 	qb := getQueryBuilder(s.driverName).
 		Insert("calls_jobs").
-		Columns("ID", "CallID", "Type", "CreatorID", "InitAt", "StartAt", "EndAt", "Props").
+		Columns(callsJobsColumns...).
 		Values(job.ID, job.CallID, job.Type, job.CreatorID, job.InitAt, job.StartAt, job.EndAt, s.newJSONValueWrapper(job.Props))
 
 	q, args, err := qb.ToSql()
@@ -82,7 +84,7 @@ func (s *Store) GetCallJob(id string, opts GetCallJobOpts) (*public.CallJob, err
 		s.metrics.ObserveStoreMethodsTime("GetCallJob", time.Since(start).Seconds())
 	}(time.Now())
 
-	qb := getQueryBuilder(s.driverName).Select("*").
+	qb := getQueryBuilder(s.driverName).Select(callsJobsColumns...).
 		From("calls_jobs").
 		Where(sq.Eq{"ID": id})
 
@@ -113,7 +115,7 @@ func (s *Store) GetActiveCallJobs(callID string, opts GetCallJobOpts) (map[publi
 		s.metrics.ObserveStoreMethodsTime("GetActiveCallJobs", time.Since(start).Seconds())
 	}(time.Now())
 
-	qb := getQueryBuilder(s.driverName).Select("*").
+	qb := getQueryBuilder(s.driverName).Select(callsJobsColumns...).
 		From("calls_jobs").
 		Where(sq.And{
 			sq.Eq{"CallID": callID},

--- a/server/db/calls_sessions_store.go
+++ b/server/db/calls_sessions_store.go
@@ -14,6 +14,8 @@ import (
 	sq "github.com/mattermost/squirrel"
 )
 
+var callsSessionsColumns = []string{"ID", "CallID", "UserID", "JoinAt", "Unmuted", "RaisedHand"}
+
 func (s *Store) CreateCallSession(session *public.CallSession) error {
 	s.metrics.IncStoreOp("CreateCallSession")
 	defer func(start time.Time) {
@@ -26,7 +28,7 @@ func (s *Store) CreateCallSession(session *public.CallSession) error {
 
 	qb := getQueryBuilder(s.driverName).
 		Insert("calls_sessions").
-		Columns("ID", "CallID", "UserID", "JoinAt", "Unmuted", "RaisedHand").
+		Columns(callsSessionsColumns...).
 		Values(session.ID, session.CallID, session.UserID, session.JoinAt, session.Unmuted, session.RaisedHand)
 
 	q, args, err := qb.ToSql()
@@ -106,7 +108,7 @@ func (s *Store) GetCallSession(id string, opts GetCallSessionOpts) (*public.Call
 		s.metrics.ObserveStoreMethodsTime("GetCallSession", time.Since(start).Seconds())
 	}(time.Now())
 
-	qb := getQueryBuilder(s.driverName).Select("*").
+	qb := getQueryBuilder(s.driverName).Select(callsSessionsColumns...).
 		From("calls_sessions").
 		Where(sq.Eq{"ID": id})
 
@@ -133,7 +135,7 @@ func (s *Store) GetCallSessions(callID string, opts GetCallSessionOpts) (map[str
 		s.metrics.ObserveStoreMethodsTime("GetCallSessions", time.Since(start).Seconds())
 	}(time.Now())
 
-	qb := getQueryBuilder(s.driverName).Select("*").
+	qb := getQueryBuilder(s.driverName).Select("ID", "CallID", "UserID", "JoinAt", "Unmuted", "RaisedHand").
 		From("calls_sessions").
 		Where(sq.Eq{"CallID": callID})
 

--- a/server/db/calls_store.go
+++ b/server/db/calls_store.go
@@ -158,7 +158,7 @@ func (s *Store) GetCall(callID string, opts GetCallOpts) (*public.Call, error) {
 		s.metrics.ObserveStoreMethodsTime("GetCall", time.Since(start).Seconds())
 	}(time.Now())
 
-	qb := getQueryBuilder(s.driverName).Select("*").
+	qb := getQueryBuilder(s.driverName).Select(callsColumns...).
 		From("calls").
 		Where(sq.Eq{"ID": callID})
 
@@ -218,7 +218,7 @@ func (s *Store) GetActiveCallByChannelID(channelID string, opts GetCallOpts) (*p
 		s.metrics.ObserveStoreMethodsTime("GetActiveCallByChannelID", time.Since(start).Seconds())
 	}(time.Now())
 
-	qb := getQueryBuilder(s.driverName).Select("*").
+	qb := getQueryBuilder(s.driverName).Select(callsColumns...).
 		From("calls").
 		Where(
 			sq.And{
@@ -252,7 +252,7 @@ func (s *Store) GetAllActiveCalls(opts GetCallOpts) ([]*public.Call, error) {
 		s.metrics.ObserveStoreMethodsTime("GetAllActiveCalls", time.Since(start).Seconds())
 	}(time.Now())
 
-	qb := getQueryBuilder(s.driverName).Select("*").
+	qb := getQueryBuilder(s.driverName).Select(callsColumns...).
 		From("calls").
 		Where(
 			sq.And{

--- a/server/db/misc_store.go
+++ b/server/db/misc_store.go
@@ -14,6 +14,12 @@ import (
 	sq "github.com/mattermost/squirrel"
 )
 
+var postColumns = []string{
+	"Id", "CreateAt", "UpdateAt", "EditAt", "DeleteAt",
+	"IsPinned", "UserId", "ChannelId", "RootId", "OriginalId",
+	"Message", "Type", "Props", "Hashtags", "Filenames", "FileIds", "HasReactions", "RemoteId",
+}
+
 func (s *Store) KVGet(pluginID, key string, fromWriter bool) ([]byte, error) {
 	s.metrics.IncStoreOp("KVGet")
 	defer func(start time.Time) {
@@ -58,7 +64,7 @@ func (s *Store) GetPost(postID string) (*model.Post, error) {
 	}(time.Now())
 
 	qb := getQueryBuilder(s.driverName).
-		Select("*").
+		Select(postColumns...).
 		From("Posts").
 		Where(sq.Eq{"Id": postID})
 	q, args, err := qb.ToSql()


### PR DESCRIPTION
#### Summary

When reverting from the video branch, everything broke down. This is because `SELECT *` is not backward compatible in case a new column is added.

Tests were Aider-generated, which I reviewed.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63373

