### PR TITLE
Fix flaky e2e test

### DIFF
--- a/e2e/tests/start_call.spec.ts
+++ b/e2e/tests/start_call.spec.ts
@@ -510,7 +510,7 @@ test.describe('call post', () => {
             });
         });
 
-        await page.keyboard.press('Enter');
+        await page.locator(`#post_${postID}`).getByRole('button', {name: 'Save', exact: true}).click();
 
         expect((await postPatch).ok()).toBe(false);
 


### PR DESCRIPTION
#### Summary

This has been flaky for a while, getting stuck on pressing `Enter` key. We take a different approach and use the `Save` button instead.

