### PR TITLE
[MM-64237] e2e: use proper CSRF header in requests

### DIFF
--- a/e2e/channels.ts
+++ b/e2e/channels.ts
@@ -5,11 +5,11 @@ import {expect} from '@playwright/test';
 import {APIRequestContext} from 'playwright-core';
 
 import {baseURL, defaultTeam} from './constants';
-import {headers} from './utils';
+import {getHTTPHeaders} from './utils';
 
 export const apiCreateGroupChannel = async (request: APIRequestContext, userIDs: string[]) => {
     const resp = await request.post(`${baseURL}/api/v4/channels/group`, {
-        headers,
+        headers: await getHTTPHeaders(request),
         data: userIDs,
     });
     expect(resp.status()).toEqual(201);
@@ -19,7 +19,7 @@ export const apiCreateGroupChannel = async (request: APIRequestContext, userIDs:
 // Return first one found (that's all we need for now)
 export const apiGetGroupChannel = async (request: APIRequestContext, userName: string) => {
     const resp = await request.post(`${baseURL}/api/v4/channels/group/search`, {
-        headers,
+        headers: await getHTTPHeaders(request),
         data: {
             term: userName,
         },
@@ -34,7 +34,7 @@ export const apiGetGroupChannel = async (request: APIRequestContext, userName: s
 
 export const apiChannelNotifyProps = async (request: APIRequestContext, channelID: string, userID: string, newProps: Record<string, string>) => {
     const resp = await request.put(`${baseURL}/api/v4/channels/${channelID}/members/${userID}/notify_props`, {
-        headers,
+        headers: await getHTTPHeaders(request),
         data: {
             channel_id: channelID,
             user_id: userID,

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -4,6 +4,7 @@
 import {expect, request} from '@playwright/test';
 
 import {adminState, baseURL, pluginID} from './constants';
+import {getHTTPHeaders} from './utils';
 
 type CallsConfig = {
     enabletranscriptions?: boolean;
@@ -16,7 +17,8 @@ export const apiPatchConfig = async (cfg: CallsConfig) => {
         baseURL,
         storageState: adminState.storageStatePath,
     });
-    const serverConfig = await (await adminContext.get(`${baseURL}/api/v4/config`)).json();
+    const headers = await getHTTPHeaders(adminContext);
+    const serverConfig = await (await adminContext.get(`${baseURL}/api/v4/config`, {headers})).json();
 
     serverConfig.PluginSettings.Plugins = {
         ...serverConfig.PluginSettings.Plugins,
@@ -27,9 +29,10 @@ export const apiPatchConfig = async (cfg: CallsConfig) => {
     };
 
     const resp = await adminContext.put(`${baseURL}/api/v4/config`, {
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        headers,
         data: serverConfig,
     });
+
     await expect(resp.status()).toEqual(200);
 };
 

--- a/e2e/scripts/prepare-server.sh
+++ b/e2e/scripts/prepare-server.sh
@@ -85,6 +85,7 @@ echo "MM_SERVICESETTINGS_ENABLEDEVELOPER=true" >>${WORKSPACE}/dotenv/app.private
 echo "MM_SERVICESETTINGS_ENABLETESTING=true" >>${WORKSPACE}/dotenv/app.private.env
 echo "MM_SERVICESETTINGS_ALLOWCORSFROM=http://localhost:8065" >>${WORKSPACE}/dotenv/app.private.env
 echo "MM_SERVICESETTINGS_ENABLEONBOARDINGFLOW=false" >>${WORKSPACE}/dotenv/app.private.env
+echo "MM_SERVICESETTINGS_EXPERIMENTALSTRICTCSRFENFORCEMENT=true" >>${WORKSPACE}/dotenv/app.private.env
 echo "MM_PLUGINSETTINGS_ENABLE=true" >>${WORKSPACE}/dotenv/app.private.env
 echo "MM_PLUGINSETTINGS_ENABLEUPLOADS=true" >>${WORKSPACE}/dotenv/app.private.env
 echo "MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS=false" >>${WORKSPACE}/dotenv/app.private.env

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -10,6 +10,7 @@ import {apiPatchNotifyProps, apiPutStatus} from '../users';
 import {
     getChannelNamesForTest,
     getChannelURL,
+    getHTTPHeaders,
     getUserIDsForTest,
     getUserIdxForTest,
     getUsernamesForTest,
@@ -726,7 +727,7 @@ test.describe('notifications', () => {
         // set automatic replies setting (ooo) to true
         const adminContext = (await newUserPage(adminState.storageStatePath)).page.request;
         let resp = await adminContext.put(`${baseURL}/api/v4/config/patch`, {
-            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            headers: await getHTTPHeaders(adminContext),
             data: {
                 TeamSettings: {
                     ExperimentalEnableAutomaticReplies: true,
@@ -769,7 +770,7 @@ test.describe('notifications', () => {
         // cleanup
         await user1.leaveCall();
         resp = await adminContext.put(`${baseURL}/api/v4/config/patch`, {
-            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            headers: await getHTTPHeaders(adminContext),
             data: {
                 TeamSettings: {
                     ExperimentalEnableAutomaticReplies: false,

--- a/e2e/tests/start_call.spec.ts
+++ b/e2e/tests/start_call.spec.ts
@@ -11,6 +11,7 @@ import PlaywrightDevPage from '../page';
 import {
     getChannelNamesForTest,
     getChannelURL,
+    getHTTPHeaders,
     getUserIDsForTest,
     getUserIdxForTest,
     getUsernamesForTest,
@@ -550,7 +551,7 @@ test.describe('permissions', () => {
         const adminContext = (await newUserPage(adminState.storageStatePath)).page.request;
         const channel = await apiGetChannelByName(adminContext, getChannelNamesForTest()[1]);
         let resp = await adminContext.delete(`${baseURL}/api/v4/channels/${channel.id}/members/${getUserIDsForTest()[0]}`, {
-            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            headers: await getHTTPHeaders(adminContext),
         });
         await expect(resp.status()).toEqual(200);
 
@@ -561,7 +562,7 @@ test.describe('permissions', () => {
 
         // Re-add user to channel
         resp = await adminContext.post(`${baseURL}/api/v4/channels/${channel.id}/members`, {
-            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            headers: await getHTTPHeaders(adminContext),
             data: {
                 channel_id: channel.id,
                 user_id: getUserIDsForTest()[0],

--- a/e2e/users.ts
+++ b/e2e/users.ts
@@ -5,14 +5,14 @@ import {expect} from '@playwright/test';
 import {APIRequestContext} from 'playwright-core';
 
 import {baseURL} from './constants';
-import {headers} from './utils';
+import {getHTTPHeaders} from './utils';
 
 export const apiPatchNotifyProps = async (request: APIRequestContext, newProps: Record<string, string>) => {
     let resp = await request.get(`${baseURL}/api/v4/users/me`);
     expect(resp.status()).toEqual(200);
     const notifyProps = (await resp.json()).notify_props;
     resp = await request.put(`${baseURL}/api/v4/users/me/patch`, {
-        headers,
+        headers: await getHTTPHeaders(request),
         data: {
             notify_props: {
                 ...notifyProps,
@@ -28,7 +28,7 @@ export const apiPutStatus = async (request: APIRequestContext, status: string) =
     expect(resp.status()).toEqual(200);
     const id = (await resp.json()).id;
     resp = await request.put(`${baseURL}/api/v4/users/${id}/status`, {
-        headers,
+        headers: await getHTTPHeaders(request),
         data: {
             user_id: id,
             status,

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -175,7 +175,14 @@ export function releaseLock(lockID: string) {
 }
 
 export async function getHTTPHeaders(context: APIRequestContext) {
+    const storageState = await context.storageState();
+    const csrfCookie = storageState.cookies.find(cookie => cookie.name === 'MMCSRF');
+
+    if (!csrfCookie) {
+        throw new Error('CSRF token cookie not found');
+    }
+
     return {
-        'X-CSRF-Token': (await context.storageState()).cookies[2].value,
+        'X-CSRF-Token': csrfCookie.value,
     };
 }

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -4,11 +4,10 @@
 /* eslint-disable no-process-env */
 import {chromium, Page, test} from '@playwright/test';
 import * as fs from 'fs';
+import {APIRequestContext} from 'playwright-core';
 
 import {baseURL, channelPrefix, defaultTeam, userPrefix} from './constants';
 import PlaywrightDevPage from './page';
-
-export const headers = {'X-Requested-With': 'XMLHttpRequest'};
 
 export function getChannelNamesForTest() {
     let idx = 0;
@@ -173,4 +172,10 @@ export function releaseLock(lockID: string) {
 
     // eslint-disable-next-line no-console
     console.log(test.info().title, 'lock released');
+}
+
+export async function getHTTPHeaders(context: APIRequestContext) {
+    return {
+        'X-CSRF-Token': (await context.storageState()).cookies[2].value,
+    };
 }


### PR DESCRIPTION
#### Summary

We'll soon deprecate cookie-authenticated API requests without a valid CSRF token, which would break the e2e pipeline completely.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64237

