### PR TITLE
[MM-63889] Add backend version check to enable DC locking

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -26,10 +26,16 @@ import (
 const requestBodyMaxSizeBytes = 1024 * 1024 // 1MB
 
 func (p *Plugin) handleGetVersion(w http.ResponseWriter, _ *http.Request) {
-	info := map[string]interface{}{
-		"version": manifest.Version,
-		"build":   buildHash,
+	p.mut.RLock()
+	defer p.mut.RUnlock()
+
+	info := public.VersionInfo{
+		Version:     manifest.Version,
+		Build:       buildHash,
+		RTCDVersion: p.rtcdVersionInfo.BuildVersion,
+		RTCDBuild:   p.rtcdVersionInfo.BuildHash,
 	}
+
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(info); err != nil {
 		p.LogError(err.Error())

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-calls/server/interfaces"
 	"github.com/mattermost/mattermost-plugin-calls/server/telemetry"
 
+	rtcd "github.com/mattermost/rtcd/service"
 	"github.com/mattermost/rtcd/service/rtc"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -55,8 +56,9 @@ type Plugin struct {
 	clusterEvCh chan model.PluginClusterEvent
 	sessions    map[string]*session
 
-	rtcServer   *rtc.Server
-	rtcdManager *rtcdClientManager
+	rtcServer       *rtc.Server
+	rtcdManager     *rtcdClientManager
+	rtcdVersionInfo rtcd.VersionInfo
 
 	jobService *jobService
 

--- a/server/public/version.go
+++ b/server/public/version.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package public
+
+type VersionInfo struct {
+	Version     string `json:"version"`
+	Build       string `json:"build"`
+	RTCDVersion string `json:"rtcd_version,omitempty"`
+	RTCDBuild   string `json:"rtcd_build,omitempty"`
+}

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@mattermost/calls-common": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
+        "@mattermost/calls-common": "github:mattermost/calls-common#02b04117fcec88f158d3d9ba62546d8d942ed647",
         "@mattermost/compass-icons": "0.1.31",
         "@msgpack/msgpack": "2.7.1",
         "bootstrap": "3.4.1",
@@ -3089,8 +3089,8 @@
     },
     "node_modules/@mattermost/calls-common": {
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#d8e1c317584077d0ebc5e159477eb533d610ee08",
-      "integrity": "sha512-KuQuj/ln09tUvsfZRvcObgm1tmhqvn51BA4ZQ59rPYyGgX+hkW3aA/w1BvufmFEeZpXAEeGaiAtVW8CQu6qHSg==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#02b04117fcec88f158d3d9ba62546d8d942ed647",
+      "integrity": "sha512-jHlw8b8k0LrOyAzh/6cSnTg3GHL3yJEZhtNhjvvfEnmxso2CzproEX7juzATtMy0Z1NXOLgdBrn/M0naPxJqgA==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
         "fflate": "0.8.2",

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@mattermost/calls-common": "github:mattermost/calls-common#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
+        "@mattermost/calls-common": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
         "@mattermost/compass-icons": "0.1.31",
         "@msgpack/msgpack": "2.7.1",
         "bootstrap": "3.4.1",
@@ -3089,11 +3089,12 @@
     },
     "node_modules/@mattermost/calls-common": {
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
-      "integrity": "sha512-Wj2fclEcPVWYtX7WdrMOaLHXS2AP3y2x8Py9FqHyhoNNY9yUg+ihocUKDKpRwqfu1qM/R02Y26d/g6Mc4+yddg==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#d8e1c317584077d0ebc5e159477eb533d610ee08",
+      "integrity": "sha512-KuQuj/ln09tUvsfZRvcObgm1tmhqvn51BA4ZQ59rPYyGgX+hkW3aA/w1BvufmFEeZpXAEeGaiAtVW8CQu6qHSg==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
-        "fflate": "0.8.2"
+        "fflate": "0.8.2",
+        "semver": "7.7.1"
       }
     },
     "node_modules/@mattermost/calls-common/node_modules/@msgpack/msgpack": {
@@ -3102,6 +3103,18 @@
       "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@mattermost/calls-common/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@mattermost/client": {

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -18,7 +18,7 @@
     "extract": "formatjs extract 'src/**/*.{ts,tsx}' --ignore 'src/**/*.d.ts' --out-file i18n/temp.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' && formatjs compile 'i18n/temp.json' --out-file i18n/en.json && rm i18n/temp.json"
   },
   "dependencies": {
-    "@mattermost/calls-common": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
+    "@mattermost/calls-common": "github:mattermost/calls-common#02b04117fcec88f158d3d9ba62546d8d942ed647",
     "@mattermost/compass-icons": "0.1.31",
     "@msgpack/msgpack": "2.7.1",
     "bootstrap": "3.4.1",

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -18,7 +18,7 @@
     "extract": "formatjs extract 'src/**/*.{ts,tsx}' --ignore 'src/**/*.d.ts' --out-file i18n/temp.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' && formatjs compile 'i18n/temp.json' --out-file i18n/en.json && rm i18n/temp.json"
   },
   "dependencies": {
-    "@mattermost/calls-common": "github:mattermost/calls-common#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
+    "@mattermost/calls-common": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
     "@mattermost/compass-icons": "0.1.31",
     "@msgpack/msgpack": "2.7.1",
     "bootstrap": "3.4.1",

--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -31,6 +31,7 @@ import {
     UserVoiceOnOffData,
     WebsocketEventData,
 } from '@mattermost/calls-common/lib/types';
+import {hasDCSignalingLockSupport} from '@mattermost/calls-common/lib/utils';
 import {WebSocketMessage} from '@mattermost/client/websocket';
 import type {DesktopAPI} from '@mattermost/desktop-api';
 import {setServerVersion} from 'mattermost-redux/actions/general';
@@ -40,7 +41,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme, Theme} from 'mattermost-redux/selectors/entities/preferences';
 import configureStore from 'mattermost-redux/store';
 import {ActionFuncAsync} from 'mattermost-redux/types/actions';
-import {getCallActive, getCallsConfig, localSessionClose, setClientConnecting} from 'plugin/actions';
+import {getCallActive, getCallsConfig, getCallsVersionInfo, localSessionClose, setClientConnecting} from 'plugin/actions';
 import CallsClient from 'plugin/client';
 import {
     logDebug,
@@ -49,7 +50,7 @@ import {
 import {pluginId} from 'plugin/manifest';
 import reducer from 'plugin/reducers';
 import RestClient from 'plugin/rest_client';
-import {callsConfig, iceServers, needsTURNCredentials} from 'plugin/selectors';
+import {callsConfig, callsVersionInfo, iceServers, needsTURNCredentials} from 'plugin/selectors';
 import {DesktopNotificationArgs, Store, WebAppUtils} from 'plugin/types/mattermost-webapp';
 import {
     getPluginPath,
@@ -213,6 +214,7 @@ export default async function init(cfg: InitConfig) {
     try {
         [, active] = await Promise.all([
             store.dispatch(getCallsConfig()),
+            store.dispatch(getCallsVersionInfo()),
             getCallActive(channelID),
         ]);
     } catch (err) {
@@ -236,6 +238,7 @@ export default async function init(cfg: InitConfig) {
         simulcast: callsConfig(store.getState()).EnableSimulcast,
         enableAV1: callsConfig(store.getState()).EnableAV1,
         dcSignaling: callsConfig(store.getState()).EnableDCSignaling,
+        dcLocking: hasDCSignalingLockSupport(callsVersionInfo(store.getState())),
     };
 
     connectCall(joinData, clientConfig, (ev) => {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "0.26.12",
-        "@mattermost/calls-common": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
+        "@mattermost/calls-common": "github:mattermost/calls-common#02b04117fcec88f158d3d9ba62546d8d942ed647",
         "@msgpack/msgpack": "2.7.1",
         "@redux-devtools/extension": "3.2.3",
         "core-js": "3.26.1",
@@ -8240,8 +8240,8 @@
     },
     "node_modules/@mattermost/calls-common": {
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#d8e1c317584077d0ebc5e159477eb533d610ee08",
-      "integrity": "sha512-KuQuj/ln09tUvsfZRvcObgm1tmhqvn51BA4ZQ59rPYyGgX+hkW3aA/w1BvufmFEeZpXAEeGaiAtVW8CQu6qHSg==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#02b04117fcec88f158d3d9ba62546d8d942ed647",
+      "integrity": "sha512-jHlw8b8k0LrOyAzh/6cSnTg3GHL3yJEZhtNhjvvfEnmxso2CzproEX7juzATtMy0Z1NXOLgdBrn/M0naPxJqgA==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
         "fflate": "0.8.2",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "0.26.12",
-        "@mattermost/calls-common": "github:mattermost/calls-common#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
+        "@mattermost/calls-common": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
         "@msgpack/msgpack": "2.7.1",
         "@redux-devtools/extension": "3.2.3",
         "core-js": "3.26.1",
@@ -8240,11 +8240,12 @@
     },
     "node_modules/@mattermost/calls-common": {
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
-      "integrity": "sha512-Wj2fclEcPVWYtX7WdrMOaLHXS2AP3y2x8Py9FqHyhoNNY9yUg+ihocUKDKpRwqfu1qM/R02Y26d/g6Mc4+yddg==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#d8e1c317584077d0ebc5e159477eb533d610ee08",
+      "integrity": "sha512-KuQuj/ln09tUvsfZRvcObgm1tmhqvn51BA4ZQ59rPYyGgX+hkW3aA/w1BvufmFEeZpXAEeGaiAtVW8CQu6qHSg==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
-        "fflate": "0.8.2"
+        "fflate": "0.8.2",
+        "semver": "7.7.1"
       }
     },
     "node_modules/@mattermost/calls-common/node_modules/@msgpack/msgpack": {
@@ -8253,6 +8254,18 @@
       "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@mattermost/calls-common/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@mattermost/client": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "0.26.12",
-    "@mattermost/calls-common": "github:mattermost/calls-common#fe9b2e74328facc46c2d9e3729ec3a9704d7c618",
+    "@mattermost/calls-common": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
     "@msgpack/msgpack": "2.7.1",
     "@redux-devtools/extension": "3.2.3",
     "core-js": "3.26.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "0.26.12",
-    "@mattermost/calls-common": "github:mattermost/calls-common#d8e1c317584077d0ebc5e159477eb533d610ee08",
+    "@mattermost/calls-common": "github:mattermost/calls-common#02b04117fcec88f158d3d9ba62546d8d942ed647",
     "@msgpack/msgpack": "2.7.1",
     "@redux-devtools/extension": "3.2.3",
     "core-js": "3.26.1",

--- a/webapp/src/action_types.ts
+++ b/webapp/src/action_types.ts
@@ -46,6 +46,7 @@ export const DID_NOTIFY_FOR_CALL = pluginId + '_did_notify_for_call';
 export const CALL_END = pluginId + '_call_end';
 
 export const RECEIVED_CALLS_CONFIG = pluginId + '_received_calls_config';
+export const RECEIVED_CALLS_VERSION_INFO = pluginId + '_received_calls_version_info';
 export const RECORDINGS_ENABLED = pluginId + '_recordings_enabled';
 export const TRANSCRIPTIONS_ENABLED = pluginId + '_transcriptions_enabled';
 export const LIVE_CAPTIONS_ENABLED = pluginId + '_live_captions_enabled';

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 /* eslint-disable max-lines */
-import {CallsConfig, CallState} from '@mattermost/calls-common/lib/types';
+import {CallsConfig, CallState, CallsVersionInfo} from '@mattermost/calls-common/lib/types';
 import {ClientError} from '@mattermost/client';
 import {Channel} from '@mattermost/types/channels';
 import {UserTypes} from 'mattermost-redux/action_types';
@@ -65,6 +65,7 @@ import {
     LIVE_CAPTIONS_ENABLED,
     LOCAL_SESSION_CLOSE,
     RECEIVED_CALLS_CONFIG,
+    RECEIVED_CALLS_VERSION_INFO,
     RECORDINGS_ENABLED,
     REMOVE_INCOMING_CALL,
     RINGING_FOR_CALL,
@@ -125,6 +126,16 @@ export const getCallsConfig = (): ActionFuncAsync<CallsConfig> => {
             {method: 'get'},
         ),
         onSuccess: [RECEIVED_CALLS_CONFIG],
+    });
+};
+
+export const getCallsVersionInfo = (): ActionFuncAsync<CallsVersionInfo> => {
+    return bindClientFunc({
+        clientFunc: () => RestClient.fetch<CallsVersionInfo>(
+            `${getPluginPath()}/version`,
+            {method: 'get'},
+        ),
+        onSuccess: [RECEIVED_CALLS_VERSION_INFO],
     });
 };
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -348,6 +348,7 @@ export default class CallsClient extends EventEmitter {
                 },
                 simulcast: this.config.simulcast,
                 dcSignaling: this.config.dcSignaling,
+                dcLocking: this.config.dcLocking,
             });
 
             this.peer = peer;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -3,6 +3,7 @@
 
 /* eslint-disable max-lines */
 import {CallChannelState} from '@mattermost/calls-common/lib/types';
+import {hasDCSignalingLockSupport} from '@mattermost/calls-common/lib/utils';
 import WebSocketClient from '@mattermost/client/websocket';
 import type {DesktopAPI} from '@mattermost/desktop-api';
 import {PluginAnalyticsRow} from '@mattermost/types/admin';
@@ -25,6 +26,7 @@ import {
     displayFreeTrial,
     getCallsConfig,
     getCallsStats,
+    getCallsVersionInfo,
     incomingCallOnChannel,
     loadProfilesByIdsIfMissing,
     localSessionClose,
@@ -132,6 +134,7 @@ import {
     callsExplicitlyDisabled,
     callsExplicitlyEnabled,
     callStartAtForCallInChannel,
+    callsVersionInfo,
     channelHasCall,
     channelIDForCurrentCall,
     defaultEnabled,
@@ -665,6 +668,7 @@ export default class Plugin {
                     simulcast: callsConfig(state).EnableSimulcast,
                     enableAV1: callsConfig(state).EnableAV1,
                     dcSignaling: callsConfig(state).EnableDCSignaling,
+                    dcLocking: hasDCSignalingLockSupport(callsVersionInfo(state)),
                 });
                 window.currentCallData = CurrentCallDataDefault;
 
@@ -944,7 +948,7 @@ export default class Plugin {
 
             unsubscribeActivateListener();
 
-            await store.dispatch(getCallsConfig());
+            await Promise.all([store.dispatch(getCallsConfig()), store.dispatch(getCallsVersionInfo())]);
 
             // We don't care about fetching other calls states in pop out.
             // Current call state will be requested over websocket

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 /* eslint-disable max-lines */
-import {CallJobState, CallsConfig, LiveCaption, Reaction, UserSessionState} from '@mattermost/calls-common/lib/types';
+import {CallJobState, CallsConfig, CallsVersionInfo, LiveCaption, Reaction, UserSessionState} from '@mattermost/calls-common/lib/types';
 import {combineReducers} from 'redux';
 import {MAX_NUM_REACTIONS_IN_REACTION_STREAM} from 'src/constants';
 import {
@@ -41,6 +41,7 @@ import {
     LOCAL_SESSION_CLOSE,
     RECEIVED_CALLS_CONFIG,
     RECEIVED_CALLS_USER_PREFERENCES,
+    RECEIVED_CALLS_VERSION_INFO,
     RECEIVED_CHANNEL_STATE,
     RECORDINGS_ENABLED,
     REMOVE_INCOMING_CALL,
@@ -783,6 +784,15 @@ const callsConfig = (state = CallsConfigDefault, action: { type: string, data: C
     }
 };
 
+const callsVersionInfo = (state = {}, action: { type: string, data: CallsVersionInfo }) => {
+    switch (action.type) {
+    case RECEIVED_CALLS_VERSION_INFO:
+        return action.data;
+    default:
+        return state;
+    }
+};
+
 const rtcdEnabled = (state = false, action: {type: string, data: boolean}) => {
     switch (action.type) {
     case RTCD_ENABLED:
@@ -1004,6 +1014,7 @@ export default combineReducers({
     switchCallModal,
     screenSourceModal,
     callsConfig,
+    callsVersionInfo,
     rtcdEnabled,
     callsUserPreferences,
     recordings,

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {CallsConfig, Reaction, UserSessionState} from '@mattermost/calls-common/lib/types';
+import {CallsConfig, CallsVersionInfo, Reaction, UserSessionState} from '@mattermost/calls-common/lib/types';
 import {Channel} from '@mattermost/types/channels';
 import {GlobalState} from '@mattermost/types/store';
 import {Team} from '@mattermost/types/teams';
@@ -634,3 +634,6 @@ export const screenSourceModal = (state: GlobalState) => {
 export const clientConnecting = (state: GlobalState) => {
     return pluginState(state).clientConnecting;
 };
+
+export const callsVersionInfo = (state: GlobalState): CallsVersionInfo =>
+    pluginState(state).callsVersionInfo;

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -37,6 +37,7 @@ export type CallsClientConfig = {
     simulcast?: boolean;
     enableAV1: boolean;
     dcSignaling: boolean;
+    dcLocking: boolean;
 }
 
 export type AudioDevices = {


### PR DESCRIPTION
#### Summary

We expose RTCD versioning info on top of the existing plugin version/build pair. We then use this information to detect whether we can safely use the new DC locking functionality.

A test plan for both backward and forward compatibility is attached to the JIRA ticket.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63889

