### PR TITLE
Fetch config env overrides only if admin

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -954,7 +954,12 @@ export default class Plugin {
 
             unsubscribeActivateListener();
 
-            await Promise.all([store.dispatch(getCallsConfig()), store.dispatch(getCallsVersionInfo()), store.dispatch(getCallsConfigEnvOverrides())]);
+            const requests = [store.dispatch(getCallsConfig()), store.dispatch(getCallsVersionInfo())];
+            if (isCurrentUserSystemAdmin(store.getState())) {
+                requests.push(store.dispatch(getCallsConfigEnvOverrides()));
+            }
+
+            await Promise.all(requests);
 
             // We don't care about fetching other calls states in pop out.
             // Current call state will be requested over websocket


### PR DESCRIPTION
#### Summary

Just noticed we'd make the call to fetch env config overrides from non-admin clients, which would fail with 403.