### PR TITLE
Add video statistics and metrics

### DIFF
--- a/server/db/stats_store.go
+++ b/server/db/stats_store.go
@@ -309,6 +309,83 @@ func (s *Store) GetRecordingJobsByDay() (map[string]int64, error) {
 	return s.getByDay(getByDayQueryBase(s.driverName, now).From("calls_jobs").Where(sq.Eq{"type": public.JobTypeRecording}), now)
 }
 
+func (s *Store) GetAvgVideoDuration() (int64, error) {
+	s.metrics.IncStoreOp("GetAvgVideoDuration")
+	defer func(start time.Time) {
+		s.metrics.ObserveStoreMethodsTime("GetAvgVideoDuration", time.Since(start).Seconds())
+	}(time.Now())
+
+	var jsonPath string
+	if s.driverName == model.DatabaseDriverMysql {
+		jsonPath = "JSON_EXTRACT(stats, '$.video_duration')"
+	} else {
+		jsonPath = "(stats->>'video_duration')::bigint"
+	}
+
+	qb := getQueryBuilder(s.driverName).
+		Select(fmt.Sprintf("AVG(%s)", jsonPath)).
+		From("calls").
+		Where(sq.And{
+			sq.Expr("EndAt > StartAt"),
+			sq.Eq{"DeleteAt": 0},
+			sq.NotEq{jsonPath: nil},
+		})
+
+	q, args, err := qb.ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	var count *float64
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*s.settings.QueryTimeout)*time.Second)
+	defer cancel()
+	if err := s.rDBx.GetContext(ctx, &count, q, args...); err != nil {
+		return 0, fmt.Errorf("failed to get average video duration: %w", err)
+	}
+
+	if count == nil {
+		return 0, nil
+	}
+
+	return int64(math.Round(*count)), nil
+}
+
+func (s *Store) GetTotalVideoDuration() (int64, error) {
+	s.metrics.IncStoreOp("GetTotalVideoDuration")
+	defer func(start time.Time) {
+		s.metrics.ObserveStoreMethodsTime("GetTotalVideoDuration", time.Since(start).Seconds())
+	}(time.Now())
+
+	var jsonPath string
+	if s.driverName == model.DatabaseDriverMysql {
+		jsonPath = "JSON_EXTRACT(stats, '$.video_duration')"
+	} else {
+		jsonPath = "(stats->>'video_duration')::bigint"
+	}
+
+	qb := getQueryBuilder(s.driverName).
+		Select(fmt.Sprintf("COALESCE(SUM(%s), 0)", jsonPath)).
+		From("calls").
+		Where(sq.And{
+			sq.Expr("EndAt > StartAt"),
+			sq.Eq{"DeleteAt": 0},
+		})
+
+	q, args, err := qb.ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	var total int64
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*s.settings.QueryTimeout)*time.Second)
+	defer cancel()
+	if err := s.rDBx.GetContext(ctx, &total, q, args...); err != nil {
+		return 0, fmt.Errorf("failed to get total video duration: %w", err)
+	}
+
+	return total, nil
+}
+
 func (s *Store) GetCallsStats() (*public.CallsStats, error) {
 	s.metrics.IncStoreOp("GetCallsStats")
 	defer func(start time.Time) {
@@ -354,6 +431,16 @@ func (s *Store) GetCallsStats() (*public.CallsStats, error) {
 	}
 
 	stats.AvgParticipants, err = s.GetAvgCallParticipants()
+	if err != nil {
+		return nil, err
+	}
+
+	stats.AvgVideoDuration, err = s.GetAvgVideoDuration()
+	if err != nil {
+		return nil, err
+	}
+
+	stats.TotalVideoDuration, err = s.GetTotalVideoDuration()
 	if err != nil {
 		return nil, err
 	}

--- a/server/db/stats_store_test.go
+++ b/server/db/stats_store_test.go
@@ -16,7 +16,8 @@ import (
 
 func TestStatsStore(t *testing.T) {
 	testStore(t, map[string]func(t *testing.T, store *Store){
-		"TestGetStats": testGetStats,
+		"TestGetStats":      testGetStats,
+		"TestGetVideoStats": testGetVideoStats,
 	})
 }
 
@@ -240,5 +241,205 @@ func testGetStats(t *testing.T, store *Store) {
 
 			require.Equal(t, int64(jobsInMonth), stats.RecordingJobsByMonth[d.Format("2006-01")])
 		}
+	})
+}
+
+func testGetVideoStats(t *testing.T, store *Store) {
+	// Helper to create a call with video statistics
+	createCallWithVideo := func(startAt time.Time, videoDuration int64, hasUsedVideo, hasUsedScreenShare bool) {
+		call := &public.Call{
+			ID:           model.NewId(),
+			CreateAt:     startAt.UnixMilli(),
+			ChannelID:    model.NewId(),
+			StartAt:      startAt.UnixMilli(),
+			EndAt:        startAt.Add(time.Hour).UnixMilli(),
+			PostID:       model.NewId(),
+			ThreadID:     model.NewId(),
+			OwnerID:      model.NewId(),
+			Participants: []string{model.NewId()},
+			Stats: public.CallStats{
+				VideoDuration:      videoDuration,
+				HasUsedVideo:       hasUsedVideo,
+				HasUsedScreenShare: hasUsedScreenShare,
+			},
+		}
+		err := store.CreateCall(call)
+		require.NoError(t, err)
+	}
+
+	t.Run("empty tables", func(t *testing.T) {
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		require.Zero(t, stats.AvgVideoDuration)
+		require.Zero(t, stats.TotalVideoDuration)
+		require.Zero(t, stats.TotalVideoCalls)
+		require.Zero(t, stats.TotalScreenShareCalls)
+	})
+
+	t.Run("average video duration", func(t *testing.T) {
+		defer resetStore(t, store)
+
+		now := time.Now()
+
+		// Create 3 calls with video: 10s, 20s, 30s
+		createCallWithVideo(now.AddDate(0, 0, -1), 10, true, false)
+		createCallWithVideo(now.AddDate(0, 0, -2), 20, true, false)
+		createCallWithVideo(now.AddDate(0, 0, -3), 30, true, false)
+
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		// Average should be (10 + 20 + 30) / 3 = 20
+		require.Equal(t, int64(20), stats.AvgVideoDuration)
+	})
+
+	t.Run("total video duration", func(t *testing.T) {
+		defer resetStore(t, store)
+
+		now := time.Now()
+
+		// Create calls with various video durations
+		createCallWithVideo(now.AddDate(0, 0, -1), 100, true, false)
+		createCallWithVideo(now.AddDate(0, 0, -2), 200, true, false)
+		createCallWithVideo(now.AddDate(0, 0, -3), 300, true, false)
+
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		// Total should be 100 + 200 + 300 = 600
+		require.Equal(t, int64(600), stats.TotalVideoDuration)
+	})
+
+	t.Run("excludes calls without video", func(t *testing.T) {
+		defer resetStore(t, store)
+
+		now := time.Now()
+
+		// 2 calls with video
+		createCallWithVideo(now.AddDate(0, 0, -1), 10, true, false)
+		createCallWithVideo(now.AddDate(0, 0, -2), 20, true, false)
+
+		// 3 calls without video (HasUsedVideo = false, VideoDuration = 0)
+		createCallWithVideo(now.AddDate(0, 0, -3), 0, false, false)
+		createCallWithVideo(now.AddDate(0, 0, -4), 0, false, false)
+		createCallWithVideo(now.AddDate(0, 0, -5), 0, false, false)
+
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		// Only 2 calls had video
+		require.Equal(t, int64(2), stats.TotalVideoCalls)
+		// Average only considers calls with video: (10 + 20) / 2 = 15
+		require.Equal(t, int64(15), stats.AvgVideoDuration)
+		// Total: 10 + 20 = 30
+		require.Equal(t, int64(30), stats.TotalVideoDuration)
+	})
+
+	t.Run("screen share statistics", func(t *testing.T) {
+		defer resetStore(t, store)
+
+		now := time.Now()
+
+		// 3 calls with screen share
+		createCallWithVideo(now.AddDate(0, 0, -1), 0, false, true)
+		createCallWithVideo(now.AddDate(0, 0, -2), 0, false, true)
+		createCallWithVideo(now.AddDate(0, 0, -3), 0, false, true)
+
+		// 2 calls without screen share
+		createCallWithVideo(now.AddDate(0, 0, -4), 0, false, false)
+		createCallWithVideo(now.AddDate(0, 0, -5), 0, false, false)
+
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(3), stats.TotalScreenShareCalls)
+	})
+
+	t.Run("mixed video and screen share", func(t *testing.T) {
+		defer resetStore(t, store)
+
+		now := time.Now()
+
+		// Call with both video and screen share
+		createCallWithVideo(now.AddDate(0, 0, -1), 100, true, true)
+
+		// Call with only video
+		createCallWithVideo(now.AddDate(0, 0, -2), 200, true, false)
+
+		// Call with only screen share
+		createCallWithVideo(now.AddDate(0, 0, -3), 0, false, true)
+
+		// Call with neither
+		createCallWithVideo(now.AddDate(0, 0, -4), 0, false, false)
+
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(2), stats.TotalVideoCalls)        // Calls 1 and 2
+		require.Equal(t, int64(2), stats.TotalScreenShareCalls)  // Calls 1 and 3
+		require.Equal(t, int64(150), stats.AvgVideoDuration)     // (100 + 200) / 2
+		require.Equal(t, int64(300), stats.TotalVideoDuration)   // 100 + 200
+	})
+
+	t.Run("person-seconds accumulation", func(t *testing.T) {
+		defer resetStore(t, store)
+
+		now := time.Now()
+
+		// Simulate a call where multiple participants had video on
+		// If 3 users had video on for 10 seconds each, total = 30 participant-seconds
+		createCallWithVideo(now.AddDate(0, 0, -1), 30, true, false)
+
+		// Another call with 2 users × 20 seconds = 40 participant-seconds
+		createCallWithVideo(now.AddDate(0, 0, -2), 40, true, false)
+
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		// Average: (30 + 40) / 2 = 35 participant-seconds
+		require.Equal(t, int64(35), stats.AvgVideoDuration)
+		// Total: 30 + 40 = 70 participant-seconds
+		require.Equal(t, int64(70), stats.TotalVideoDuration)
+	})
+
+	t.Run("handles zero and null values", func(t *testing.T) {
+		defer resetStore(t, store)
+
+		now := time.Now()
+
+		// Mix of calls with video and without
+		createCallWithVideo(now.AddDate(0, 0, -1), 100, true, false)
+		createCallWithVideo(now.AddDate(0, 0, -2), 0, false, false)
+		createCallWithVideo(now.AddDate(0, 0, -3), 50, true, false)
+
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		// Should only average over calls with video (100 + 50) / 2 = 75
+		require.Equal(t, int64(75), stats.AvgVideoDuration)
+		// Total: 100 + 50 = 150 (zero excluded due to NULL filter)
+		require.Equal(t, int64(150), stats.TotalVideoDuration)
+		require.Equal(t, int64(2), stats.TotalVideoCalls)
+	})
+
+	t.Run("large participant-seconds values", func(t *testing.T) {
+		defer resetStore(t, store)
+
+		now := time.Now()
+
+		// Simulate a large call: 100 participants × 3600 seconds (1 hour) = 360,000 participant-seconds
+		createCallWithVideo(now.AddDate(0, 0, -1), 360000, true, false)
+
+		// Smaller call: 10 participants × 600 seconds (10 min) = 6,000 participant-seconds
+		createCallWithVideo(now.AddDate(0, 0, -2), 6000, true, false)
+
+		stats, err := store.GetCallsStats()
+		require.NoError(t, err)
+
+		// Average: (360,000 + 6,000) / 2 = 183,000
+		require.Equal(t, int64(183000), stats.AvgVideoDuration)
+		// Total: 360,000 + 6,000 = 366,000
+		require.Equal(t, int64(366000), stats.TotalVideoDuration)
 	})
 }

--- a/server/db/stats_store_test.go
+++ b/server/db/stats_store_test.go
@@ -376,10 +376,10 @@ func testGetVideoStats(t *testing.T, store *Store) {
 		stats, err := store.GetCallsStats()
 		require.NoError(t, err)
 
-		require.Equal(t, int64(2), stats.TotalVideoCalls)        // Calls 1 and 2
-		require.Equal(t, int64(2), stats.TotalScreenShareCalls)  // Calls 1 and 3
-		require.Equal(t, int64(150), stats.AvgVideoDuration)     // (100 + 200) / 2
-		require.Equal(t, int64(300), stats.TotalVideoDuration)   // 100 + 200
+		require.Equal(t, int64(2), stats.TotalVideoCalls)       // Calls 1 and 2
+		require.Equal(t, int64(2), stats.TotalScreenShareCalls) // Calls 1 and 3
+		require.Equal(t, int64(150), stats.AvgVideoDuration)    // (100 + 200) / 2
+		require.Equal(t, int64(300), stats.TotalVideoDuration)  // 100 + 200
 	})
 
 	t.Run("person-seconds accumulation", func(t *testing.T) {

--- a/server/metrics_update.go
+++ b/server/metrics_update.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"github.com/mattermost/mattermost-plugin-calls/server/performance"
+)
+
+// runMetricsUpdateJob runs a periodic job to update historical metrics from the database
+func (p *Plugin) runMetricsUpdateJob() {
+	// Run immediately on startup
+	p.updateHistoricalMetrics()
+
+	// Then run periodically
+	for range p.metricsUpdateTicker.C {
+		p.updateHistoricalMetrics()
+	}
+}
+
+// updateHistoricalMetrics fetches stats from the database and updates Prometheus gauges
+func (p *Plugin) updateHistoricalMetrics() {
+	// Type assert to get access to UpdateHistoricalMetrics method
+	metricsImpl, ok := p.metrics.(*performance.Metrics)
+	if !ok || metricsImpl == nil {
+		return
+	}
+
+	// Get stats from database (reuse existing code from api.go)
+	stats, err := p.store.GetCallsStats()
+	if err != nil {
+		p.LogError("Failed to get stats for metrics update", "error", err.Error())
+		return
+	}
+
+	// Extract calls by day and month from stats
+	callsByDay := stats.CallsByDay
+	callsByMonth := stats.CallsByMonth
+
+	// Update the metrics
+	metricsImpl.UpdateHistoricalMetrics(stats, callsByDay, callsByMonth)
+
+	p.LogDebug("Updated historical metrics", "total_calls", stats.TotalCalls, "daily_entries", len(callsByDay), "monthly_entries", len(callsByMonth))
+}

--- a/server/metrics_update.go
+++ b/server/metrics_update.go
@@ -13,8 +13,13 @@ func (p *Plugin) runMetricsUpdateJob() {
 	p.updateHistoricalMetrics()
 
 	// Then run periodically
-	for range p.metricsUpdateTicker.C {
-		p.updateHistoricalMetrics()
+	for {
+		select {
+		case <-p.metricsUpdateTicker.C:
+			p.updateHistoricalMetrics()
+		case <-p.stopCh:
+			return
+		}
 	}
 }
 

--- a/server/performance/metrics.go
+++ b/server/performance/metrics.go
@@ -345,22 +345,14 @@ func (m *Metrics) UpdateHistoricalMetrics(stats *public.CallsStats, callsByDay, 
 	m.HistoricalDailyCallsGauge.Reset()
 	m.HistoricalMonthlyCallsGauge.Reset()
 
-	// Update daily metrics (last 30 days) - shorten date format from YYYY-MM-DD to MM-DD
+	// Update daily metrics (last 30 days)
 	for date, count := range callsByDay {
-		shortDate := date
-		if len(date) == 10 && date[4] == '-' {
-			shortDate = date[5:] // Extract MM-DD from YYYY-MM-DD
-		}
-		m.HistoricalDailyCallsGauge.With(prometheus.Labels{"date": shortDate}).Set(float64(count))
+		m.HistoricalDailyCallsGauge.With(prometheus.Labels{"date": date}).Set(float64(count))
 	}
 
-	// Update monthly metrics - shorten from YYYY-MM to MM
+	// Update monthly metrics
 	for month, count := range callsByMonth {
-		shortMonth := month
-		if len(month) == 7 && month[4] == '-' {
-			shortMonth = month[5:] // Extract MM from YYYY-MM
-		}
-		m.HistoricalMonthlyCallsGauge.With(prometheus.Labels{"month": shortMonth}).Set(float64(count))
+		m.HistoricalMonthlyCallsGauge.With(prometheus.Labels{"month": month}).Set(float64(count))
 	}
 
 	// Update channel type distribution

--- a/server/performance/metrics.go
+++ b/server/performance/metrics.go
@@ -53,6 +53,12 @@ type Metrics struct {
 	LiveCaptionsPktPayloadChBufFullCounter prometheus.Counter
 
 	ClientICECandidatePairsCounter *prometheus.CounterVec
+
+	// Historical statistics gauges
+	HistoricalDailyCallsGauge   *prometheus.GaugeVec
+	HistoricalMonthlyCallsGauge *prometheus.GaugeVec
+	CallsByChannelTypeGauge     *prometheus.GaugeVec
+	AggregateStatsGauges        *prometheus.GaugeVec
 }
 
 func NewMetrics() *Metrics {
@@ -209,6 +215,47 @@ func NewMetrics() *Metrics {
 	)
 	m.registry.MustRegister(m.ClientICECandidatePairsCounter)
 
+	// Historical statistics gauges
+	m.HistoricalDailyCallsGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "daily_calls_total",
+			Help:      "Total number of calls per day (last 30 days)",
+		},
+		[]string{"date"},
+	)
+	m.registry.MustRegister(m.HistoricalDailyCallsGauge)
+
+	m.HistoricalMonthlyCallsGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "monthly_calls_total",
+			Help:      "Total number of calls per month",
+		},
+		[]string{"month"},
+	)
+	m.registry.MustRegister(m.HistoricalMonthlyCallsGauge)
+
+	m.CallsByChannelTypeGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "calls_by_channel_type",
+			Help:      "Total calls by channel type (public, private, direct, group)",
+		},
+		[]string{"type"},
+	)
+	m.registry.MustRegister(m.CallsByChannelTypeGauge)
+
+	m.AggregateStatsGauges = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "aggregate_stats",
+			Help:      "Aggregate statistics (avg_duration, avg_participants, etc)",
+		},
+		[]string{"stat"},
+	)
+	m.registry.MustRegister(m.AggregateStatsGauges)
+
 	m.rtcMetrics = perf.NewMetrics(metricsNamespace, m.registry)
 
 	return &m
@@ -290,4 +337,59 @@ func (m *Metrics) IncClientICECandidatePairs(p public.ClientICECandidatePairMetr
 		"remote_type":     p.Remote.Type,
 		"remote_protocol": p.Remote.Protocol,
 	}).Inc()
+}
+
+// UpdateHistoricalMetrics updates the historical statistics gauges with data from the database
+func (m *Metrics) UpdateHistoricalMetrics(stats *public.CallsStats, callsByDay, callsByMonth map[string]int64) {
+	// Reset gauges before updating to remove old dates
+	m.HistoricalDailyCallsGauge.Reset()
+	m.HistoricalMonthlyCallsGauge.Reset()
+
+	// Update daily metrics (last 30 days) - shorten date format from YYYY-MM-DD to MM-DD
+	for date, count := range callsByDay {
+		shortDate := date
+		if len(date) == 10 && date[4] == '-' {
+			shortDate = date[5:] // Extract MM-DD from YYYY-MM-DD
+		}
+		m.HistoricalDailyCallsGauge.With(prometheus.Labels{"date": shortDate}).Set(float64(count))
+	}
+
+	// Update monthly metrics - shorten from YYYY-MM to MM
+	for month, count := range callsByMonth {
+		shortMonth := month
+		if len(month) == 7 && month[4] == '-' {
+			shortMonth = month[5:] // Extract MM from YYYY-MM
+		}
+		m.HistoricalMonthlyCallsGauge.With(prometheus.Labels{"month": shortMonth}).Set(float64(count))
+	}
+
+	// Update channel type distribution
+	for channelType, count := range stats.CallsByChannelType {
+		typeLabel := channelTypeToLabel(channelType)
+		m.CallsByChannelTypeGauge.With(prometheus.Labels{"type": typeLabel}).Set(float64(count))
+	}
+
+	// Update aggregate stats
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "total_calls"}).Set(float64(stats.TotalCalls))
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "total_active_calls"}).Set(float64(stats.TotalActiveCalls))
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "total_active_sessions"}).Set(float64(stats.TotalActiveSessions))
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "avg_duration_seconds"}).Set(float64(stats.AvgDuration))
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "avg_participants"}).Set(float64(stats.AvgParticipants))
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "avg_video_duration_seconds"}).Set(float64(stats.AvgVideoDuration))
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "total_video_duration_seconds"}).Set(float64(stats.TotalVideoDuration))
+}
+
+func channelTypeToLabel(t string) string {
+	switch t {
+	case "O":
+		return "public"
+	case "P":
+		return "private"
+	case "D":
+		return "direct"
+	case "G":
+		return "group"
+	default:
+		return "unknown"
+	}
 }

--- a/server/performance/metrics.go
+++ b/server/performance/metrics.go
@@ -377,6 +377,8 @@ func (m *Metrics) UpdateHistoricalMetrics(stats *public.CallsStats, callsByDay, 
 	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "avg_participants"}).Set(float64(stats.AvgParticipants))
 	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "avg_video_duration_seconds"}).Set(float64(stats.AvgVideoDuration))
 	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "total_video_duration_seconds"}).Set(float64(stats.TotalVideoDuration))
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "total_video_calls"}).Set(float64(stats.TotalVideoCalls))
+	m.AggregateStatsGauges.With(prometheus.Labels{"stat": "total_screen_share_calls"}).Set(float64(stats.TotalScreenShareCalls))
 }
 
 func channelTypeToLabel(t string) string {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -79,6 +79,9 @@ type Plugin struct {
 	// Batchers
 	addSessionsBatchers    map[string]*batching.Batcher
 	removeSessionsBatchers map[string]*batching.Batcher
+
+	// Historical metrics update ticker
+	metricsUpdateTicker *time.Ticker
 }
 
 func (p *Plugin) startSession(us *session, senderID string, props rtc.SessionProps) {

--- a/server/public/call.go
+++ b/server/public/call.go
@@ -78,8 +78,10 @@ type CallProps struct {
 
 type CallStats struct {
 	ScreenDuration int64 `json:"screen_duration,omitempty"`
-	// VideoDuration tracks the total time (in seconds) that any participant had video enabled.
-	// This is cumulative across all participants (e.g., if 2 users have video on for 10s each, this would be 20s).
+	// VideoDuration tracks the cumulative participant-seconds of video usage across all participants.
+	// This is a "person-seconds" metric that sums individual video time for capacity planning.
+	// Example: 3 participants with video on for 10 seconds each = 30 seconds total.
+	// Example: 8 participants on video for a 30-minute call = 14,400 seconds (240 participant-minutes).
 	VideoDuration int64 `json:"video_duration,omitempty"`
 	// HasUsedVideo indicates if video was enabled at least once during this call.
 	// This flag is set to true the first time any participant enables video, and remains true

--- a/server/public/call.go
+++ b/server/public/call.go
@@ -71,8 +71,14 @@ type CallProps struct {
 	NodeID                 string              `json:"node_id,omitempty"`
 	Participants           map[string]struct{} `json:"participants,omitempty"`
 	HostLockedUserID       string              `json:"host_locked_user_id,omitempty"`
+	// VideoStartAt tracks when each session started video, keyed by session ID.
+	// Used to calculate accumulated video duration.
+	VideoStartAt map[string]int64 `json:"video_start_at,omitempty"`
 }
 
 type CallStats struct {
 	ScreenDuration int64 `json:"screen_duration,omitempty"`
+	// VideoDuration tracks the total time (in seconds) that any participant had video enabled.
+	// This is cumulative across all participants (e.g., if 2 users have video on for 10s each, this would be 20s).
+	VideoDuration int64 `json:"video_duration,omitempty"`
 }

--- a/server/public/call.go
+++ b/server/public/call.go
@@ -81,4 +81,12 @@ type CallStats struct {
 	// VideoDuration tracks the total time (in seconds) that any participant had video enabled.
 	// This is cumulative across all participants (e.g., if 2 users have video on for 10s each, this would be 20s).
 	VideoDuration int64 `json:"video_duration,omitempty"`
+	// HasUsedVideo indicates if video was enabled at least once during this call.
+	// This flag is set to true the first time any participant enables video, and remains true
+	// even if video is subsequently disabled. Used for counting calls with video usage.
+	HasUsedVideo bool `json:"has_used_video,omitempty"`
+	// HasUsedScreenShare indicates if screen sharing was enabled at least once during this call.
+	// This flag is set to true the first time any participant enables screen sharing, and remains true
+	// even if screen sharing is subsequently disabled. Used for counting calls with screen sharing usage.
+	HasUsedScreenShare bool `json:"has_used_screen_share,omitempty"`
 }

--- a/server/public/stats.go
+++ b/server/public/stats.go
@@ -20,6 +20,10 @@ type CallsStats struct {
 	AvgDuration int64 `json:"avg_duration" yaml:"avg_duration"`
 	// The average peak number of participants in calls.
 	AvgParticipants int64 `json:"avg_participants" yaml:"avg_participants"`
+	// The average video duration in seconds across all calls.
+	AvgVideoDuration int64 `json:"avg_video_duration" yaml:"avg_video_duration"`
+	// The total accumulated video duration in seconds across all calls.
+	TotalVideoDuration int64 `json:"total_video_duration" yaml:"total_video_duration"`
 	// The number of daily recording jobs in the last 30 days.
 	RecordingJobsByDay map[string]int64 `json:"recording_jobs_by_day" yaml:"-"`
 	// The number of monthly recording jobs in the last 12 months.

--- a/server/public/stats.go
+++ b/server/public/stats.go
@@ -20,9 +20,11 @@ type CallsStats struct {
 	AvgDuration int64 `json:"avg_duration" yaml:"avg_duration"`
 	// The average peak number of participants in calls.
 	AvgParticipants int64 `json:"avg_participants" yaml:"avg_participants"`
-	// The average video duration in seconds across all calls.
+	// The average participant-seconds of video usage per call (person-seconds metric).
+	// This represents average video capacity consumed per call.
 	AvgVideoDuration int64 `json:"avg_video_duration" yaml:"avg_video_duration"`
-	// The total accumulated video duration in seconds across all calls.
+	// The total accumulated participant-seconds of video usage across all calls (person-seconds metric).
+	// This represents total video capacity consumed across the platform.
 	TotalVideoDuration int64 `json:"total_video_duration" yaml:"total_video_duration"`
 	// The total number of calls that had video enabled at least once.
 	TotalVideoCalls int64 `json:"total_video_calls" yaml:"total_video_calls"`

--- a/server/public/stats.go
+++ b/server/public/stats.go
@@ -24,6 +24,10 @@ type CallsStats struct {
 	AvgVideoDuration int64 `json:"avg_video_duration" yaml:"avg_video_duration"`
 	// The total accumulated video duration in seconds across all calls.
 	TotalVideoDuration int64 `json:"total_video_duration" yaml:"total_video_duration"`
+	// The total number of calls that had video enabled at least once.
+	TotalVideoCalls int64 `json:"total_video_calls" yaml:"total_video_calls"`
+	// The total number of calls that had screen sharing enabled at least once.
+	TotalScreenShareCalls int64 `json:"total_screen_share_calls" yaml:"total_screen_share_calls"`
 	// The number of daily recording jobs in the last 30 days.
 	RecordingJobsByDay map[string]int64 `json:"recording_jobs_by_day" yaml:"-"`
 	// The number of monthly recording jobs in the last 12 months.

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -184,6 +184,11 @@ func (p *Plugin) handleClientMessageTypeScreen(us *session, msg clientMessage, h
 		}
 		state.Call.Props.ScreenSharingSessionID = us.originalConnID
 		state.Call.Props.ScreenStartAt = time.Now().Unix()
+
+		// Mark that this call has used screen sharing (only set once per call)
+		if !state.Call.Stats.HasUsedScreenShare {
+			state.Call.Stats.HasUsedScreenShare = true
+		}
 	} else {
 		if state.Call.Props.ScreenSharingSessionID != us.originalConnID {
 			return fmt.Errorf("cannot stop screen sharing, someone else is sharing already: connID=%s", state.Call.Props.ScreenSharingSessionID)
@@ -422,6 +427,11 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 				state.Call.Props.VideoStartAt = make(map[string]int64)
 			}
 			state.Call.Props.VideoStartAt[us.originalConnID] = time.Now().Unix()
+
+			// Mark that this call has used video (only set once per call)
+			if !state.Call.Stats.HasUsedVideo {
+				state.Call.Stats.HasUsedVideo = true
+			}
 		} else {
 			// Video turned off - accumulate the duration
 			session.Video = false

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -200,9 +200,8 @@ func (p *Plugin) handleClientMessageTypeScreen(us *session, msg clientMessage, h
 		}
 	}
 
-	if err := p.store.UpdateCall(&state.Call); err != nil {
-		return fmt.Errorf("failed to update call: %w", err)
-	}
+	// Note: Screen sharing stats are persisted when users leave or call ends,
+	// no need to write to DB on every toggle for performance.
 
 	msgType := rtc.ScreenOnMessage
 	wsMsgType := wsEventUserScreenOn
@@ -447,9 +446,8 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 			return fmt.Errorf("failed to update call session: %w", err)
 		}
 
-		if err := p.store.UpdateCall(&state.Call); err != nil {
-			return fmt.Errorf("failed to update call: %w", err)
-		}
+		// Note: Video stats are persisted when users leave or call ends,
+		// no need to write to DB on every toggle for performance.
 
 		evType := wsEventUserVideoOn
 		if msg.Type == clientMessageTypeVideoOff {


### PR DESCRIPTION
#### Summary
This PR adds comprehensive video usage tracking and metrics to the Calls plugin. It tracks participant-seconds of video usage, video-enabled call counts, and screen sharing statistics in real-time during calls, storing them in the call stats JSON field. New database queries calculate aggregate metrics (average/total video duration, counts of calls with video/screen share) with cross-database support for MySQL and PostgreSQL. A background job updates Prometheus gauges hourly for monitoring and alerting, with metrics exposed via the existing /metrics endpoint. Performance is optimized by deferring database writes until users leave or calls end. Includes test coverage.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66865