### PR TITLE
Backport env var passthrough for recorder and transcriber

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -124,9 +124,9 @@ jobs:
       CONTAINER_PROXY: playwright_tests_proxy
       CONTAINER_RTCD: playwright_tests_rtcd
       CONTAINER_OFFLOADER: playwright_tests_offloader
-      IMAGE_CALLS_OFFLOADER: mattermost/calls-offloader:v0.9.3
-      IMAGE_CALLS_RECORDER: mattermost/calls-recorder:v0.8.8
-      IMAGE_CALLS_TRANSCRIBER: mattermost/calls-transcriber:v0.7.1
+      IMAGE_CALLS_OFFLOADER: mattermost/calls-offloader:v0.9.6
+      IMAGE_CALLS_RECORDER: mattermost/calls-recorder:v0.8.13
+      IMAGE_CALLS_TRANSCRIBER: mattermost/calls-transcriber:v0.7.2
       IMAGE_SERVER: mattermostdevelopment/mattermost-enterprise-edition:master
       IMAGE_CURL: curlimages/curl:8.7.1
       CI_NODE_INDEX: ${{ matrix.run_id }}
@@ -153,11 +153,13 @@ jobs:
           go-version-file: mattermost/server/go.mod
 
       - name: e2e/generate-configuration
-        working-directory: ./mattermost/server/scripts/config_generator
+        working-directory: ./mattermost/server
         env:
           OUTPUT_CONFIG: ${{ github.workspace }}/config/config.json
         run: |
+          go work init . ./public
           mkdir -p ${{ github.workspace }}/config
+          cd scripts/config_generator
           go run main.go
 
       - name: e2e/download-mattermost-plugin-calls-package

--- a/plugin.json
+++ b/plugin.json
@@ -722,7 +722,7 @@
   "props": {
     "min_rtcd_version": "v0.17.0",
     "min_offloader_version": "v0.9.0",
-    "calls_recorder_version": "v0.8.8",
-    "calls_transcriber_version": "v0.7.1"
+    "calls_recorder_version": "v0.8.13",
+    "calls_transcriber_version": "v0.7.2"
   }
 }

--- a/server/job_service.go
+++ b/server/job_service.go
@@ -301,6 +301,8 @@ func (s *jobService) RunJob(jobType job.Type, callID, postID, jobID, authToken s
 		jobCfg.Runner = recorderJobRunner
 		jobCfg.MaxDurationSec = int64(*cfg.MaxRecordingDuration * 60)
 		jobCfg.InputData = baseRecorderCfg.ToMap()
+
+		applyEnvOverrides(jobCfg.InputData, "MM_CALLS_RECORDER_")
 	case job.TypeTranscribing:
 		var transcriberConfig transcriber.CallTranscriberConfig
 		transcriberConfig.SetDefaults()
@@ -339,6 +341,8 @@ func (s *jobService) RunJob(jobType job.Type, callID, postID, jobID, authToken s
 		// transcribe a 1 hour long call).
 		jobCfg.MaxDurationSec = int64(*cfg.MaxRecordingDuration*60) * 2
 		jobCfg.InputData = transcriberConfig.ToMap()
+
+		applyEnvOverrides(jobCfg.InputData, "MM_CALLS_TRANSCRIBER_")
 	}
 
 	jb, err := s.client.CreateJob(jobCfg)
@@ -347,6 +351,20 @@ func (s *jobService) RunJob(jobType job.Type, callID, postID, jobID, authToken s
 	}
 
 	return jb.ID, nil
+}
+
+// applyEnvOverrides reads environment variables with the given prefix and merges
+// them into inputData, stripping the prefix and lowercasing the key.
+// The offloader will uppercase the keys again when setting container env vars.
+func applyEnvOverrides(inputData job.InputData, prefix string) {
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, prefix) {
+			if parts := strings.SplitN(env, "=", 2); len(parts) == 2 {
+				key := strings.ToLower(strings.TrimPrefix(parts[0], prefix))
+				inputData[key] = parts[1]
+			}
+		}
+	}
 }
 
 func (s *jobService) Close() error {

--- a/server/job_service_test.go
+++ b/server/job_service_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 
+	"github.com/mattermost/calls-offloader/public/job"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -83,5 +85,52 @@ func TestJobServiceStopJob(t *testing.T) {
 
 		err := p.jobService.StopJob("callChannelID", "jobID", "botUserID", "botConnID")
 		require.NoError(t, err)
+	})
+}
+
+func TestJobServiceApplyEnvOverrides(t *testing.T) {
+	t.Run("matching prefix is applied", func(t *testing.T) {
+		t.Setenv("MM_CALLS_RECORDER_TLS_CA_CERT_FILE", "/certs/ca.pem")
+		data := job.InputData{}
+		applyEnvOverrides(data, "MM_CALLS_RECORDER_")
+		require.Equal(t, "/certs/ca.pem", data["tls_ca_cert_file"])
+	})
+
+	t.Run("non-matching prefix is ignored", func(t *testing.T) {
+		t.Setenv("MM_CALLS_TRANSCRIBER_TLS_CA_CERT_FILE", "/certs/ca.pem")
+		data := job.InputData{}
+		applyEnvOverrides(data, "MM_CALLS_RECORDER_")
+		require.Empty(t, data)
+	})
+
+	t.Run("key collision: env overrides existing entry", func(t *testing.T) {
+		t.Setenv("MM_CALLS_RECORDER_SITE_URL", "https://override.example.com")
+		data := job.InputData{"site_url": "https://original.example.com"}
+		applyEnvOverrides(data, "MM_CALLS_RECORDER_")
+		require.Equal(t, "https://override.example.com", data["site_url"])
+	})
+
+	t.Run("equals sign in value is preserved", func(t *testing.T) {
+		t.Setenv("MM_CALLS_RECORDER_EXTRA_CHROMIUM_ARGS", "--proxy-server=http://proxy:8080")
+		data := job.InputData{}
+		applyEnvOverrides(data, "MM_CALLS_RECORDER_")
+		require.Equal(t, "--proxy-server=http://proxy:8080", data["extra_chromium_args"])
+	})
+
+	t.Run("multiple matching vars all applied", func(t *testing.T) {
+		t.Setenv("MM_CALLS_RECORDER_TLS_CA_CERT_FILE", "/certs/ca.pem")
+		t.Setenv("MM_CALLS_RECORDER_TLS_INSECURE_SKIP_VERIFY", "true")
+		data := job.InputData{}
+		applyEnvOverrides(data, "MM_CALLS_RECORDER_")
+		require.Equal(t, "/certs/ca.pem", data["tls_ca_cert_file"])
+		require.Equal(t, "true", data["tls_insecure_skip_verify"])
+	})
+
+	t.Run("key is lowercased", func(t *testing.T) {
+		t.Setenv("MM_CALLS_RECORDER_SITE_URL", "http://localhost:8065")
+		data := job.InputData{}
+		applyEnvOverrides(data, "MM_CALLS_RECORDER_")
+		require.Contains(t, data, "site_url")
+		require.NotContains(t, data, "SITE_URL")
 	})
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #1142 from main to `release-1.11`, excluding `lt/` module changes (not used by end users).

- Pass through `MM_CALLS_RECORDER_*` and `MM_CALLS_TRANSCRIBER_*` env vars to job containers via `applyEnvOverrides` helper
- Bump recorder to v0.8.13 and transcriber to v0.7.2 for TLS CA cert support
- Update e2e workflow to use matching container image versions

## Test plan

- [ ] CI passes (including e2e tests with updated container images)
- [ ] Verify `applyEnvOverrides` unit tests pass