### PR TITLE
[MM-64487] Improve error checking in load-test client signup logic

### DIFF
--- a/lt/client/client.go
+++ b/lt/client/client.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -555,9 +556,13 @@ func (u *User) Connect(stopCh chan struct{}) error {
 	}
 	cancel()
 
-	if ok && appErr != nil && appErr.Id != "api.user.login.invalid_credentials_email_username" {
+	isInvalidCredentialsError := func(id string) bool {
+		return strings.Contains(id, "invalid_credentials")
+	}
+
+	if ok && appErr != nil && !isInvalidCredentialsError(appErr.Id) {
 		return fmt.Errorf("login failed: %w", err)
-	} else if ok && appErr != nil && appErr.Id == "api.user.login.invalid_credentials_email_username" {
+	} else if ok && appErr != nil && isInvalidCredentialsError(appErr.Id) {
 		if !u.cfg.Setup {
 			return fmt.Errorf("cannot register user with setup disabled")
 		}


### PR DESCRIPTION
#### Summary

If SSO is enabled, the returned error ID is slightly different than expected (`api.user.login.invalid_credentials_sso` vs `api.user.login.invalid_credentials_email_username`), so we wouldn't try to register the users. Tweaking the check to cover all the potential "invalid credentials" errors.

@DHaussermann (not urgent) Could you give this a pass when you get a chance? 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64487
