### PR TITLE
e2e: skip installing playbooks, since pre-packaged

### DIFF
--- a/e2e/scripts/run.sh
+++ b/e2e/scripts/run.sh
@@ -46,6 +46,12 @@ docker exec --env="XDG_CONFIG_HOME=/mattermost/config" \
 	${CONTAINER_SERVER}1 \
 	/mattermost/bin/mmctl auth login http://localhost:8065 --username sysadmin --name local --password-file /mattermost/pwd.txt
 
+# Install Playbooks
+echo "Installing playbooks ..."
+docker exec --env="XDG_CONFIG_HOME=/mattermost/config" \
+	${CONTAINER_SERVER}1 \
+	/mattermost/bin/mmctl plugin marketplace install playbooks
+
 # Enable Playbooks
 echo "Enabling playbooks ..."
 docker exec --env="XDG_CONFIG_HOME=/mattermost/config" \

--- a/e2e/scripts/run.sh
+++ b/e2e/scripts/run.sh
@@ -46,12 +46,6 @@ docker exec --env="XDG_CONFIG_HOME=/mattermost/config" \
 	${CONTAINER_SERVER}1 \
 	/mattermost/bin/mmctl auth login http://localhost:8065 --username sysadmin --name local --password-file /mattermost/pwd.txt
 
-# Install Playbooks
-echo "Installing playbooks ..."
-docker exec --env="XDG_CONFIG_HOME=/mattermost/config" \
-	${CONTAINER_SERVER}1 \
-	/mattermost/bin/mmctl plugin add /mattermost/prepackaged_plugins/mattermost-plugin-playbooks-v2.4.1-linux-amd64.tar.gz
-
 # Enable Playbooks
 echo "Enabling playbooks ..."
 docker exec --env="XDG_CONFIG_HOME=/mattermost/config" \


### PR DESCRIPTION
#### Summary
We currently hard-code a version of Playbooks to install in the e2e tests, but this relies on the prepackaged plugins cache and doesn't work unless exactly that version is prepackaged. Just install the one that's already there "from the marketplace" (i.e. the prepackaged plugins) to unblock e2e tests.

#### Ticket Link
None