### PR TITLE
[MM-64390] Safely access `window.opener` in cross-origin contexes

### DIFF
--- a/webapp/src/browser_routing.ts
+++ b/webapp/src/browser_routing.ts
@@ -9,7 +9,7 @@ import {getWebappUtils} from './utils';
 const WebappUtils = getWebappUtils();
 
 export const navigateToURL = (urlPath: string) => {
-    WebappUtils.browserHistory.push(urlPath);
+    WebappUtils?.browserHistory.push(urlPath);
 };
 
 export const handleFormattedTextClick = (e: React.MouseEvent<HTMLElement, MouseEvent>, url: string) => {

--- a/webapp/src/components/custom_post_types/post_type/component.tsx
+++ b/webapp/src/components/custom_post_types/post_type/component.tsx
@@ -24,6 +24,7 @@ import {idForCallInChannel} from 'src/selectors';
 import {
     callStartedTimestampFn,
     getCallPropsFromPost,
+    getCallsClient,
     getUserDisplayName,
     toHuman,
     untranslatable,
@@ -69,8 +70,7 @@ const PostType = ({
     }, [intl, callProps.start_at]);
 
     const onLeaveButtonClick = () => {
-        const win = window.opener || window;
-        const callsClient = win.callsClient;
+        const callsClient = getCallsClient();
         if (callsClient) {
             // NOTE: this also handles the desktop global widget case since the opener window
             // will have the client.

--- a/webapp/src/components/switch_call_modal/component.tsx
+++ b/webapp/src/components/switch_call_modal/component.tsx
@@ -8,7 +8,7 @@ import {UserProfile} from '@mattermost/types/users';
 import React, {CSSProperties} from 'react';
 import {IntlShape} from 'react-intl';
 import CompassIcon from 'src/components/icons/compassIcon';
-import {getUserDisplayName, isDMChannel, isGMChannel, untranslatable} from 'src/utils';
+import {getCallsWindow, getUserDisplayName, isDMChannel, isGMChannel, untranslatable} from 'src/utils';
 
 interface Props {
     intl: IntlShape,
@@ -102,7 +102,7 @@ export default class SwitchCallModal extends React.PureComponent<Props> {
         this.props.dismissIncomingCallNotification(this.props.targetChannelID, this.props.targetCallID);
 
         this.props.hideSwitchCallModal();
-        const win = window.opener ? window.opener : window;
+        const win = getCallsWindow();
         win.callsClient?.disconnect();
         win.postMessage({type: 'connectCall', channelID: this.props.currentChannel?.id}, win.origin);
     };

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1043,7 +1043,7 @@ export default class Plugin {
             switch (keyToAction('global', ev)) {
             case JOIN_CALL:
                 // We don't allow joining a new call from the pop-out window.
-                if (!window.opener) {
+                if (!isCallsPopOut()) {
                     joinCall(getCurrentChannelId(store.getState()), getCurrentTeamId(store.getState()));
                 }
                 break;

--- a/webapp/src/slash_commands.tsx
+++ b/webapp/src/slash_commands.tsx
@@ -35,7 +35,7 @@ import {
     isRecordingInCurrentCall,
 } from './selectors';
 import {Store} from './types/mattermost-webapp';
-import {getCallsClient, getPersistentStorage, isDMChannel, sendDesktopEvent, shouldRenderDesktopWidget} from './utils';
+import {getCallsClient, getCallsWindow, getPersistentStorage, isDMChannel, sendDesktopEvent, shouldRenderDesktopWidget} from './utils';
 
 type joinCallFn = (channelId: string, teamId?: string, title?: string, rootId?: string) => void;
 
@@ -116,7 +116,7 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
     }
     case 'leave':
         if (connectedID && args.channel_id === connectedID) {
-            const win = window.opener || window;
+            const win = getCallsWindow();
             const callsClient = getCallsClient();
             if (callsClient) {
                 callsClient.disconnect();

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -125,4 +125,5 @@ export type WebAppUtils = {
     notificationSounds: { ring: (sound: string) => void, stopRing: () => void },
     sendDesktopNotificationToMe: (title: string, body: string, channel: Channel, teamId: string, silent: boolean, soundName: string, url: string) => (dispatch: DispatchFunc) => void,
     openUserSettings: (dialogProps: {activeTab: string, isContentProductSettings: boolean}) => ActionFuncAsync;
+    browserHistory: ReturnType<typeof getHistory>;
 };

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -12,6 +12,7 @@ import {
     getCallPropsFromPost,
     getCallRecordingPropsFromPost,
     getCallsClient,
+    getCallsWindow,
     getWebappUtils,
     getWSConnectionURL,
     maxAttemptsReachedErr,
@@ -481,6 +482,35 @@ describe('utils', () => {
             expect(props.call_post_id).toBe(recProps.call_post_id);
             expect(props.recording_id).toBe(recProps.recording_id);
             expect(props.captions).toBe(recProps.captions);
+        });
+    });
+
+    describe('getCallsWindow', () => {
+        test('basic', () => {
+            const win = getCallsWindow();
+            expect(win).toBe(window);
+        });
+
+        test('opener', () => {
+            window.opener = {
+                callsClient: true,
+            };
+
+            const win = getCallsWindow();
+            expect(win).toBe(window.opener);
+        });
+
+        test('permission error on opener', () => {
+            Object.defineProperty(window, 'opener', {
+                get() {
+                    throw new Error('Permission denied to access property "window"');
+                },
+            });
+
+            const win = getCallsWindow();
+            expect(win).toBe(window);
+
+            delete window.opener;
         });
     });
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -85,7 +85,7 @@ export function getChannelURL(state: GlobalState, channel?: Channel, teamId?: st
 export function getCallsClient(): CallsClient | undefined {
     let callsClient;
     try {
-        callsClient = window.opener ? window.opener.callsClient : window.callsClient;
+        callsClient = getCallsWindow().callsClient;
     } catch (err) {
         logErr(err);
     }
@@ -108,19 +108,36 @@ export function isCallsPopOut(): boolean {
     try {
         return window.opener && window.opener.callsClient;
     } catch (err) {
-        logErr(err);
+        // This can happen if the MM window already has an opener on a different origin (e.g. user clicked a link on a calendar app to open MM).
+        // In this case, we know we are not in the expanded view so we can directly return window.callsClient.
+        logWarn(err);
+
         return false;
     }
     return false;
 }
 
+export function getCallsWindow(): Window {
+    try {
+        if (window.opener && window.opener.callsClient) {
+            return window.opener;
+        }
+    } catch (err) {
+        // This can happen if the MM window already has an opener on a different origin (e.g. user clicked a link on a calendar app to open MM).
+        // In this case, we know we are not in the expanded view so we can directly return window.callsClient.
+        logWarn(err);
+    }
+
+    return window;
+}
+
 export function shouldRenderCallsIncoming() {
     try {
-        const win = window.opener ? window.opener : window;
+        const win = getCallsWindow();
         const nonChannels = window.location.pathname.startsWith('/boards') || window.location.pathname.startsWith('/playbooks') || window.location.pathname.includes(`${pluginId}/expanded/`);
         if (win.desktop && nonChannels) {
-        // don't render when we're in desktop, or in boards or playbooks, or in the expanded view.
-        // (can be simplified, but this is clearer)
+            // don't render when we're in desktop, or in boards or playbooks, or in the expanded view.
+            // (can be simplified, but this is clearer)
             return false;
         }
         return true;
@@ -396,7 +413,7 @@ export function shouldRenderDesktopWidget() {
 }
 
 export function desktopGTE(major: number, minor: number) {
-    const win = window.opener ? window.opener : window;
+    const win = getCallsWindow();
     if (!win.desktop) {
         return false;
     }
@@ -412,7 +429,7 @@ export function desktopGTE(major: number, minor: number) {
 
 // DEPRECATED: legacy Desktop API logic (<= 5.6.0)
 export function sendDesktopEvent(event: string, data?: Record<string, unknown>) {
-    const win = window.opener ? window.opener : window;
+    const win = getCallsWindow();
     win.postMessage(
         {
             type: event,
@@ -617,11 +634,10 @@ export function getCallRecordingPropsFromPost(post: Post): CallRecordingPostProp
 export function getWebappUtils() {
     let utils;
     try {
-        utils = window.opener ? window.opener.WebappUtils : window.WebappUtils;
+        utils = getCallsWindow().WebappUtils;
     } catch (err) {
         logErr(err);
     }
-
     return utils;
 }
 

--- a/webapp/src/webapp_globals.ts
+++ b/webapp/src/webapp_globals.ts
@@ -9,6 +9,7 @@ export const {
     modals,
     notificationSounds,
     sendDesktopNotificationToMe,
+    browserHistory,
 }: WebAppUtils =
 
 // @ts-ignore


### PR DESCRIPTION
#### Summary

It's possible that the main Mattermost view already has `window.opener` set. This can happen when clicking a link to the MM instance that doesn't set [`noopener`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noopener) or [`noreferrer`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noreferrer), from a calendar app, for example (how we reproduced this).

When this happens, there are two problems:

1. `window.opener` won't be a good way to determine whether we are in the pop-up window anymore.
2. The opener could be on a different origin which would cause a security error when accessing it (i.e., `window.opener.callsClient` will throw). 

PR adds some guards to handle this case while also limiting the places that rely on `window.opener` directly.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64390