### PR TITLE
Calls security updates

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -175,6 +175,7 @@
             "key": "ICEServersConfigs",
             "display_name": "ICE Servers Configurations",
             "type": "longtext",
+            "secret": true,
             "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
             "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]",
             "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]",
@@ -184,6 +185,7 @@
             "key": "TURNStaticAuthSecret",
             "display_name": "TURN Static Auth Secret",
             "type": "text",
+            "secret": true,
             "default": "",
             "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials.",
             "hosting": "on-prem"
@@ -192,7 +194,7 @@
             "key": "TURNCredentialsExpirationMinutes",
             "display_name": "TURN Credentials Expiration (minutes)",
             "type": "number",
-            "default": 1440,
+            "default": 240,
             "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
             "hosting": "on-prem"
           },
@@ -493,7 +495,7 @@
         "key": "TURNCredentialsExpirationMinutes",
         "display_name": "TURN Credentials Expiration (minutes)",
         "type": "number",
-        "default": 1440,
+        "default": 240,
         "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
         "hosting": "on-prem"
       },

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -204,7 +204,7 @@ func (c *configuration) SetDefaults() {
 		c.MaxCallParticipants = model.NewPointer(0) // unlimited
 	}
 	if c.TURNCredentialsExpirationMinutes == nil {
-		c.TURNCredentialsExpirationMinutes = model.NewPointer(1440)
+		c.TURNCredentialsExpirationMinutes = model.NewPointer(240)
 	}
 	if c.ServerSideTURN == nil {
 		c.ServerSideTURN = model.NewPointer(false)


### PR DESCRIPTION
#### Summary

This addresses two security issues in Calls:
- Redact secret configuration settings in system console
- Reduce default ICE/TURN credential expiration time from 24 hours to 4 hours

Note that the secret configuration settings requires branch MM-66820 on server, see [PR #34642](https://github.com/mattermost/mattermost/pull/34642)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-66820
