### PR TITLE
Handle join_call links in webapp

### DIFF
--- a/webapp/src/components/join_call_watcher.test.tsx
+++ b/webapp/src/components/join_call_watcher.test.tsx
@@ -1,0 +1,147 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Channel} from '@mattermost/types/channels';
+import {act, render} from '@testing-library/react';
+import {createMemoryHistory} from 'history';
+import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import React from 'react';
+import {Provider} from 'react-redux';
+import {Router} from 'react-router-dom';
+import {mockStore} from 'src/testUtils';
+
+import JoinCallWatcher from './join_call_watcher';
+
+jest.mock('mattermost-redux/selectors/entities/channels', () => ({
+    getChannelsNameMapInCurrentTeam: jest.fn(),
+}));
+
+const townSquare = {id: 'town-square-id', name: 'town-square'} as Channel;
+const offTopic = {id: 'off-topic-id', name: 'off-topic'} as Channel;
+
+type RenderOpts = {
+    path: string;
+    channelsById?: Record<string, Channel>;
+    channelsByName?: Record<string, Channel>;
+};
+
+const renderWatcher = ({path, channelsById = {}, channelsByName = {}}: RenderOpts) => {
+    const onJoinCall = jest.fn();
+    const history = createMemoryHistory({initialEntries: [path]});
+    const store = mockStore({
+        entities: {
+            channels: {
+                channels: channelsById,
+            },
+        },
+    });
+    (getChannelsNameMapInCurrentTeam as jest.Mock).mockReturnValue(channelsByName);
+
+    const result = render(
+        <Provider store={store}>
+            <Router history={history}>
+                <JoinCallWatcher onJoinCall={onJoinCall}/>
+            </Router>
+        </Provider>,
+    );
+
+    return {onJoinCall, history, ...result};
+};
+
+describe('JoinCallWatcher', () => {
+    it('does nothing when join_call param is absent', () => {
+        const {onJoinCall} = renderWatcher({
+            path: '/team/channels/town-square',
+            channelsByName: {'town-square': townSquare},
+        });
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when join_call is not "true"', () => {
+        const {onJoinCall} = renderWatcher({
+            path: '/team/channels/town-square?join_call=false',
+            channelsByName: {'town-square': townSquare},
+        });
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('joins via channel ID when URL pathname is in ID form', () => {
+        const {onJoinCall} = renderWatcher({
+            path: '/team/channels/town-square-id?join_call=true',
+            channelsById: {'town-square-id': townSquare},
+            channelsByName: {'town-square': townSquare},
+        });
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+        expect(onJoinCall).toHaveBeenCalledWith('town-square-id');
+    });
+
+    it('joins via channel ID when URL pathname is in canonical name form', () => {
+        const {onJoinCall} = renderWatcher({
+            path: '/team/channels/town-square?join_call=true',
+            channelsByName: {'town-square': townSquare},
+        });
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+        expect(onJoinCall).toHaveBeenCalledWith('town-square-id');
+    });
+
+    it('does nothing when the URL channel is not loaded in Redux', () => {
+        const {onJoinCall} = renderWatcher({
+            path: '/team/channels/unknown-channel?join_call=true',
+            channelsById: {},
+            channelsByName: {},
+        });
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when pathname does not match /channels/<...>', () => {
+        const {onJoinCall} = renderWatcher({
+            path: '/team/messages/@somebody?join_call=true',
+            channelsByName: {'town-square': townSquare},
+        });
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('joins exactly once across cross-channel navigation + canonicalization', () => {
+        // Simulates the real cross-channel flow: navigate to /channels/<id>?join_call=true,
+        // then the webapp canonicalizes to /channels/<name> and strips the param.
+        const {onJoinCall, history} = renderWatcher({
+            path: '/team/channels/off-topic',
+            channelsById: {
+                'town-square-id': townSquare,
+                'off-topic-id': offTopic,
+            },
+            channelsByName: {'town-square': townSquare, 'off-topic': offTopic},
+        });
+
+        act(() => {
+            history.push('/team/channels/town-square-id?join_call=true');
+        });
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+        expect(onJoinCall).toHaveBeenCalledWith('town-square-id');
+
+        act(() => {
+            history.replace('/team/channels/town-square');
+        });
+        expect(onJoinCall).toHaveBeenCalledTimes(1); // not called again
+    });
+
+    it('joins again when navigating to a different channel with the param', () => {
+        const {onJoinCall, history} = renderWatcher({
+            path: '/team/channels/town-square?join_call=true',
+            channelsById: {
+                'town-square-id': townSquare,
+                'off-topic-id': offTopic,
+            },
+            channelsByName: {'town-square': townSquare, 'off-topic': offTopic},
+        });
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+        expect(onJoinCall).toHaveBeenLastCalledWith('town-square-id');
+
+        act(() => {
+            history.replace('/team/channels/town-square'); // canonicalization
+            history.push('/team/channels/off-topic-id?join_call=true');
+        });
+        expect(onJoinCall).toHaveBeenCalledTimes(2);
+        expect(onJoinCall).toHaveBeenLastCalledWith('off-topic-id');
+    });
+});

--- a/webapp/src/components/join_call_watcher.test.tsx
+++ b/webapp/src/components/join_call_watcher.test.tsx
@@ -15,6 +15,8 @@ import {mockStore} from 'src/testUtils';
 import JoinCallWatcher from './join_call_watcher';
 
 jest.mock('mattermost-redux/selectors/entities/channels', () => ({
+    getChannel: (state: {entities: {channels: {channels: Record<string, unknown>}}}, id: string) =>
+        state?.entities?.channels?.channels?.[id],
     getChannelsNameMapInCurrentTeam: jest.fn(),
 }));
 

--- a/webapp/src/components/join_call_watcher.test.tsx
+++ b/webapp/src/components/join_call_watcher.test.tsx
@@ -2,9 +2,11 @@
 // See LICENSE.txt for license information.
 
 import {Channel} from '@mattermost/types/channels';
+import {Team} from '@mattermost/types/teams';
 import {act, render} from '@testing-library/react';
 import {createMemoryHistory} from 'history';
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import React from 'react';
 import {Provider} from 'react-redux';
 import {Router} from 'react-router-dom';
@@ -16,6 +18,11 @@ jest.mock('mattermost-redux/selectors/entities/channels', () => ({
     getChannelsNameMapInCurrentTeam: jest.fn(),
 }));
 
+jest.mock('mattermost-redux/selectors/entities/teams', () => ({
+    getCurrentTeam: jest.fn(),
+}));
+
+const team1 = {id: 'team-1-id', name: 'team-1'} as Team;
 const townSquare = {id: 'town-square-id', name: 'town-square'} as Channel;
 const offTopic = {id: 'off-topic-id', name: 'off-topic'} as Channel;
 
@@ -23,9 +30,15 @@ type RenderOpts = {
     path: string;
     channelsById?: Record<string, Channel>;
     channelsByName?: Record<string, Channel>;
+    currentTeam?: Team | null; // null means explicitly no current team
 };
 
-const renderWatcher = ({path, channelsById = {}, channelsByName = {}}: RenderOpts) => {
+const renderWatcher = ({
+    path,
+    channelsById = {},
+    channelsByName = {},
+    currentTeam = team1,
+}: RenderOpts) => {
     const onJoinCall = jest.fn();
     const history = createMemoryHistory({initialEntries: [path]});
     const store = mockStore({
@@ -36,6 +49,9 @@ const renderWatcher = ({path, channelsById = {}, channelsByName = {}}: RenderOpt
         },
     });
     (getChannelsNameMapInCurrentTeam as jest.Mock).mockReturnValue(channelsByName);
+
+    // null passes through fine — null?.name in the watcher is the same as undefined?.name.
+    (getCurrentTeam as jest.Mock).mockReturnValue(currentTeam);
 
     const result = render(
         <Provider store={store}>
@@ -51,7 +67,7 @@ const renderWatcher = ({path, channelsById = {}, channelsByName = {}}: RenderOpt
 describe('JoinCallWatcher', () => {
     it('does nothing when join_call param is absent', () => {
         const {onJoinCall} = renderWatcher({
-            path: '/team/channels/town-square',
+            path: '/team-1/channels/town-square',
             channelsByName: {'town-square': townSquare},
         });
         expect(onJoinCall).not.toHaveBeenCalled();
@@ -59,7 +75,7 @@ describe('JoinCallWatcher', () => {
 
     it('does nothing when join_call is not "true"', () => {
         const {onJoinCall} = renderWatcher({
-            path: '/team/channels/town-square?join_call=false',
+            path: '/team-1/channels/town-square?join_call=false',
             channelsByName: {'town-square': townSquare},
         });
         expect(onJoinCall).not.toHaveBeenCalled();
@@ -67,7 +83,7 @@ describe('JoinCallWatcher', () => {
 
     it('joins via channel ID when URL pathname is in ID form', () => {
         const {onJoinCall} = renderWatcher({
-            path: '/team/channels/town-square-id?join_call=true',
+            path: '/team-1/channels/town-square-id?join_call=true',
             channelsById: {'town-square-id': townSquare},
             channelsByName: {'town-square': townSquare},
         });
@@ -77,7 +93,7 @@ describe('JoinCallWatcher', () => {
 
     it('joins via channel ID when URL pathname is in canonical name form', () => {
         const {onJoinCall} = renderWatcher({
-            path: '/team/channels/town-square?join_call=true',
+            path: '/team-1/channels/town-square?join_call=true',
             channelsByName: {'town-square': townSquare},
         });
         expect(onJoinCall).toHaveBeenCalledTimes(1);
@@ -86,7 +102,7 @@ describe('JoinCallWatcher', () => {
 
     it('does nothing when the URL channel is not loaded in Redux', () => {
         const {onJoinCall} = renderWatcher({
-            path: '/team/channels/unknown-channel?join_call=true',
+            path: '/team-1/channels/unknown-channel?join_call=true',
             channelsById: {},
             channelsByName: {},
         });
@@ -95,8 +111,29 @@ describe('JoinCallWatcher', () => {
 
     it('does nothing when pathname does not match /channels/<...>', () => {
         const {onJoinCall} = renderWatcher({
-            path: '/team/messages/@somebody?join_call=true',
+            path: '/team-1/messages/@somebody?join_call=true',
             channelsByName: {'town-square': townSquare},
+        });
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when URL team does not match current team', () => {
+        // Cross-team link: another team has a channel with the same name as
+        // ours. Without the team check we would mis-resolve and join the wrong
+        // call in the current team.
+        const {onJoinCall} = renderWatcher({
+            path: '/other-team/channels/town-square?join_call=true',
+            channelsByName: {'town-square': townSquare},
+            currentTeam: team1,
+        });
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there is no current team yet', () => {
+        const {onJoinCall} = renderWatcher({
+            path: '/team-1/channels/town-square?join_call=true',
+            channelsByName: {'town-square': townSquare},
+            currentTeam: null,
         });
         expect(onJoinCall).not.toHaveBeenCalled();
     });
@@ -105,7 +142,7 @@ describe('JoinCallWatcher', () => {
         // Simulates the real cross-channel flow: navigate to /channels/<id>?join_call=true,
         // then the webapp canonicalizes to /channels/<name> and strips the param.
         const {onJoinCall, history} = renderWatcher({
-            path: '/team/channels/off-topic',
+            path: '/team-1/channels/off-topic',
             channelsById: {
                 'town-square-id': townSquare,
                 'off-topic-id': offTopic,
@@ -114,20 +151,20 @@ describe('JoinCallWatcher', () => {
         });
 
         act(() => {
-            history.push('/team/channels/town-square-id?join_call=true');
+            history.push('/team-1/channels/town-square-id?join_call=true');
         });
         expect(onJoinCall).toHaveBeenCalledTimes(1);
         expect(onJoinCall).toHaveBeenCalledWith('town-square-id');
 
         act(() => {
-            history.replace('/team/channels/town-square');
+            history.replace('/team-1/channels/town-square');
         });
         expect(onJoinCall).toHaveBeenCalledTimes(1); // not called again
     });
 
     it('joins again when navigating to a different channel with the param', () => {
         const {onJoinCall, history} = renderWatcher({
-            path: '/team/channels/town-square?join_call=true',
+            path: '/team-1/channels/town-square?join_call=true',
             channelsById: {
                 'town-square-id': townSquare,
                 'off-topic-id': offTopic,
@@ -138,8 +175,8 @@ describe('JoinCallWatcher', () => {
         expect(onJoinCall).toHaveBeenLastCalledWith('town-square-id');
 
         act(() => {
-            history.replace('/team/channels/town-square'); // canonicalization
-            history.push('/team/channels/off-topic-id?join_call=true');
+            history.replace('/team-1/channels/town-square'); // canonicalization
+            history.push('/team-1/channels/off-topic-id?join_call=true');
         });
         expect(onJoinCall).toHaveBeenCalledTimes(2);
         expect(onJoinCall).toHaveBeenLastCalledWith('off-topic-id');

--- a/webapp/src/components/join_call_watcher.tsx
+++ b/webapp/src/components/join_call_watcher.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Channel} from '@mattermost/types/channels';
 import {GlobalState} from '@mattermost/types/store';
-import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {useEffect} from 'react';
 import {useSelector} from 'react-redux';
@@ -22,43 +23,36 @@ type Props = {
 const JoinCallWatcher = ({onJoinCall}: Props) => {
     const location = useLocation();
     const joinCall = new URLSearchParams(location.search).get('join_call');
-    const channelsById = useSelector((state: GlobalState) => state.entities.channels.channels);
-    const channelsByName = useSelector(getChannelsNameMapInCurrentTeam);
-    const currentTeamName = useSelector(getCurrentTeam)?.name;
 
-    useEffect(() => {
-        if (joinCall !== 'true') {
-            return;
-        }
-
+    // Resolve the URL's channel in a single selector so the effect only
+    // re-fires when the resolved channel itself changes, not whenever
+    // unrelated channel map updates replace the broader Redux objects.
+    const channelFromUrl = useSelector((state: GlobalState): Channel | null => {
         // Pathname is /TEAM/channels/<channelID-or-name>. During cross-channel
-        // navigation, it's the channel ID briefly before Mattermost canonicalizes
-        // it to the channel name. We accept either by looking up both maps.
-        // Resolving via Redux directly (rather than gating on currentChannelId)
-        // is essential — currentChannelId lags the URL during cross-channel nav,
-        // and canonicalization strips the param before Redux catches up.
+        // navigation it's the ID form briefly before Mattermost canonicalizes
+        // to the name form. We accept either.
         //
-        // The team segment must match the current team. channelsByName is
-        // scoped to the current team, so a cross-team link like
-        // /other-team/channels/town-square would otherwise mis-resolve to the
-        // current team's town-square. DM/GM URLs (/messages/...) are not
-        // handled — see open work in feature doc.
+        // The team segment must match the current team to avoid mis-resolving
+        // a cross-team link against the current team's channel map.
+        // DM/GM URLs (/messages/...) are not handled — see feature doc.
         const match = location.pathname.match(/^\/([^/]+)\/channels\/([^/]+)/);
         if (!match) {
-            return;
+            return null;
         }
         const [, teamName, idOrName] = match;
+        const currentTeamName = getCurrentTeam(state)?.name;
         if (!currentTeamName || teamName !== currentTeamName) {
+            return null;
+        }
+        return getChannel(state, idOrName) || getChannelsNameMapInCurrentTeam(state)[idOrName] || null;
+    });
+
+    useEffect(() => {
+        if (joinCall !== 'true' || !channelFromUrl) {
             return;
         }
-
-        const channel = channelsById[idOrName] || channelsByName[idOrName];
-        if (!channel) {
-            return;
-        }
-
-        onJoinCall(channel.id);
-    }, [joinCall, location.pathname, channelsById, channelsByName, currentTeamName, onJoinCall]);
+        onJoinCall(channelFromUrl.id);
+    }, [joinCall, channelFromUrl, onJoinCall]);
 
     return null;
 };

--- a/webapp/src/components/join_call_watcher.tsx
+++ b/webapp/src/components/join_call_watcher.tsx
@@ -3,6 +3,7 @@
 
 import {GlobalState} from '@mattermost/types/store';
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 import {useLocation} from 'react-router-dom';
@@ -23,6 +24,7 @@ const JoinCallWatcher = ({onJoinCall}: Props) => {
     const joinCall = new URLSearchParams(location.search).get('join_call');
     const channelsById = useSelector((state: GlobalState) => state.entities.channels.channels);
     const channelsByName = useSelector(getChannelsNameMapInCurrentTeam);
+    const currentTeamName = useSelector(getCurrentTeam)?.name;
 
     useEffect(() => {
         if (joinCall !== 'true') {
@@ -35,11 +37,20 @@ const JoinCallWatcher = ({onJoinCall}: Props) => {
         // Resolving via Redux directly (rather than gating on currentChannelId)
         // is essential — currentChannelId lags the URL during cross-channel nav,
         // and canonicalization strips the param before Redux catches up.
-        const match = location.pathname.match(/\/channels\/([^/]+)/);
+        //
+        // The team segment must match the current team. channelsByName is
+        // scoped to the current team, so a cross-team link like
+        // /other-team/channels/town-square would otherwise mis-resolve to the
+        // current team's town-square. DM/GM URLs (/messages/...) are not
+        // handled — see open work in feature doc.
+        const match = location.pathname.match(/^\/([^/]+)\/channels\/([^/]+)/);
         if (!match) {
             return;
         }
-        const idOrName = match[1];
+        const [, teamName, idOrName] = match;
+        if (!currentTeamName || teamName !== currentTeamName) {
+            return;
+        }
 
         const channel = channelsById[idOrName] || channelsByName[idOrName];
         if (!channel) {
@@ -47,7 +58,7 @@ const JoinCallWatcher = ({onJoinCall}: Props) => {
         }
 
         onJoinCall(channel.id);
-    }, [joinCall, location.pathname, channelsById, channelsByName, onJoinCall]);
+    }, [joinCall, location.pathname, channelsById, channelsByName, currentTeamName, onJoinCall]);
 
     return null;
 };

--- a/webapp/src/components/join_call_watcher.tsx
+++ b/webapp/src/components/join_call_watcher.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {GlobalState} from '@mattermost/types/store';
+import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import {useEffect} from 'react';
+import {useSelector} from 'react-redux';
+import {useLocation} from 'react-router-dom';
+
+type Props = {
+    onJoinCall: (channelId: string) => void;
+};
+
+// Watches for the ?join_call=true query parameter and triggers a join when it
+// appears. Handles cross-channel link clicks and pasted URLs: the parameter
+// is briefly visible at React Router's level before Mattermost canonicalizes
+// the URL away, which is enough for an effect to observe it.
+//
+// Same-channel clicks are NOT handled here because the URL never updates in
+// that case — see the click handler in index.tsx.
+const JoinCallWatcher = ({onJoinCall}: Props) => {
+    const location = useLocation();
+    const joinCall = new URLSearchParams(location.search).get('join_call');
+    const channelsById = useSelector((state: GlobalState) => state.entities.channels.channels);
+    const channelsByName = useSelector(getChannelsNameMapInCurrentTeam);
+
+    useEffect(() => {
+        if (joinCall !== 'true') {
+            return;
+        }
+
+        // Pathname is /TEAM/channels/<channelID-or-name>. During cross-channel
+        // navigation, it's the channel ID briefly before Mattermost canonicalizes
+        // it to the channel name. We accept either by looking up both maps.
+        // Resolving via Redux directly (rather than gating on currentChannelId)
+        // is essential — currentChannelId lags the URL during cross-channel nav,
+        // and canonicalization strips the param before Redux catches up.
+        const match = location.pathname.match(/\/channels\/([^/]+)/);
+        if (!match) {
+            return;
+        }
+        const idOrName = match[1];
+
+        const channel = channelsById[idOrName] || channelsByName[idOrName];
+        if (!channel) {
+            return;
+        }
+
+        onJoinCall(channel.id);
+    }, [joinCall, location.pathname, channelsById, channelsByName, onJoinCall]);
+
+    return null;
+};
+
+export default JoinCallWatcher;

--- a/webapp/src/components/same_channel_link_click_handler.test.ts
+++ b/webapp/src/components/same_channel_link_click_handler.test.ts
@@ -1,0 +1,209 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {makeSameChannelLinkClickHandler} from './same_channel_link_click_handler';
+
+// Helpers ——————————————————————————————————————————————————————————————————
+
+const TEAM = 'team-1';
+const CHANNEL_ID = 'town-square-id';
+const CHANNEL_NAME = 'town-square';
+const ORIGIN = window.location.origin; // matches jest testURL (http://localhost:8065)
+
+const makeHandler = (overrides: {
+    teamName?: string | null;
+    channelId?: string;
+    channelName?: string;
+    onJoinCall?: jest.Mock;
+} = {}) => {
+    const onJoinCall = overrides.onJoinCall ?? jest.fn();
+    const handler = makeSameChannelLinkClickHandler(
+        () => overrides.teamName === null ? '' : (overrides.teamName ?? TEAM),
+        () => overrides.channelId ?? CHANNEL_ID,
+        () => overrides.channelName ?? CHANNEL_NAME,
+        onJoinCall,
+    );
+    return {handler, onJoinCall};
+};
+
+const makeLink = (href: string, target?: string): HTMLAnchorElement => {
+    const link = document.createElement('a');
+    link.setAttribute('href', href);
+    if (target) {
+        link.target = target;
+    }
+    return link;
+};
+
+const makeEvent = (
+    link: HTMLAnchorElement,
+    opts: Partial<Pick<MouseEvent, 'button' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'>> = {},
+): MouseEvent => ({
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    target: link,
+    preventDefault: jest.fn(),
+    stopPropagation: jest.fn(),
+    stopImmediatePropagation: jest.fn(),
+    ...opts,
+} as unknown as MouseEvent);
+
+const joinCallHref = (opts: {team?: string; channel?: string; origin?: string} = {}) => {
+    const origin = opts.origin ?? ORIGIN;
+    const team = opts.team ?? TEAM;
+    const channel = opts.channel ?? CHANNEL_ID;
+    return `${origin}/${team}/channels/${channel}?join_call=true`;
+};
+
+// Tests ————————————————————————————————————————————————————————————————————
+
+describe('makeSameChannelLinkClickHandler', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        (window as Window & {basename: string}).basename = '';
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('calls joinCall for a same-channel join_call link matched by channel ID', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref());
+        handler(makeEvent(link));
+
+        expect(onJoinCall).not.toHaveBeenCalled(); // deferred
+        jest.runAllTimers();
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+        expect(onJoinCall).toHaveBeenCalledWith(CHANNEL_ID);
+    });
+
+    it('calls joinCall for a same-channel join_call link matched by channel name', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref({channel: CHANNEL_NAME}));
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+        expect(onJoinCall).toHaveBeenCalledWith(CHANNEL_ID);
+    });
+
+    it('joinCall is deferred via setTimeout, not called synchronously', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref());
+        handler(makeEvent(link));
+
+        expect(onJoinCall).not.toHaveBeenCalled();
+        jest.runAllTimers();
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        {modifier: 'metaKey'},
+        {modifier: 'ctrlKey'},
+        {modifier: 'shiftKey'},
+        {modifier: 'altKey'},
+    ])('does not intercept $modifier click', ({modifier}) => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref());
+        handler(makeEvent(link, {[modifier]: true}));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept non-primary button click', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref());
+        handler(makeEvent(link, {button: 1}));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept link with target="_blank"', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref(), '_blank');
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept cross-origin link', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref({origin: 'https://attacker.com'}));
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept cross-team link', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref({team: 'other-team'}));
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept when no current team', () => {
+        const {handler, onJoinCall} = makeHandler({teamName: null});
+        const link = makeLink(joinCallHref());
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept link pointing to a different channel', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref({channel: 'off-topic-id'}));
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept link without join_call param', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(`${ORIGIN}/${TEAM}/channels/${CHANNEL_ID}`);
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept DM/messages URL', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(`${ORIGIN}/${TEAM}/messages/@somebody?join_call=true`);
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).not.toHaveBeenCalled();
+    });
+
+    it('strips window.basename before matching team segment on subpath deployments', () => {
+        (window as Window & {basename?: string}).basename = '/mattermost';
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(`${ORIGIN}/mattermost/${TEAM}/channels/${CHANNEL_ID}?join_call=true`);
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+        expect(onJoinCall).toHaveBeenCalledWith(CHANNEL_ID);
+    });
+
+    it('works correctly when no basename is set', () => {
+        const {handler, onJoinCall} = makeHandler();
+        const link = makeLink(joinCallHref());
+        handler(makeEvent(link));
+
+        jest.runAllTimers();
+        expect(onJoinCall).toHaveBeenCalledTimes(1);
+    });
+});

--- a/webapp/src/components/same_channel_link_click_handler.ts
+++ b/webapp/src/components/same_channel_link_click_handler.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// makeSameChannelLinkClickHandler returns a capture-phase click handler that
+// intercepts same-channel ?join_call=true links. When the link target is the
+// channel the user is already viewing, the webapp short-circuits navigation
+// entirely and the URL never updates, so JoinCallWatcher can't detect the
+// click. This handler catches it directly.
+//
+// Cross-channel clicks are intentionally NOT intercepted — they fall through
+// to React Router and are handled by JoinCallWatcher after navigation.
+export function makeSameChannelLinkClickHandler(
+    getCurrentTeamName: () => string | undefined,
+    getCurrentChannelId: () => string,
+    getCurrentChannelName: () => string | undefined,
+    onJoinCall: (channelId: string) => void,
+): (e: MouseEvent) => void {
+    return (e: MouseEvent) => {
+        // Preserve normal browser behavior for non-primary clicks and modified
+        // clicks (Cmd/Ctrl-click → new tab, Shift-click → new window).
+        if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+            return;
+        }
+
+        const link = (e.target as HTMLElement | null)?.closest('a');
+        if (!link || (link.target && link.target !== '_self')) {
+            return;
+        }
+
+        const href = link.getAttribute('href');
+        if (!href) {
+            return;
+        }
+
+        let url: URL;
+        try {
+            url = new URL(href, window.location.origin);
+        } catch {
+            return;
+        }
+        if (url.origin !== window.location.origin) {
+            return;
+        }
+        if (url.searchParams.get('join_call') !== 'true') {
+            return;
+        }
+
+        // On subpath deployments, url.pathname is /<basename>/<team>/...
+        // — strip the basename so the regex matches the team segment
+        // correctly. JoinCallWatcher doesn't need this because React
+        // Router's history is configured with basename and useLocation
+        // already returns paths relative to it.
+        const pathname = window.basename && url.pathname.startsWith(window.basename) ?
+            url.pathname.slice(window.basename.length) :
+            url.pathname;
+
+        // Match the team segment — a cross-team link like
+        // /other-team/channels/<name> would otherwise mis-resolve against
+        // the current channel's name in the current team.
+        const targetMatch = pathname.match(/^\/([^/]+)\/channels\/([^/]+)/);
+        if (!targetMatch) {
+            return;
+        }
+        const [, teamName, target] = targetMatch;
+
+        const currentTeamName = getCurrentTeamName();
+        if (!currentTeamName || teamName !== currentTeamName) {
+            return;
+        }
+
+        const channelId = getCurrentChannelId();
+        const channelName = getCurrentChannelName();
+        if (target !== channelId && target !== channelName) {
+            return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+
+        // Defer to the next tick so the click event finishes propagating
+        // before the switch modal might be shown — the modal's closeOnBlur
+        // handler is registered in capture phase and would otherwise catch
+        // this same click and immediately hide the modal.
+        setTimeout(() => onJoinCall(channelId), 0);
+    };
+}

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -110,7 +110,6 @@ import {
     CALL_STATE,
     DISMISS_CALL,
     RECEIVED_CHANNEL_STATE,
-    SHOW_SWITCH_CALL_MODAL,
     UNINIT,
     USER_LOWER_HAND,
     USER_MUTED,
@@ -446,12 +445,7 @@ export default class Plugin {
                 }
             } else if ((currentCallChannelId && currentCallChannelId !== channelId) || (activeClientChannel && activeClientChannel !== channelId)) {
                 // In a different call - show switch modal
-                store.dispatch({
-                    type: SHOW_SWITCH_CALL_MODAL,
-                    data: {
-                        targetID: channelId,
-                    },
-                });
+                store.dispatch(showSwitchCallModal(channelId));
             }
 
             // If already in this call, do nothing

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -430,6 +430,7 @@ export default class Plugin {
 
         const connectToCall = async (channelId: string, teamId?: string, title?: string, rootId?: string) => {
             const currentCallChannelId = channelIDForCurrentCall(store.getState());
+
             // Also check window.callsClient for active call (handles race condition during page load)
             const hasActiveClient = Boolean(window.callsClient);
             const activeClientChannel = window.callsClient?.channelID;
@@ -452,6 +453,7 @@ export default class Plugin {
                     },
                 });
             }
+
             // If already in this call, do nothing
         };
 
@@ -1178,6 +1180,7 @@ export default class Plugin {
                         e.preventDefault();
                         e.stopPropagation();
                         e.stopImmediatePropagation();
+
                         // Defer connectToCall to next tick to avoid modal's closeOnBlur handler
                         // catching the same click event that triggered showing the modal
                         setTimeout(() => {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -9,7 +9,7 @@ import type {DesktopAPI} from '@mattermost/desktop-api';
 import {PluginAnalyticsRow} from '@mattermost/types/admin';
 import {getChannel as getChannelAction} from 'mattermost-redux/actions/channels';
 import {Client4} from 'mattermost-redux/client';
-import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getCurrentChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig, getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
@@ -95,6 +95,7 @@ import {
     StopRecordingConfirmation,
 } from 'src/components/expanded_view/stop_recording_confirmation';
 import {IncomingCallContainer} from 'src/components/incoming_calls/call_container';
+import JoinCallWatcher from 'src/components/join_call_watcher';
 import RecordingsFilePreview from 'src/components/recordings_file_preview';
 import AudioDevicesSettingsSection from 'src/components/user_settings/audio_devices_settings_section';
 import ScreenSharingSettingsSection from 'src/components/user_settings/screen_sharing_settings_section';
@@ -1099,6 +1100,14 @@ export default class Plugin {
             });
         });
 
+        // Watch the URL for ?join_call=true and trigger a join when it appears.
+        // Handles cross-channel link clicks and pasted URLs. Same-channel
+        // clicks are handled by the click handler below since the URL never
+        // changes in that case.
+        registry.registerRootComponent(() => (
+            <JoinCallWatcher onJoinCall={connectToCall}/>
+        ));
+
         // A dummy React component so we can access webapp's
         // WebSocket client through the provided hook. Just lovely.
         registry.registerGlobalComponent(() => {
@@ -1125,115 +1134,65 @@ export default class Plugin {
         this.registerWebSocketEvents(registry, store);
 
         let currChannelId = getCurrentChannelId(store.getState());
-        let processedJoinCallUrl = '';
-        let pendingJoinChannelId = '';
-        let lastCheckedUrl = '';
 
-        // Capture join_call parameter immediately at initialization, before React Router can strip it
-        // This is essential for pasted URLs where the channel ID isn't loaded in Redux yet
-        let initialJoinCallParam = new URLSearchParams(window.location.search).get('join_call');
-
-        // Function to check and handle join_call parameter
-        const handleJoinCallParam = () => {
-            const currentChannelId = getCurrentChannelId(store.getState());
-            const currentUrl = window.location.href;
-            const joinCallParam = new URLSearchParams(window.location.search).get('join_call');
-
-            // Check join_call parameter - only process each unique URL once
-            if (joinCallParam && currentChannelId && currentUrl !== processedJoinCallUrl) {
-                connectToCall(currentChannelId);
-                processedJoinCallUrl = currentUrl;
-                initialJoinCallParam = null; // Clear captured param since we processed it
-            }
-        };
-
-        // Intercept clicks on links with join_call parameter BEFORE React Router handles them
-        const handleLinkClick = (e: MouseEvent) => {
-            const target = e.target as HTMLElement;
-            const link = target.closest('a');
-            if (!link) {
-                return;
-            }
-
-            const href = link.getAttribute('href');
+        // Same-channel join_call links: when the link target is the channel
+        // we're already viewing, the webapp short-circuits navigation entirely
+        // and the URL never updates — so JoinCallWatcher can't see it. Catch
+        // those clicks here. Cross-channel clicks fall through to React Router
+        // and are handled by JoinCallWatcher after navigation.
+        const handleSameChannelLinkClick = (e: MouseEvent) => {
+            const link = (e.target as HTMLElement | null)?.closest('a');
+            const href = link?.getAttribute('href');
             if (!href) {
                 return;
             }
 
-            // Check if link contains join_call parameter
+            let url: URL;
             try {
-                const url = new URL(href, window.location.origin);
-                if (url.searchParams.get('join_call') === 'true') {
-                    // Extract channel ID from URL
-                    // URL format: /team-name/channels/channel-id?join_call=true
-                    const channelMatch = url.pathname.match(/\/channels\/([a-z0-9]+)/i);
-                    if (channelMatch) {
-                        const targetChannelId = channelMatch[1];
-                        const currentChannelId = getCurrentChannelId(store.getState());
-
-                        // If clicking link in same channel, prevent navigation and join directly
-                        if (targetChannelId === currentChannelId) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            e.stopImmediatePropagation();
-
-                            // Defer connectToCall to next tick to avoid the modal's closeOnBlur handler
-                            // catching the same click event that triggered showing the modal, which would
-                            // immediately hide the modal that was just shown
-                            setTimeout(() => {
-                                connectToCall(targetChannelId);
-                            }, 0);
-                            return;
-                        }
-
-                        // Different channel - set pending join and let navigation happen
-                        // React Router will strip the query param, so we track it here
-                        pendingJoinChannelId = targetChannelId;
-                    }
-                }
+                url = new URL(href, window.location.origin);
             } catch {
-                // Invalid URL, ignore
+                return;
             }
-        };
-        document.addEventListener('click', handleLinkClick, true);
-        this.unsubscribers.push(() => document.removeEventListener('click', handleLinkClick, true));
+            if (url.searchParams.get('join_call') !== 'true') {
+                return;
+            }
 
-        // Also check on Redux store updates (for navigation to different channels)
+            const targetMatch = url.pathname.match(/\/channels\/([^/]+)/);
+            if (!targetMatch) {
+                return;
+            }
+            const target = targetMatch[1];
+
+            const currentChannelId = getCurrentChannelId(store.getState());
+            const currentChannelName = getCurrentChannel(store.getState())?.name;
+            if (target !== currentChannelId && target !== currentChannelName) {
+                return;
+            }
+
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+
+            // Defer to the next tick so the click event finishes propagating
+            // before the switch modal might be shown — the modal's closeOnBlur
+            // handler is registered in capture phase and would otherwise catch
+            // this same click and immediately hide the modal.
+            setTimeout(() => connectToCall(currentChannelId), 0);
+        };
+        document.addEventListener('click', handleSameChannelLinkClick, true);
+        this.unsubscribers.push(() => document.removeEventListener('click', handleSameChannelLinkClick, true));
+
         this.unsubscribers.push(store.subscribe(() => {
             const currentChannelId = getCurrentChannelId(store.getState());
 
-            // Handle channel changes
+            // We only want to register the header menu component on first load
+            // and not on every channel switch.
             if (currChannelId !== currentChannelId) {
                 const firstLoad = !currChannelId;
                 currChannelId = currentChannelId;
-
-                // We only want to register the header menu component on first load and not
-                // on every channel switch.
                 if (firstLoad) {
                     registerHeaderMenuComponentIfNeeded(currentChannelId);
-
-                    // On first load, if we captured a join_call parameter, process it now
-                    // This handles pasted URLs where the parameter is captured before channel loads
-                    if (initialJoinCallParam && currentChannelId) {
-                        initialJoinCallParam = null; // Clear it so we don't process again
-                        connectToCall(currentChannelId);
-                    }
                 }
-
-                // Check if we navigated to a pending join channel
-                if (pendingJoinChannelId && pendingJoinChannelId === currentChannelId) {
-                    // Clear the flag immediately - connectToCall() will handle the rest
-                    // (including showing switch modal if already in a call)
-                    pendingJoinChannelId = '';
-                    connectToCall(currentChannelId);
-                }
-            }
-
-            // Check for join_call parameter only when URL changes (optimization)
-            const currentUrl = window.location.href;
-            if (currentUrl !== lastCheckedUrl) {
-                lastCheckedUrl = currentUrl;
-                handleJoinCallParam();
             }
         }));
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -429,13 +429,14 @@ export default class Plugin {
         });
 
         const connectToCall = async (channelId: string, teamId?: string, title?: string, rootId?: string) => {
-            const currentCallChannelId = channelIDForCurrentCall(store.getState());
+            // Prefer the live window.callsClient over Redux state: the client
+            // is the concrete "I am literally in a call right now" signal,
+            // while Redux can be transiently stale during reload reconnect.
+            // Falling back to Redux covers the case where the client hasn't
+            // attached yet on initial load.
+            const effectiveCurrentChannel = window.callsClient?.channelID ?? channelIDForCurrentCall(store.getState());
 
-            // Also check window.callsClient for active call (handles race condition during page load)
-            const hasActiveClient = Boolean(window.callsClient);
-            const activeClientChannel = window.callsClient?.channelID;
-
-            if (!currentCallChannelId && !hasActiveClient) {
+            if (!effectiveCurrentChannel) {
                 // Not in any call - join the new one
                 connectCall(channelId, title, rootId);
 
@@ -444,7 +445,7 @@ export default class Plugin {
                 if (channelHasCall(store.getState(), channelId)) {
                     followThread(store, channelId, teamId);
                 }
-            } else if ((currentCallChannelId && currentCallChannelId !== channelId) || (activeClientChannel && activeClientChannel !== channelId)) {
+            } else if (effectiveCurrentChannel !== channelId) {
                 // In a different call - show switch modal
                 store.dispatch(showSwitchCallModal(channelId));
             }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1103,9 +1103,11 @@ export default class Plugin {
         // Watch the URL for ?join_call=true and trigger a join when it appears.
         // Handles cross-channel link clicks and pasted URLs. Same-channel
         // clicks are handled by the click handler below since the URL never
-        // changes in that case.
+        // changes in that case. Routes through joinCall (not connectToCall)
+        // so URL-driven joins go through the same enabled/disabled, limit,
+        // and test-mode gating as the regular UI buttons.
         registry.registerRootComponent(() => (
-            <JoinCallWatcher onJoinCall={connectToCall}/>
+            <JoinCallWatcher onJoinCall={joinCall}/>
         ));
 
         // A dummy React component so we can access webapp's
@@ -1208,7 +1210,7 @@ export default class Plugin {
             // before the switch modal might be shown — the modal's closeOnBlur
             // handler is registered in capture phase and would otherwise catch
             // this same click and immediately hide the modal.
-            setTimeout(() => connectToCall(currentChannelId), 0);
+            setTimeout(() => joinCall(currentChannelId), 0);
         };
         document.addEventListener('click', handleSameChannelLinkClick, true);
         this.unsubscribers.push(() => document.removeEventListener('click', handleSameChannelLinkClick, true));

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1171,10 +1171,19 @@ export default class Plugin {
                 return;
             }
 
+            // On subpath deployments, url.pathname is /<basename>/<team>/...
+            // — strip the basename so the regex matches the team segment
+            // correctly. JoinCallWatcher doesn't need this because React
+            // Router's history is configured with basename and useLocation
+            // already returns paths relative to it.
+            const pathname = window.basename && url.pathname.startsWith(window.basename) ?
+                url.pathname.slice(window.basename.length) :
+                url.pathname;
+
             // Match the team segment too — a cross-team link like
             // /other-team/channels/<name> would otherwise mis-resolve against
             // the current channel's name in the current team.
-            const targetMatch = url.pathname.match(/^\/([^/]+)\/channels\/([^/]+)/);
+            const targetMatch = pathname.match(/^\/([^/]+)\/channels\/([^/]+)/);
             if (!targetMatch) {
                 return;
             }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -13,7 +13,7 @@ import {getChannel, getCurrentChannel, getCurrentChannelId} from 'mattermost-red
 import {getConfig, getServerVersion} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentTeam, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {ActionFuncAsync} from 'mattermost-redux/types/actions';
 import React, {useEffect} from 'react';
@@ -1141,8 +1141,19 @@ export default class Plugin {
         // those clicks here. Cross-channel clicks fall through to React Router
         // and are handled by JoinCallWatcher after navigation.
         const handleSameChannelLinkClick = (e: MouseEvent) => {
+            // Preserve normal browser behavior for non-primary clicks, modified
+            // clicks (Cmd/Ctrl-click → new tab, Shift-click → new window), and
+            // links that explicitly open elsewhere.
+            if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+                return;
+            }
+
             const link = (e.target as HTMLElement | null)?.closest('a');
-            const href = link?.getAttribute('href');
+            if (!link || (link.target && link.target !== '_self')) {
+                return;
+            }
+
+            const href = link.getAttribute('href');
             if (!href) {
                 return;
             }
@@ -1153,15 +1164,26 @@ export default class Plugin {
             } catch {
                 return;
             }
+            if (url.origin !== window.location.origin) {
+                return;
+            }
             if (url.searchParams.get('join_call') !== 'true') {
                 return;
             }
 
-            const targetMatch = url.pathname.match(/\/channels\/([^/]+)/);
+            // Match the team segment too — a cross-team link like
+            // /other-team/channels/<name> would otherwise mis-resolve against
+            // the current channel's name in the current team.
+            const targetMatch = url.pathname.match(/^\/([^/]+)\/channels\/([^/]+)/);
             if (!targetMatch) {
                 return;
             }
-            const target = targetMatch[1];
+            const [, teamName, target] = targetMatch;
+
+            const currentTeamName = getCurrentTeam(store.getState())?.name;
+            if (!currentTeamName || teamName !== currentTeamName) {
+                return;
+            }
 
             const currentChannelId = getCurrentChannelId(store.getState());
             const currentChannelName = getCurrentChannel(store.getState())?.name;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -97,6 +97,7 @@ import {
 import {IncomingCallContainer} from 'src/components/incoming_calls/call_container';
 import JoinCallWatcher from 'src/components/join_call_watcher';
 import RecordingsFilePreview from 'src/components/recordings_file_preview';
+import {makeSameChannelLinkClickHandler} from 'src/components/same_channel_link_click_handler';
 import AudioDevicesSettingsSection from 'src/components/user_settings/audio_devices_settings_section';
 import ScreenSharingSettingsSection from 'src/components/user_settings/screen_sharing_settings_section';
 import VideoDevicesSettingsSection from 'src/components/user_settings/video_devices_settings_section';
@@ -1143,76 +1144,12 @@ export default class Plugin {
         // and the URL never updates — so JoinCallWatcher can't see it. Catch
         // those clicks here. Cross-channel clicks fall through to React Router
         // and are handled by JoinCallWatcher after navigation.
-        const handleSameChannelLinkClick = (e: MouseEvent) => {
-            // Preserve normal browser behavior for non-primary clicks, modified
-            // clicks (Cmd/Ctrl-click → new tab, Shift-click → new window), and
-            // links that explicitly open elsewhere.
-            if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
-                return;
-            }
-
-            const link = (e.target as HTMLElement | null)?.closest('a');
-            if (!link || (link.target && link.target !== '_self')) {
-                return;
-            }
-
-            const href = link.getAttribute('href');
-            if (!href) {
-                return;
-            }
-
-            let url: URL;
-            try {
-                url = new URL(href, window.location.origin);
-            } catch {
-                return;
-            }
-            if (url.origin !== window.location.origin) {
-                return;
-            }
-            if (url.searchParams.get('join_call') !== 'true') {
-                return;
-            }
-
-            // On subpath deployments, url.pathname is /<basename>/<team>/...
-            // — strip the basename so the regex matches the team segment
-            // correctly. JoinCallWatcher doesn't need this because React
-            // Router's history is configured with basename and useLocation
-            // already returns paths relative to it.
-            const pathname = window.basename && url.pathname.startsWith(window.basename) ?
-                url.pathname.slice(window.basename.length) :
-                url.pathname;
-
-            // Match the team segment too — a cross-team link like
-            // /other-team/channels/<name> would otherwise mis-resolve against
-            // the current channel's name in the current team.
-            const targetMatch = pathname.match(/^\/([^/]+)\/channels\/([^/]+)/);
-            if (!targetMatch) {
-                return;
-            }
-            const [, teamName, target] = targetMatch;
-
-            const currentTeamName = getCurrentTeam(store.getState())?.name;
-            if (!currentTeamName || teamName !== currentTeamName) {
-                return;
-            }
-
-            const currentChannelId = getCurrentChannelId(store.getState());
-            const currentChannelName = getCurrentChannel(store.getState())?.name;
-            if (target !== currentChannelId && target !== currentChannelName) {
-                return;
-            }
-
-            e.preventDefault();
-            e.stopPropagation();
-            e.stopImmediatePropagation();
-
-            // Defer to the next tick so the click event finishes propagating
-            // before the switch modal might be shown — the modal's closeOnBlur
-            // handler is registered in capture phase and would otherwise catch
-            // this same click and immediately hide the modal.
-            setTimeout(() => joinCall(currentChannelId), 0);
-        };
+        const handleSameChannelLinkClick = makeSameChannelLinkClickHandler(
+            () => getCurrentTeam(store.getState())?.name,
+            () => getCurrentChannelId(store.getState()),
+            () => getCurrentChannel(store.getState())?.name,
+            joinCall,
+        );
         document.addEventListener('click', handleSameChannelLinkClick, true);
         this.unsubscribers.push(() => document.removeEventListener('click', handleSameChannelLinkClick, true));
 


### PR DESCRIPTION
#### Summary
Problem: Call links (/call link) don't work when clicked from within webapp - join_call parameter is read once at initialization and only checked on channel changes. These links only work when pasted into browser or clicked externally, causing new page load. See Jira ticket for more explanation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67348


