### PR TITLE
[MM-68145] Remove css-vars-ponyfill its unnecessary IE11 CSS custom properties polyfill

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -432,21 +432,6 @@ THE SOFTWARE.
 
 ---
 
-## css-vars-ponyfill
-
-This product contains 'css-vars-ponyfill' by John Hildenbiddle.
-
-Client-side support for CSS custom properties (aka "CSS variables") in legacy and modern browsers
-
-* HOMEPAGE:
-  * https://jhildenbiddle.github.io/css-vars-ponyfill/
-
-* LICENSE: MIT
-
-
-
----
-
 ## emoji-picker-react
 
 This product contains 'emoji-picker-react' by ealush.

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -51,7 +51,6 @@
         "babel-plugin-styled-components": "2.1.4",
         "babel-plugin-typescript-to-proptypes": "2.1.0",
         "css-loader": "5.2.6",
-        "css-vars-ponyfill": "2.4.8",
         "eslint": "8.57.0",
         "eslint-import-resolver-webpack": "0.13.8",
         "eslint-plugin-formatjs": "4.13.0",
@@ -5239,15 +5238,6 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
-    "node_modules/css-vars-ponyfill": {
-      "version": "2.4.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.2",
-        "get-css-data": "^2.0.2"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "dev": true,
@@ -7110,11 +7100,6 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
-    },
-    "node_modules/get-css-data": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
@@ -16328,14 +16313,6 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
-    "css-vars-ponyfill": {
-      "version": "2.4.8",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.2",
-        "get-css-data": "^2.0.2"
-      }
-    },
     "css-what": {
       "version": "6.1.0",
       "dev": true
@@ -17576,10 +17553,6 @@
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "dev": true
-    },
-    "get-css-data": {
-      "version": "2.1.0",
       "dev": true
     },
     "get-intrinsic": {

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -64,7 +64,6 @@
     "babel-plugin-styled-components": "2.1.4",
     "babel-plugin-typescript-to-proptypes": "2.1.0",
     "css-loader": "5.2.6",
-    "css-vars-ponyfill": "2.4.8",
     "eslint": "8.57.0",
     "eslint-import-resolver-webpack": "0.13.8",
     "eslint-plugin-formatjs": "4.13.0",

--- a/standalone/src/theme_utils.ts
+++ b/standalone/src/theme_utils.ts
@@ -8,7 +8,6 @@ import {blendColors, changeOpacity} from 'mattermost-redux/utils/theme_utils';
  * NOTE: functions in this file are ported over from mattermost-webapp/utils/utils.tsx
  * with some unnecessary code removed.
  */
-// with some unnecessary code removed.
 function dropAlpha(value: string): string {
     return value.substr(value.indexOf('(') + 1).split(',', 3).join(',');
 }

--- a/standalone/src/theme_utils.ts
+++ b/standalone/src/theme_utils.ts
@@ -1,140 +1,148 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import cssVars from 'css-vars-ponyfill';
 import {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {blendColors, changeOpacity} from 'mattermost-redux/utils/theme_utils';
 
-// NOTE: functions in this file are ported over from mattermost-webapp/utils/utils.tsx
+/**
+ * NOTE: functions in this file are ported over from mattermost-webapp/utils/utils.tsx
+ * with some unnecessary code removed.
+ */
 // with some unnecessary code removed.
-
 function dropAlpha(value: string): string {
     return value.substr(value.indexOf('(') + 1).split(',', 3).join(',');
 }
 
-// given '#fffff', returns '255, 255, 255' (no trailing comma)
+/**
+ * given '#fffff', returns '255, 255, 255' (no trailing comma)
+ */
 export function toRgbValues(hexStr: string): string {
     const rgbaStr = `${parseInt(hexStr.substr(1, 2), 16)}, ${parseInt(hexStr.substr(3, 2), 16)}, ${parseInt(hexStr.substr(5, 2), 16)}`;
     return rgbaStr;
 }
 
 export function applyTheme(theme: Theme) {
-    cssVars({
-        variables: {
+    const themeCssVariablesMap = {
 
-            // RGB values derived from theme hex values i.e. '255, 255, 255'
-            // (do not apply opacity mutations here)
-            'away-indicator-rgb': toRgbValues(theme.awayIndicator),
-            'button-bg-rgb': toRgbValues(theme.buttonBg),
-            'button-color-rgb': toRgbValues(theme.buttonColor),
-            'center-channel-bg-rgb': toRgbValues(theme.centerChannelBg),
-            'center-channel-color-rgb': toRgbValues(theme.centerChannelColor),
-            'dnd-indicator-rgb': toRgbValues(theme.dndIndicator),
-            'error-text-color-rgb': toRgbValues(theme.errorTextColor),
-            'link-color-rgb': toRgbValues(theme.linkColor),
-            'mention-bg-rgb': toRgbValues(theme.mentionBg),
-            'mention-color-rgb': toRgbValues(theme.mentionColor),
-            'mention-highlight-bg-rgb': toRgbValues(theme.mentionHighlightBg),
-            'mention-highlight-link-rgb': toRgbValues(theme.mentionHighlightLink),
-            'mention-highlight-bg-mixed-rgb': dropAlpha(blendColors(theme.centerChannelBg, theme.mentionHighlightBg, 0.5)),
-            'pinned-highlight-bg-mixed-rgb': dropAlpha(blendColors(theme.centerChannelBg, theme.mentionHighlightBg, 0.24)),
-            'own-highlight-bg-rgb': dropAlpha(blendColors(theme.mentionHighlightBg, theme.centerChannelColor, 0.05)),
-            'new-message-separator-rgb': toRgbValues(theme.newMessageSeparator),
-            'online-indicator-rgb': toRgbValues(theme.onlineIndicator),
-            'sidebar-bg-rgb': toRgbValues(theme.sidebarBg),
-            'sidebar-header-bg-rgb': toRgbValues(theme.sidebarHeaderBg),
-            'sidebar-teambar-bg-rgb': toRgbValues(theme.sidebarTeamBarBg),
-            'sidebar-header-text-color-rgb': toRgbValues(theme.sidebarHeaderTextColor),
-            'sidebar-text-rgb': toRgbValues(theme.sidebarText),
-            'sidebar-text-active-border-rgb': toRgbValues(theme.sidebarTextActiveBorder),
-            'sidebar-text-active-color-rgb': toRgbValues(theme.sidebarTextActiveColor),
-            'sidebar-text-hover-bg-rgb': toRgbValues(theme.sidebarTextHoverBg),
-            'sidebar-unread-text-rgb': toRgbValues(theme.sidebarUnreadText),
+        // RGB values derived from theme hex values i.e. '255, 255, 255'
+        // (do not apply opacity mutations here)
+        'away-indicator-rgb': toRgbValues(theme.awayIndicator),
+        'button-bg-rgb': toRgbValues(theme.buttonBg),
+        'button-color-rgb': toRgbValues(theme.buttonColor),
+        'center-channel-bg-rgb': toRgbValues(theme.centerChannelBg),
+        'center-channel-color-rgb': toRgbValues(theme.centerChannelColor),
+        'dnd-indicator-rgb': toRgbValues(theme.dndIndicator),
+        'error-text-color-rgb': toRgbValues(theme.errorTextColor),
+        'link-color-rgb': toRgbValues(theme.linkColor),
+        'mention-bg-rgb': toRgbValues(theme.mentionBg),
+        'mention-color-rgb': toRgbValues(theme.mentionColor),
+        'mention-highlight-bg-rgb': toRgbValues(theme.mentionHighlightBg),
+        'mention-highlight-link-rgb': toRgbValues(theme.mentionHighlightLink),
+        'mention-highlight-bg-mixed-rgb': dropAlpha(blendColors(theme.centerChannelBg, theme.mentionHighlightBg, 0.5)),
+        'pinned-highlight-bg-mixed-rgb': dropAlpha(blendColors(theme.centerChannelBg, theme.mentionHighlightBg, 0.24)),
+        'own-highlight-bg-rgb': dropAlpha(blendColors(theme.mentionHighlightBg, theme.centerChannelColor, 0.05)),
+        'new-message-separator-rgb': toRgbValues(theme.newMessageSeparator),
+        'online-indicator-rgb': toRgbValues(theme.onlineIndicator),
+        'sidebar-bg-rgb': toRgbValues(theme.sidebarBg),
+        'sidebar-header-bg-rgb': toRgbValues(theme.sidebarHeaderBg),
+        'sidebar-teambar-bg-rgb': toRgbValues(theme.sidebarTeamBarBg),
+        'sidebar-header-text-color-rgb': toRgbValues(theme.sidebarHeaderTextColor),
+        'sidebar-text-rgb': toRgbValues(theme.sidebarText),
+        'sidebar-text-active-border-rgb': toRgbValues(theme.sidebarTextActiveBorder),
+        'sidebar-text-active-color-rgb': toRgbValues(theme.sidebarTextActiveColor),
+        'sidebar-text-hover-bg-rgb': toRgbValues(theme.sidebarTextHoverBg),
+        'sidebar-unread-text-rgb': toRgbValues(theme.sidebarUnreadText),
 
-            // Hex CSS variables
-            'sidebar-bg': theme.sidebarBg,
-            'sidebar-text': theme.sidebarText,
-            'sidebar-unread-text': theme.sidebarUnreadText,
-            'sidebar-text-hover-bg': theme.sidebarTextHoverBg,
-            'sidebar-text-active-border': theme.sidebarTextActiveBorder,
-            'sidebar-text-active-color': theme.sidebarTextActiveColor,
-            'sidebar-header-bg': theme.sidebarHeaderBg,
-            'sidebar-teambar-bg': theme.sidebarTeamBarBg,
-            'sidebar-header-text-color': theme.sidebarHeaderTextColor,
-            'online-indicator': theme.onlineIndicator,
-            'away-indicator': theme.awayIndicator,
-            'dnd-indicator': theme.dndIndicator,
-            'mention-bg': theme.mentionBg,
-            'mention-color': theme.mentionColor,
-            'center-channel-bg': theme.centerChannelBg,
-            'center-channel-color': theme.centerChannelColor,
-            'new-message-separator': theme.newMessageSeparator,
-            'link-color': theme.linkColor,
-            'button-bg': theme.buttonBg,
-            'button-color': theme.buttonColor,
-            'error-text': theme.errorTextColor,
-            'mention-highlight-bg': theme.mentionHighlightBg,
-            'mention-highlight-link': theme.mentionHighlightLink,
+        // Hex CSS variables
+        'sidebar-bg': theme.sidebarBg,
+        'sidebar-text': theme.sidebarText,
+        'sidebar-unread-text': theme.sidebarUnreadText,
+        'sidebar-text-hover-bg': theme.sidebarTextHoverBg,
+        'sidebar-text-active-border': theme.sidebarTextActiveBorder,
+        'sidebar-text-active-color': theme.sidebarTextActiveColor,
+        'sidebar-header-bg': theme.sidebarHeaderBg,
+        'sidebar-teambar-bg': theme.sidebarTeamBarBg,
+        'sidebar-header-text-color': theme.sidebarHeaderTextColor,
+        'online-indicator': theme.onlineIndicator,
+        'away-indicator': theme.awayIndicator,
+        'dnd-indicator': theme.dndIndicator,
+        'mention-bg': theme.mentionBg,
+        'mention-color': theme.mentionColor,
+        'center-channel-bg': theme.centerChannelBg,
+        'center-channel-color': theme.centerChannelColor,
+        'new-message-separator': theme.newMessageSeparator,
+        'link-color': theme.linkColor,
+        'button-bg': theme.buttonBg,
+        'button-color': theme.buttonColor,
+        'error-text': theme.errorTextColor,
+        'mention-highlight-bg': theme.mentionHighlightBg,
+        'mention-highlight-link': theme.mentionHighlightLink,
 
-            // Legacy variables with baked in opacity, do not use!
-            'sidebar-text-08': changeOpacity(theme.sidebarText, 0.08),
-            'sidebar-text-16': changeOpacity(theme.sidebarText, 0.16),
-            'sidebar-text-30': changeOpacity(theme.sidebarText, 0.3),
-            'sidebar-text-40': changeOpacity(theme.sidebarText, 0.4),
-            'sidebar-text-50': changeOpacity(theme.sidebarText, 0.5),
-            'sidebar-text-60': changeOpacity(theme.sidebarText, 0.6),
-            'sidebar-text-72': changeOpacity(theme.sidebarText, 0.72),
-            'sidebar-text-80': changeOpacity(theme.sidebarText, 0.8),
-            'sidebar-header-text-color-80': changeOpacity(theme.sidebarHeaderTextColor, 0.8),
-            'center-channel-bg-88': changeOpacity(theme.centerChannelBg, 0.88),
-            'center-channel-color-88': changeOpacity(theme.centerChannelColor, 0.88),
-            'center-channel-bg-80': changeOpacity(theme.centerChannelBg, 0.8),
-            'center-channel-color-80': changeOpacity(theme.centerChannelColor, 0.8),
-            'center-channel-color-72': changeOpacity(theme.centerChannelColor, 0.72),
-            'center-channel-bg-64': changeOpacity(theme.centerChannelBg, 0.64),
-            'center-channel-color-64': changeOpacity(theme.centerChannelColor, 0.64),
-            'center-channel-bg-56': changeOpacity(theme.centerChannelBg, 0.56),
-            'center-channel-color-56': changeOpacity(theme.centerChannelColor, 0.56),
-            'center-channel-color-48': changeOpacity(theme.centerChannelColor, 0.48),
-            'center-channel-bg-40': changeOpacity(theme.centerChannelBg, 0.4),
-            'center-channel-color-40': changeOpacity(theme.centerChannelColor, 0.4),
-            'center-channel-bg-30': changeOpacity(theme.centerChannelBg, 0.3),
-            'center-channel-color-32': changeOpacity(theme.centerChannelColor, 0.32),
-            'center-channel-bg-20': changeOpacity(theme.centerChannelBg, 0.2),
-            'center-channel-color-20': changeOpacity(theme.centerChannelColor, 0.2),
-            'center-channel-bg-16': changeOpacity(theme.centerChannelBg, 0.16),
-            'center-channel-color-24': changeOpacity(theme.centerChannelColor, 0.24),
-            'center-channel-color-16': changeOpacity(theme.centerChannelColor, 0.16),
-            'center-channel-bg-08': changeOpacity(theme.centerChannelBg, 0.08),
-            'center-channel-color-08': changeOpacity(theme.centerChannelColor, 0.08),
-            'center-channel-color-04': changeOpacity(theme.centerChannelColor, 0.04),
-            'link-color-08': changeOpacity(theme.linkColor, 0.08),
-            'button-bg-88': changeOpacity(theme.buttonBg, 0.88),
-            'button-color-88': changeOpacity(theme.buttonColor, 0.88),
-            'button-bg-80': changeOpacity(theme.buttonBg, 0.8),
-            'button-color-80': changeOpacity(theme.buttonColor, 0.8),
-            'button-bg-72': changeOpacity(theme.buttonBg, 0.72),
-            'button-color-72': changeOpacity(theme.buttonColor, 0.72),
-            'button-bg-64': changeOpacity(theme.buttonBg, 0.64),
-            'button-color-64': changeOpacity(theme.buttonColor, 0.64),
-            'button-bg-56': changeOpacity(theme.buttonBg, 0.56),
-            'button-color-56': changeOpacity(theme.buttonColor, 0.56),
-            'button-bg-48': changeOpacity(theme.buttonBg, 0.48),
-            'button-color-48': changeOpacity(theme.buttonColor, 0.48),
-            'button-bg-40': changeOpacity(theme.buttonBg, 0.4),
-            'button-color-40': changeOpacity(theme.buttonColor, 0.4),
-            'button-bg-30': changeOpacity(theme.buttonBg, 0.32),
-            'button-color-32': changeOpacity(theme.buttonColor, 0.32),
-            'button-bg-24': changeOpacity(theme.buttonBg, 0.24),
-            'button-color-24': changeOpacity(theme.buttonColor, 0.24),
-            'button-bg-16': changeOpacity(theme.buttonBg, 0.16),
-            'button-color-16': changeOpacity(theme.buttonColor, 0.16),
-            'button-bg-08': changeOpacity(theme.buttonBg, 0.08),
-            'button-color-08': changeOpacity(theme.buttonColor, 0.08),
-            'button-bg-04': changeOpacity(theme.buttonBg, 0.04),
-            'button-color-04': changeOpacity(theme.buttonColor, 0.04),
-            'error-text-08': changeOpacity(theme.errorTextColor, 0.08),
-            'error-text-12': changeOpacity(theme.errorTextColor, 0.12),
-        },
-    });
+        // Legacy variables with baked in opacity, do not use!
+        'sidebar-text-08': changeOpacity(theme.sidebarText, 0.08),
+        'sidebar-text-16': changeOpacity(theme.sidebarText, 0.16),
+        'sidebar-text-30': changeOpacity(theme.sidebarText, 0.3),
+        'sidebar-text-40': changeOpacity(theme.sidebarText, 0.4),
+        'sidebar-text-50': changeOpacity(theme.sidebarText, 0.5),
+        'sidebar-text-60': changeOpacity(theme.sidebarText, 0.6),
+        'sidebar-text-72': changeOpacity(theme.sidebarText, 0.72),
+        'sidebar-text-80': changeOpacity(theme.sidebarText, 0.8),
+        'sidebar-header-text-color-80': changeOpacity(theme.sidebarHeaderTextColor, 0.8),
+        'center-channel-bg-88': changeOpacity(theme.centerChannelBg, 0.88),
+        'center-channel-color-88': changeOpacity(theme.centerChannelColor, 0.88),
+        'center-channel-bg-80': changeOpacity(theme.centerChannelBg, 0.8),
+        'center-channel-color-80': changeOpacity(theme.centerChannelColor, 0.8),
+        'center-channel-color-72': changeOpacity(theme.centerChannelColor, 0.72),
+        'center-channel-bg-64': changeOpacity(theme.centerChannelBg, 0.64),
+        'center-channel-color-64': changeOpacity(theme.centerChannelColor, 0.64),
+        'center-channel-bg-56': changeOpacity(theme.centerChannelBg, 0.56),
+        'center-channel-color-56': changeOpacity(theme.centerChannelColor, 0.56),
+        'center-channel-color-48': changeOpacity(theme.centerChannelColor, 0.48),
+        'center-channel-bg-40': changeOpacity(theme.centerChannelBg, 0.4),
+        'center-channel-color-40': changeOpacity(theme.centerChannelColor, 0.4),
+        'center-channel-bg-30': changeOpacity(theme.centerChannelBg, 0.3),
+        'center-channel-color-32': changeOpacity(theme.centerChannelColor, 0.32),
+        'center-channel-bg-20': changeOpacity(theme.centerChannelBg, 0.2),
+        'center-channel-color-20': changeOpacity(theme.centerChannelColor, 0.2),
+        'center-channel-bg-16': changeOpacity(theme.centerChannelBg, 0.16),
+        'center-channel-color-24': changeOpacity(theme.centerChannelColor, 0.24),
+        'center-channel-color-16': changeOpacity(theme.centerChannelColor, 0.16),
+        'center-channel-bg-08': changeOpacity(theme.centerChannelBg, 0.08),
+        'center-channel-color-08': changeOpacity(theme.centerChannelColor, 0.08),
+        'center-channel-color-04': changeOpacity(theme.centerChannelColor, 0.04),
+        'link-color-08': changeOpacity(theme.linkColor, 0.08),
+        'button-bg-88': changeOpacity(theme.buttonBg, 0.88),
+        'button-color-88': changeOpacity(theme.buttonColor, 0.88),
+        'button-bg-80': changeOpacity(theme.buttonBg, 0.8),
+        'button-color-80': changeOpacity(theme.buttonColor, 0.8),
+        'button-bg-72': changeOpacity(theme.buttonBg, 0.72),
+        'button-color-72': changeOpacity(theme.buttonColor, 0.72),
+        'button-bg-64': changeOpacity(theme.buttonBg, 0.64),
+        'button-color-64': changeOpacity(theme.buttonColor, 0.64),
+        'button-bg-56': changeOpacity(theme.buttonBg, 0.56),
+        'button-color-56': changeOpacity(theme.buttonColor, 0.56),
+        'button-bg-48': changeOpacity(theme.buttonBg, 0.48),
+        'button-color-48': changeOpacity(theme.buttonColor, 0.48),
+        'button-bg-40': changeOpacity(theme.buttonBg, 0.4),
+        'button-color-40': changeOpacity(theme.buttonColor, 0.4),
+        'button-bg-30': changeOpacity(theme.buttonBg, 0.32),
+        'button-color-32': changeOpacity(theme.buttonColor, 0.32),
+        'button-bg-24': changeOpacity(theme.buttonBg, 0.24),
+        'button-color-24': changeOpacity(theme.buttonColor, 0.24),
+        'button-bg-16': changeOpacity(theme.buttonBg, 0.16),
+        'button-color-16': changeOpacity(theme.buttonColor, 0.16),
+        'button-bg-08': changeOpacity(theme.buttonBg, 0.08),
+        'button-color-08': changeOpacity(theme.buttonColor, 0.08),
+        'button-bg-04': changeOpacity(theme.buttonBg, 0.04),
+        'button-color-04': changeOpacity(theme.buttonColor, 0.04),
+        'error-text-08': changeOpacity(theme.errorTextColor, 0.08),
+        'error-text-12': changeOpacity(theme.errorTextColor, 0.12),
+    };
+
+    const root = document.documentElement;
+    for (const [key, themeCssVariable] of Object.entries(themeCssVariablesMap)) {
+        // Set the CSS variable on the root element
+        // e.g. --sidebar-bg: #191919;
+        root.style.setProperty(`--${key}`, themeCssVariable);
+    }
 }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -12,7 +12,6 @@
         "@msgpack/msgpack": "2.7.1",
         "@redux-devtools/extension": "3.2.3",
         "core-js": "3.26.1",
-        "css-vars-ponyfill": "2.4.8",
         "emoji-picker-react": "4.4.7",
         "fflate": "0.8.2",
         "highlight.js": "11.6.0",
@@ -11741,7 +11740,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -14406,6 +14406,7 @@
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.4.8.tgz",
       "integrity": "sha512-4/j4AX4htytYHWyHVZ2BFQ+NoCGZEcOH2h4/2mmgE4SkrFg4Xq6tGYR77DtvvUIDsaXuJN+sj41bbgauA0Gfmg==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.2",
         "get-css-data": "^2.0.2"
@@ -17764,7 +17765,8 @@
     "node_modules/get-css-data": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/get-css-data/-/get-css-data-2.1.0.tgz",
-      "integrity": "sha512-HtPrzGk8aBF9rLeQNuImcXci7YVqsMEKzVflEWaCJu25ehxyDNiZRWoSxqSFUBfma8LERqKo70t/TcaGjIsM9g=="
+      "integrity": "sha512-HtPrzGk8aBF9rLeQNuImcXci7YVqsMEKzVflEWaCJu25ehxyDNiZRWoSxqSFUBfma8LERqKo70t/TcaGjIsM9g==",
+      "dev": true
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -25,7 +25,6 @@
     "@msgpack/msgpack": "2.7.1",
     "@redux-devtools/extension": "3.2.3",
     "core-js": "3.26.1",
-    "css-vars-ponyfill": "2.4.8",
     "emoji-picker-react": "4.4.7",
     "fflate": "0.8.2",
     "highlight.js": "11.6.0",


### PR DESCRIPTION
#### Summary
* Removed `css-vars-ponyfill`
* Updated `standalone/src/theme_utils.ts` to remove the use of `css-vars-ponyfill` and instead set CSS variables directly on the root element using `document.documentElement.style.setProperty`.

#### Ticket Link


  Fixes https://mattermost.atlassian.net/browse/MM-68145

