### PR TITLE
[MM-64539] Implement simple ping mechanism in WebSocket client

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1107,6 +1107,11 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 	var msg clientMessage
 	msg.Type = strings.TrimPrefix(req.Action, wsActionPrefix)
 
+	// This is the standard ping message handled by Mattermost server. Nothing to do here.
+	if msg.Type == "ping" {
+		return
+	}
+
 	p.mut.RLock()
 	us := p.sessions[connID]
 	p.mut.RUnlock()

--- a/webapp/src/websocket.test.ts
+++ b/webapp/src/websocket.test.ts
@@ -219,7 +219,7 @@ describe('WebSocketClient', () => {
 
             // Verify waitingForPong state is cleared
             expect((client as any).waitingForPong).toBe(false);
-            expect((client as any).pendingPingSeq).toBe(0);
+            expect((client as any).expectedPongSeqNo).toBe(0);
         });
 
         it('should emit join event for plugin join messages', () => {
@@ -332,7 +332,7 @@ describe('WebSocketClient', () => {
 
             // Verify we're waiting for pong with seq 1
             expect((client as any).waitingForPong).toBe(true);
-            expect((client as any).pendingPingSeq).toBe(1);
+            expect((client as any).expectedPongSeqNo).toBe(1);
 
             // Simulate pong response with wrong seq_reply
             const wrongPongMessage = {
@@ -345,7 +345,7 @@ describe('WebSocketClient', () => {
 
             // Should still be waiting for correct pong
             expect((client as any).waitingForPong).toBe(true);
-            expect((client as any).pendingPingSeq).toBe(1);
+            expect((client as any).expectedPongSeqNo).toBe(1);
         });
 
         it('should send ping at regular intervals', () => {
@@ -362,9 +362,9 @@ describe('WebSocketClient', () => {
             // Trigger next ping.
             jest.advanceTimersByTime(5000);
 
-            // Verify pendingPingSeq is set
+            // Verify expectedPongSeqNo is set
             expect((client as any).waitingForPong).toBe(true);
-            expect((client as any).pendingPingSeq).toBe(2);
+            expect((client as any).expectedPongSeqNo).toBe(2);
         });
 
         it('should reconnect on ping timeout', () => {
@@ -476,7 +476,7 @@ describe('WebSocketClient', () => {
             expect((client as any).connID).toBe('');
             expect((client as any).originalConnID).toBe('');
             expect((client as any).closed).toBe(true);
-            expect((client as any).pendingPingSeq).toBe(0);
+            expect((client as any).expectedPongSeqNo).toBe(0);
         });
 
         it('should not attempt reconnection when closed', () => {

--- a/webapp/src/websocket.test.ts
+++ b/webapp/src/websocket.test.ts
@@ -1,0 +1,467 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {WebSocketClient, WebSocketErrorType} from './websocket';
+
+// Mock the log functions
+jest.mock('./log', () => ({
+    logDebug: jest.fn(),
+    logErr: jest.fn(),
+    logInfo: jest.fn(),
+    logWarn: jest.fn(),
+}));
+
+// Mock the manifest
+jest.mock('./manifest', () => ({
+    pluginId: 'com.mattermost.calls',
+}));
+
+// Mock WebSocket
+class MockWebSocket {
+    public readyState: number = WebSocket.CONNECTING;
+    public onopen: ((event: Event) => void) | null = null;
+    public onclose: ((event: CloseEvent) => void) | null = null;
+    public onerror: ((event: Event) => void) | null = null;
+    public onmessage: ((event: MessageEvent) => void) | null = null;
+    public url: string;
+
+    constructor(url: string) {
+        this.url = url;
+
+        // Simulate async connection
+        setTimeout(() => {
+            this.readyState = WebSocket.OPEN;
+            if (this.onopen) {
+                this.onopen(new Event('open'));
+            }
+        }, 0);
+    }
+
+    send(_: string | ArrayBuffer) {
+        // Mock send implementation
+    }
+
+    close() {
+        this.readyState = WebSocket.CLOSED;
+        if (this.onclose) {
+            this.onclose(new CloseEvent('close', {code: 1000}));
+        }
+    }
+}
+
+// Replace global WebSocket with mock
+(global as any).WebSocket = MockWebSocket;
+(global as any).WebSocket.CONNECTING = 0;
+(global as any).WebSocket.OPEN = 1;
+(global as any).WebSocket.CLOSING = 2;
+(global as any).WebSocket.CLOSED = 3;
+
+describe('WebSocketClient', () => {
+    let client: WebSocketClient;
+    let mockWebSocket: MockWebSocket;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+        client = new WebSocketClient('ws://test.com', 'test-token');
+
+        // Get reference to the mock WebSocket instance
+        mockWebSocket = (client as any).ws;
+    });
+
+    afterEach(() => {
+        client.close();
+        jest.useRealTimers();
+    });
+
+    describe('constructor', () => {
+        it('should initialize with correct URL and token', () => {
+            expect(mockWebSocket.url).toContain('ws://test.com');
+            expect(mockWebSocket.url).toContain('connection_id=');
+            expect(mockWebSocket.url).toContain('sequence_number=0');
+        });
+
+        it('should set up event listeners', () => {
+            expect(mockWebSocket.onopen).toBeDefined();
+            expect(mockWebSocket.onclose).toBeDefined();
+            expect(mockWebSocket.onerror).toBeDefined();
+            expect(mockWebSocket.onmessage).toBeDefined();
+        });
+    });
+
+    describe('connection handling', () => {
+        it('should send authentication challenge on open when token provided', () => {
+            client = new WebSocketClient('ws://test.com', 'test-token');
+            mockWebSocket = (client as any).ws;
+
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+
+            // Trigger onopen
+            mockWebSocket.onopen!(new Event('open'));
+
+            expect(sendSpy).toHaveBeenCalledWith(
+                JSON.stringify({
+                    action: 'authentication_challenge',
+                    seq: 1,
+                    data: {token: 'test-token'},
+                }),
+            );
+        });
+
+        it('should start ping interval on open', () => {
+            client = new WebSocketClient('ws://test.com');
+            mockWebSocket = (client as any).ws;
+
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+
+            mockWebSocket.readyState = WebSocket.OPEN;
+            mockWebSocket.onopen!(new Event('open'));
+
+            // Initial ping.
+            expect(sendSpy).toHaveBeenCalledWith(JSON.stringify({
+                action: 'ping',
+                seq: 1,
+            }));
+
+            // Fast-forward to trigger ping interval.
+            jest.advanceTimersByTime(5000);
+
+            expect(sendSpy).toHaveBeenCalledWith(JSON.stringify({
+                action: 'ping',
+                seq: 2,
+            }));
+        });
+
+        it('should emit open event on successful connection', () => {
+            client = new WebSocketClient('ws://test.com');
+            mockWebSocket = (client as any).ws;
+
+            const openSpy = jest.fn();
+            client.on('open', openSpy);
+
+            // Simulate hello message
+            const helloMessage = {
+                event: 'hello',
+                data: {connection_id: 'test-conn-id'},
+                seq: 1,
+            };
+
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(helloMessage),
+            }));
+
+            expect(openSpy).toHaveBeenCalledWith('test-conn-id', 'test-conn-id', false);
+        });
+    });
+
+    describe('message handling', () => {
+        beforeEach(() => {
+            // Set up connection
+            const helloMessage = {
+                event: 'hello',
+                data: {connection_id: 'test-conn-id'},
+                seq: 1,
+            };
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(helloMessage),
+            }));
+        });
+
+        it('should handle valid JSON messages', () => {
+            const eventSpy = jest.fn();
+            client.on('event', eventSpy);
+
+            const testMessage = {
+                event: 'test_event',
+                data: {test: 'data'},
+                seq: 2,
+            };
+
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(testMessage),
+            }));
+
+            expect(eventSpy).toHaveBeenCalledWith(testMessage);
+        });
+
+        it('should ignore invalid JSON messages', () => {
+            const eventSpy = jest.fn();
+            client.on('event', eventSpy);
+
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: 'invalid json',
+            }));
+
+            expect(eventSpy).not.toHaveBeenCalled();
+        });
+
+        it('should handle pong responses', () => {
+            // Trigger ping
+            mockWebSocket.onopen!(new Event('open'));
+            jest.advanceTimersByTime(5000);
+
+            // Simulate pong response
+            const pongMessage = {
+                seq_reply: 2,
+            };
+
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(pongMessage),
+            }));
+
+            // Should not emit event for pong
+            const eventSpy = jest.fn();
+            client.on('event', eventSpy);
+            expect(eventSpy).not.toHaveBeenCalled();
+        });
+
+        it('should emit join event for plugin join messages', () => {
+            const joinSpy = jest.fn();
+            client.on('join', joinSpy);
+
+            const joinMessage = {
+                event: 'custom_com.mattermost.calls_join',
+                data: {connID: 'test-conn-id'},
+                seq: 2,
+            };
+
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(joinMessage),
+            }));
+
+            expect(joinSpy).toHaveBeenCalled();
+        });
+
+        it('should emit error for plugin error messages', () => {
+            const errorSpy = jest.fn();
+            client.on('error', errorSpy);
+
+            const errorMessage = {
+                event: 'custom_com.mattermost.calls_error',
+                data: {data: 'test error', connID: 'test-conn-id'},
+                seq: 2,
+            };
+
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(errorMessage),
+            }));
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: WebSocketErrorType.Join,
+                    message: 'test error',
+                }),
+            );
+        });
+
+        it('should emit message for plugin signal messages', () => {
+            const messageSpy = jest.fn();
+            client.on('message', messageSpy);
+
+            const signalMessage = {
+                event: 'custom_com.mattermost.calls_signal',
+                data: {test: 'signal data', connID: 'test-conn-id'},
+                seq: 2,
+            };
+
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(signalMessage),
+            }));
+
+            expect(messageSpy).toHaveBeenCalledWith({test: 'signal data', connID: 'test-conn-id'});
+        });
+    });
+
+    describe('sending messages', () => {
+        beforeEach(() => {
+            // Set up connection
+            mockWebSocket.readyState = WebSocket.OPEN;
+            const helloMessage = {
+                event: 'hello',
+                data: {connection_id: 'test-conn-id'},
+                seq: 1,
+            };
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(helloMessage),
+            }));
+        });
+
+        it('should send JSON messages when connection is open', () => {
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+
+            client.send('test_action', {test: 'data'});
+
+            expect(sendSpy).toHaveBeenCalledWith('{"action":"custom_com.mattermost.calls_test_action","seq":1,"data":{"test":"data"}}');
+        });
+
+        it('should send binary messages when binary flag is true', () => {
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+
+            client.send('test_action', {test: 'data'}, true);
+
+            expect(sendSpy).toHaveBeenCalledWith(expect.any(Uint8Array));
+        });
+
+        it('should not send when connection is not open', () => {
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+            mockWebSocket.readyState = WebSocket.CONNECTING;
+
+            client.send('test_action', {test: 'data'});
+
+            expect(sendSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('ping/pong handling', () => {
+        beforeEach(() => {
+            mockWebSocket.readyState = WebSocket.OPEN;
+        });
+
+        it('should send ping at regular intervals', () => {
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+
+            mockWebSocket.onopen!(new Event('open'));
+
+            // Clear initial ping
+            sendSpy.mockClear();
+
+            jest.advanceTimersByTime(5000);
+
+            expect(sendSpy).toHaveBeenCalledWith(
+                JSON.stringify({
+                    action: 'ping',
+                    seq: 4,
+                }),
+            );
+        });
+
+        it('should reconnect on ping timeout', () => {
+            const closeSpy = jest.spyOn(mockWebSocket, 'close');
+
+            mockWebSocket.onopen!(new Event('open'));
+
+            // Trigger first ping
+            jest.advanceTimersByTime(5000);
+
+            // Trigger second ping without pong response (timeout)
+            jest.advanceTimersByTime(5000);
+
+            expect(closeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('reconnection logic', () => {
+        it('should attempt reconnection on close', () => {
+            const initSpy = jest.spyOn(client as any, 'init');
+
+            mockWebSocket.onclose!(new CloseEvent('close', {code: 1000}));
+
+            jest.advanceTimersByTime(1000);
+
+            expect(initSpy).toHaveBeenCalledWith(true);
+        });
+
+        it('should increase retry time on subsequent reconnections', () => {
+            const initSpy = jest.spyOn(client as any, 'init');
+
+            // First reconnection
+            mockWebSocket.onclose!(new CloseEvent('close', {code: 1000}));
+            jest.advanceTimersByTime(1000);
+            expect(initSpy).toHaveBeenCalledTimes(1);
+
+            // Second reconnection should take longer
+            mockWebSocket.onclose!(new CloseEvent('close', {code: 1000}));
+            jest.advanceTimersByTime(1000);
+            expect(initSpy).toHaveBeenCalledTimes(1); // Should not have been called yet
+
+            jest.advanceTimersByTime(500);
+            expect(initSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('should emit error on reconnection timeout', () => {
+            const errorSpy = jest.fn();
+            client.on('error', errorSpy);
+
+            // Set last disconnect time to simulate timeout
+            (client as any).lastDisconnect = Date.now() - 31000; // 31 seconds ago
+
+            client.reconnect();
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: WebSocketErrorType.ReconnectTimeout,
+                }),
+            );
+        });
+    });
+
+    describe('error handling', () => {
+        it('should emit error on WebSocket error', () => {
+            const errorSpy = jest.fn();
+            client.on('error', errorSpy);
+
+            mockWebSocket.onerror!(new Event('error'));
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: WebSocketErrorType.Native,
+                }),
+            );
+        });
+    });
+
+    describe('cleanup', () => {
+        it('should clean up resources on close', () => {
+            const removeAllListenersSpy = jest.spyOn(client, 'removeAllListeners');
+            const closeSpy = jest.spyOn(mockWebSocket, 'close');
+
+            client.close();
+
+            expect(closeSpy).toHaveBeenCalled();
+            expect(removeAllListenersSpy).toHaveBeenCalledWith('open');
+            expect(removeAllListenersSpy).toHaveBeenCalledWith('event');
+            expect(removeAllListenersSpy).toHaveBeenCalledWith('join');
+            expect(removeAllListenersSpy).toHaveBeenCalledWith('close');
+            expect(removeAllListenersSpy).toHaveBeenCalledWith('error');
+            expect(removeAllListenersSpy).toHaveBeenCalledWith('message');
+        });
+
+        it('should reset internal state on close', () => {
+            client.close();
+
+            expect((client as any).ws).toBeNull();
+            expect((client as any).seqNo).toBe(1);
+            expect((client as any).serverSeqNo).toBe(0);
+            expect((client as any).connID).toBe('');
+            expect((client as any).originalConnID).toBe('');
+            expect((client as any).closed).toBe(true);
+        });
+
+        it('should not attempt reconnection when closed', () => {
+            const initSpy = jest.spyOn(client as any, 'init');
+
+            client.close();
+            mockWebSocket.onclose!(new CloseEvent('close', {code: 1000}));
+
+            jest.advanceTimersByTime(5000);
+
+            expect(initSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getOriginalConnID', () => {
+        it('should return the original connection ID', () => {
+            // Set up connection
+            const helloMessage = {
+                event: 'hello',
+                data: {connection_id: 'test-conn-id'},
+                seq: 1,
+            };
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify(helloMessage),
+            }));
+
+            expect(client.getOriginalConnID()).toBe('test-conn-id');
+        });
+    });
+});

--- a/webapp/src/websocket.ts
+++ b/webapp/src/websocket.ts
@@ -10,6 +10,7 @@ import {pluginId} from './manifest';
 const wsMinReconnectRetryTimeMs = 1000; // 1 second
 const wsReconnectionTimeout = 30000; // 30 seconds
 const wsReconnectTimeIncrement = 500; // 0.5 seconds
+const wsPingIntervalMs = 5000; // 5 seconds
 
 export enum WebSocketErrorType {
     Native,
@@ -42,6 +43,8 @@ export class WebSocketClient extends EventEmitter {
     private lastDisconnect = 0;
     private reconnectRetryTime = wsMinReconnectRetryTimeMs;
     private closed = false;
+    private pingInterval: ReturnType<typeof setInterval> | null = null;
+    private waitingForPong = false;
 
     constructor(wsURL: string, authToken?: string) {
         super();
@@ -67,23 +70,24 @@ export class WebSocketClient extends EventEmitter {
                 }));
             }
             if (isReconnect) {
-                logDebug('ws: reconnected');
+                logDebug('ws: reconnected', this.originalConnID, this.connID);
                 this.lastDisconnect = 0;
                 this.reconnectRetryTime = wsMinReconnectRetryTimeMs;
                 this.emit('open', this.originalConnID, this.connID, true);
             }
+
+            // Send initial ping.
+            this.ping();
+
+            // Start ping interval
+            this.startPingInterval();
         };
 
         this.ws.onerror = () => {
             this.emit('error', new WebSocketError(WebSocketErrorType.Native, 'websocket error'));
         };
 
-        this.ws.onclose = ({code}) => {
-            this.emit('close', code);
-            if (!this.closed) {
-                this.reconnect();
-            }
-        };
+        this.ws.onclose = this.closeHandler;
 
         this.ws.onmessage = ({data}) => {
             if (!data) {
@@ -97,6 +101,12 @@ export class WebSocketClient extends EventEmitter {
                 return;
             }
 
+            // Handle pong response
+            if (msg?.seq_reply && this.waitingForPong) {
+                this.waitingForPong = false;
+                return;
+            }
+
             if (msg) {
                 this.serverSeqNo = msg.seq + 1;
             }
@@ -107,11 +117,11 @@ export class WebSocketClient extends EventEmitter {
 
             if (msg.event === 'hello') {
                 if (msg.data.connection_id !== this.connID) {
-                    logDebug('ws: new conn id from server');
+                    logDebug('ws: new conn id from server', msg.data.connection_id);
                     this.connID = msg.data.connection_id;
                     this.serverSeqNo = 0;
                     if (this.originalConnID === '') {
-                        logDebug('ws: setting original conn id');
+                        logDebug('ws: setting original conn id', this.connID);
                         this.originalConnID = this.connID;
                     }
 
@@ -146,6 +156,14 @@ export class WebSocketClient extends EventEmitter {
         };
     }
 
+    private closeHandler = (ev: CloseEvent) => {
+        this.stopPingInterval();
+        this.emit('close', ev.code);
+        if (!this.closed) {
+            this.reconnect();
+        }
+    };
+
     send(action: string, data?: Record<string, unknown>, binary?: boolean) {
         const msg = {
             action: `${this.eventPrefix}_${action}`,
@@ -165,6 +183,7 @@ export class WebSocketClient extends EventEmitter {
 
     close() {
         this.closed = true;
+        this.stopPingInterval();
         this.ws?.close();
         this.ws = null;
         this.seqNo = 1;
@@ -194,7 +213,7 @@ export class WebSocketClient extends EventEmitter {
 
         setTimeout(() => {
             if (!this.closed) {
-                logInfo('ws: reconnecting');
+                logInfo('ws: reconnecting', this.originalConnID);
                 this.init(true);
             }
         }, this.reconnectRetryTime);
@@ -204,5 +223,43 @@ export class WebSocketClient extends EventEmitter {
 
     getOriginalConnID() {
         return this.originalConnID;
+    }
+
+    private startPingInterval() {
+        this.stopPingInterval();
+        this.pingInterval = setInterval(() => {
+            if (this.waitingForPong && this.ws) {
+                logWarn('ws: ping timeout, reconnecting', this.originalConnID);
+                this.stopPingInterval();
+
+                // We call the close handler directly since through ws.close() it could execute after a significant delay.
+                this.ws.onclose = null;
+                this.ws.close();
+                this.closeHandler(new CloseEvent('close', {
+                    code: 4000,
+                }));
+
+                return;
+            }
+
+            this.ping();
+        }, wsPingIntervalMs);
+    }
+
+    private stopPingInterval() {
+        if (this.pingInterval) {
+            clearInterval(this.pingInterval);
+            this.pingInterval = null;
+        }
+    }
+
+    private ping() {
+        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+            this.waitingForPong = true;
+            this.ws.send(JSON.stringify({
+                action: 'ping',
+                seq: this.seqNo++,
+            }));
+        }
     }
 }


### PR DESCRIPTION
#### Summary

We received a report of some significant delays in WS disconnect detection on the client side. On the server side, we wait up to 10 seconds for a gone client to reconnect, then give up, closing the underlying peer connection, even if healthy. Adding an explicit ping mechanism should help to mitigate this issue and trigger a reconnect before the server-side timeout expires.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64539

