### PR TITLE
[MM-64737] Nil session from plugin API's GetSession

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -504,7 +504,8 @@ func (p *Plugin) wsReader(us *session, authSessionID, handlerID string) {
 				continue
 			}
 
-			if s, appErr := p.API.GetSession(authSessionID); appErr != nil || (s.ExpiresAt != 0 && time.Now().UnixMilli() >= s.ExpiresAt) {
+			s, appErr := p.API.GetSession(authSessionID)
+			if appErr != nil || (s != nil && s.ExpiresAt != 0 && time.Now().UnixMilli() >= s.ExpiresAt) {
 				fields := []any{
 					"channelID",
 					us.channelID,


### PR DESCRIPTION
#### Summary
- A customer provided logs showing a nil deference after calling `p.API.GetSession`. There was no `AppErr`, but apparently the session was nil. That shouldn't happen. But regardless of how or why, let's protect against that in the future.
- We don't have any other calls to `p.API.GetSession` to protect.
- Added a test which fails if the check is removed.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-64737
