### PR TITLE
Fix recording banner dismiss and call timer with clock skew

### DIFF
--- a/webapp/src/components/call_widget/call_duration.test.tsx
+++ b/webapp/src/components/call_widget/call_duration.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
 import {render, screen} from '@testing-library/react';
+import React from 'react';
 
 import CallDuration from './call_duration';
 

--- a/webapp/src/components/call_widget/call_duration.test.tsx
+++ b/webapp/src/components/call_widget/call_duration.test.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+
+import CallDuration from './call_duration';
+
+describe('CallDuration', () => {
+    it('should display 00:00 when startAt is in the future (server clock ahead)', () => {
+        const futureStartAt = Date.now() + 60_000;
+        render(<CallDuration startAt={futureStartAt}/>);
+        expect(screen.getByText('00:00')).toBeInTheDocument();
+    });
+
+    it('should not display negative time when startAt is in the future', () => {
+        const futureStartAt = Date.now() + 180_000;
+        const {container} = render(<CallDuration startAt={futureStartAt}/>);
+        expect(container.textContent).not.toMatch(/-/);
+    });
+
+    it('should display positive duration when startAt is in the past', () => {
+        const pastStartAt = Date.now() - 65_000;
+        const {container} = render(<CallDuration startAt={pastStartAt}/>);
+        const text = container.textContent || '';
+        expect(text).toMatch(/^01:0[45]$/);
+    });
+
+    it('should display hh:mm:ss format for durations over one hour', () => {
+        const pastStartAt = Date.now() - (3600_000 + 120_000);
+        const {container} = render(<CallDuration startAt={pastStartAt}/>);
+        const text = container.textContent || '';
+        expect(text).toMatch(/^01:02:0\d$/);
+    });
+});

--- a/webapp/src/components/call_widget/call_duration.test.tsx
+++ b/webapp/src/components/call_widget/call_duration.test.tsx
@@ -32,4 +32,19 @@ describe('CallDuration', () => {
         const text = container.textContent || '';
         expect(text).toMatch(/^01:02:0\d$/);
     });
+
+    it('should re-sync when startAt prop changes', () => {
+        // Start with a future timestamp (server clock ahead).
+        const futureStartAt = Date.now() + 60_000;
+        const {container, rerender} = render(<CallDuration startAt={futureStartAt}/>);
+        expect(container.textContent).toBe('00:00');
+        expect(container.textContent).not.toMatch(/-/);
+
+        // Rerender with a past timestamp (e.g. reconnect with corrected time).
+        const pastStartAt = Date.now() - 90_000;
+        rerender(<CallDuration startAt={pastStartAt}/>);
+        const text = container.textContent || '';
+        expect(text).toMatch(/^01:3\d$/);
+        expect(text).not.toMatch(/-/);
+    });
 });

--- a/webapp/src/components/call_widget/call_duration.tsx
+++ b/webapp/src/components/call_widget/call_duration.tsx
@@ -24,7 +24,11 @@ export default function CallDuration(props: Props) {
     // future and the raw duration would be negative. Capture an adjusted
     // start time on mount so the timer counts up from 0:00 immediately
     // rather than displaying negative values or sticking at 0.
-    const [adjustedStartAt] = useState(() => Math.min(props.startAt, Date.now()));
+    // Re-sync if the prop changes (e.g. after a WebSocket reconnect).
+    const [adjustedStartAt, setAdjustedStartAt] = useState(() => Math.min(props.startAt, Date.now()));
+    useEffect(() => {
+        setAdjustedStartAt(Math.min(props.startAt, Date.now()));
+    }, [props.startAt]);
 
     // This is needed to force a re-render to periodically update
     // the time displayed.

--- a/webapp/src/components/call_widget/call_duration.tsx
+++ b/webapp/src/components/call_widget/call_duration.tsx
@@ -20,6 +20,12 @@ function getCallDuration(startAt: number) {
 }
 
 export default function CallDuration(props: Props) {
+    // If the server clock is ahead of the client, startAt will be in the
+    // future and the raw duration would be negative. Capture an adjusted
+    // start time on mount so the timer counts up from 0:00 immediately
+    // rather than displaying negative values or sticking at 0.
+    const [adjustedStartAt] = useState(() => Math.min(props.startAt, Date.now()));
+
     // This is needed to force a re-render to periodically update
     // the time displayed.
     const [, updateState] = useState({});
@@ -34,6 +40,6 @@ export default function CallDuration(props: Props) {
     }
 
     return (
-        <div style={style}>{getCallDuration(props.startAt)}</div>
+        <div style={style}>{getCallDuration(adjustedStartAt)}</div>
     );
 }

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -808,11 +808,24 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             return;
         }
 
+        // Use the latest server-side timestamp rather than Date.now() so that
+        // the dismissed-at value is in the same clock domain as start_at,
+        // end_at, hostChangeAt, and error_at. This avoids issues when the
+        // client and server clocks are out of sync (e.g. air-gapped
+        // environments without NTP).
+        const rec = this.props.callRecording;
+        const dismissedAt = Math.max(
+            rec?.start_at || 0,
+            rec?.end_at || 0,
+            rec?.error_at || 0,
+            this.props.callHostChangeAt || 0,
+        ) + 1;
+
         // Dismiss our prompt.
-        this.props.recordingPromptDismissedAt(this.props.channel.id, Date.now());
+        this.props.recordingPromptDismissedAt(this.props.channel.id, dismissedAt);
 
         // Dismiss the expanded window's prompt.
-        this.state.expandedViewWindow?.callActions?.setRecordingPromptDismissedAt(this.props.channel.id, Date.now());
+        this.state.expandedViewWindow?.callActions?.setRecordingPromptDismissedAt(this.props.channel.id, dismissedAt);
     };
 
     onRecordToggle = async () => {

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -60,7 +60,6 @@ import {
     STORAGE_CALLS_MIRROR_VIDEO_KEY,
 } from 'src/constants';
 import {logDebug, logErr} from 'src/log';
-import {serverDismissedAt} from 'src/utils/clock_skew';
 import {
     keyToAction,
     LEAVE_CALL,
@@ -91,6 +90,7 @@ import {
     shareAudioWithScreen,
     untranslatable,
 } from 'src/utils';
+import {serverDismissedAt} from 'src/utils/clock_skew';
 import styled, {css} from 'styled-components';
 
 import CallDuration from './call_duration';
@@ -1414,8 +1414,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             }
         };
 
-        let devices = deviceType === 'audioinput' ? this.state.devices.inputs?.filter((device) => device.deviceId && device.label) :
-            this.state.devices.outputs?.filter((device) => device.deviceId && device.label);
+        let devices = deviceType === 'audioinput' ? this.state.devices.inputs?.filter((device) => device.deviceId && device.label) : this.state.devices.outputs?.filter((device) => device.deviceId && device.label);
         if (deviceType === 'videoinput' && this.state.videoDevices) {
             devices = this.state.videoDevices.filter((device) => device.deviceId && device.label);
         }
@@ -1437,8 +1436,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             showSubMenu = devices.length > 0;
         }
 
-        let deviceTypeLabel = deviceType === 'audioinput' ?
-            formatMessage({defaultMessage: 'Microphone'}) : formatMessage({defaultMessage: 'Audio output'});
+        let deviceTypeLabel = deviceType === 'audioinput' ? formatMessage({defaultMessage: 'Microphone'}) : formatMessage({defaultMessage: 'Audio output'});
         if (deviceType === 'videoinput') {
             deviceTypeLabel = formatMessage({defaultMessage: 'Camera'});
         }
@@ -1622,8 +1620,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
         const RecordIcon = this.props.isRecording ? RecordSquareIcon : RecordCircleIcon;
 
-        const recordingActionLabel = this.props.isRecording ? formatMessage({defaultMessage: 'Stop recording'}) :
-            formatMessage({defaultMessage: 'Record call'});
+        const recordingActionLabel = this.props.isRecording ? formatMessage({defaultMessage: 'Stop recording'}) : formatMessage({defaultMessage: 'Record call'});
 
         return (
             <React.Fragment>
@@ -1671,8 +1668,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         const noPermissions = this.state.alerts.missingScreenPermissions.active;
 
         const ShareIcon = isSharing ? UnshareScreenIcon : ShareScreenIcon;
-        const screenSharingActionLabel = isSharing ? formatMessage({defaultMessage: 'Stop presenting'}) :
-            formatMessage({defaultMessage: 'Start presenting'});
+        const screenSharingActionLabel = isSharing ? formatMessage({defaultMessage: 'Stop presenting'}) : formatMessage({defaultMessage: 'Start presenting'});
 
         return (
             <React.Fragment>
@@ -2515,8 +2511,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         const showLeaveMenuShim = !(this.state.showMenu || this.state.showParticipantsList || this.props.screenSharingSession) && this.state.leaveMenuOpen;
 
         const openPopOutLabel = formatMessage({defaultMessage: 'Open in new window'});
-        const showParticipantsListLabel = this.state.showParticipantsList ?
-            formatMessage({defaultMessage: 'Hide participants'}) : formatMessage({defaultMessage: 'Show participants'});
+        const showParticipantsListLabel = this.state.showParticipantsList ? formatMessage({defaultMessage: 'Hide participants'}) : formatMessage({defaultMessage: 'Show participants'});
         const settingsButtonLabel = formatMessage({defaultMessage: 'More options'});
         const leaveMenuLabel = formatMessage({defaultMessage: 'Leave call'});
 

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -60,6 +60,7 @@ import {
     STORAGE_CALLS_MIRROR_VIDEO_KEY,
 } from 'src/constants';
 import {logDebug, logErr} from 'src/log';
+import {serverDismissedAt} from 'src/utils/clock_skew';
 import {
     keyToAction,
     LEAVE_CALL,
@@ -808,18 +809,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             return;
         }
 
-        // Use the latest server-side timestamp rather than Date.now() so that
-        // the dismissed-at value is in the same clock domain as start_at,
-        // end_at, hostChangeAt, and error_at. This avoids issues when the
-        // client and server clocks are out of sync (e.g. air-gapped
-        // environments without NTP).
-        const rec = this.props.callRecording;
-        const dismissedAt = Math.max(
-            rec?.start_at || 0,
-            rec?.end_at || 0,
-            rec?.error_at || 0,
-            this.props.callHostChangeAt || 0,
-        ) + 1;
+        const dismissedAt = serverDismissedAt(this.props.callRecording, this.props.callHostChangeAt);
 
         // Dismiss our prompt.
         this.props.recordingPromptDismissedAt(this.props.channel.id, dismissedAt);

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -18,6 +18,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {IntlShape} from 'react-intl';
 import {RouteComponentProps} from 'react-router-dom';
 import {hostMuteOthers, hostRemove} from 'src/actions';
+import {serverDismissedAt} from 'src/utils/clock_skew';
 import Avatar from 'src/components/avatar/avatar';
 import {Badge} from 'src/components/badge';
 import CallDuration from 'src/components/call_widget/call_duration';
@@ -831,18 +832,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             return;
         }
 
-        // Use the latest server-side timestamp rather than Date.now() so that
-        // the dismissed-at value is in the same clock domain as start_at,
-        // end_at, hostChangeAt, and error_at. This avoids issues when the
-        // client and server clocks are out of sync (e.g. air-gapped
-        // environments without NTP).
-        const rec = this.props.callRecording;
-        const dismissedAt = Math.max(
-            rec?.start_at || 0,
-            rec?.end_at || 0,
-            rec?.error_at || 0,
-            this.props.callHostChangeAt || 0,
-        ) + 1;
+        const dismissedAt = serverDismissedAt(this.props.callRecording, this.props.callHostChangeAt);
 
         // Dismiss our prompt.
         this.props.recordingPromptDismissedAt(this.props.channel.id, dismissedAt);

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -18,7 +18,6 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {IntlShape} from 'react-intl';
 import {RouteComponentProps} from 'react-router-dom';
 import {hostMuteOthers, hostRemove} from 'src/actions';
-import {serverDismissedAt} from 'src/utils/clock_skew';
 import Avatar from 'src/components/avatar/avatar';
 import {Badge} from 'src/components/badge';
 import CallDuration from 'src/components/call_widget/call_duration';
@@ -80,6 +79,7 @@ import {
     shareAudioWithScreen,
     untranslatable,
 } from 'src/utils';
+import {serverDismissedAt} from 'src/utils/clock_skew';
 import styled, {createGlobalStyle, css} from 'styled-components';
 
 import {CallSettingsButton} from './call_settings';

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -831,11 +831,24 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             return;
         }
 
+        // Use the latest server-side timestamp rather than Date.now() so that
+        // the dismissed-at value is in the same clock domain as start_at,
+        // end_at, hostChangeAt, and error_at. This avoids issues when the
+        // client and server clocks are out of sync (e.g. air-gapped
+        // environments without NTP).
+        const rec = this.props.callRecording;
+        const dismissedAt = Math.max(
+            rec?.start_at || 0,
+            rec?.end_at || 0,
+            rec?.error_at || 0,
+            this.props.callHostChangeAt || 0,
+        ) + 1;
+
         // Dismiss our prompt.
-        this.props.recordingPromptDismissedAt(this.props.channel.id, Date.now());
+        this.props.recordingPromptDismissedAt(this.props.channel.id, dismissedAt);
 
         // Dismiss the parent window's prompt.
-        window.opener?.callActions?.setRecordingPromptDismissedAt(this.props.channel.id, Date.now());
+        window.opener?.callActions?.setRecordingPromptDismissedAt(this.props.channel.id, dismissedAt);
     };
 
     onRemove = (sessionID: string, userID: string) => {

--- a/webapp/src/components/expanded_view/recording_info_prompt.tsx
+++ b/webapp/src/components/expanded_view/recording_info_prompt.tsx
@@ -53,7 +53,10 @@ export default function RecordingInfoPrompt(props: Props) {
         }
 
         if (getMinutesLeftBeforeEnd() <= minutesLeftThreshold) {
-            updateRecordingWillEndSoon(Date.now());
+            // Use a server-derived timestamp so the comparison against
+            // disclaimerDismissedAt (also server-based) is consistent
+            // regardless of client/server clock skew.
+            updateRecordingWillEndSoon((props.recording?.start_at ?? 0) + 1);
         }
     }, [props.isHost, props.recording, recordingWillEndSoon, getMinutesLeftBeforeEnd]);
 

--- a/webapp/src/utils/clock_skew.test.ts
+++ b/webapp/src/utils/clock_skew.test.ts
@@ -6,7 +6,8 @@ import {CallJobReduxState} from 'src/types/types';
 import {serverDismissedAt} from './clock_skew';
 
 describe('serverDismissedAt', () => {
-    it('should return 1 when recording is undefined', () => {
+    it('should return 1 when recording is not provided', () => {
+        // eslint-disable-next-line no-undefined
         expect(serverDismissedAt(undefined, 0)).toBe(1);
     });
 

--- a/webapp/src/utils/clock_skew.test.ts
+++ b/webapp/src/utils/clock_skew.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {CallJobReduxState} from 'src/types/types';
+
+import {serverDismissedAt} from './clock_skew';
+
+describe('serverDismissedAt', () => {
+    it('should return 1 when recording is undefined', () => {
+        expect(serverDismissedAt(undefined, 0)).toBe(1);
+    });
+
+    it('should return start_at + 1 when only start_at is set', () => {
+        const rec: CallJobReduxState = {init_at: 100, start_at: 1000, end_at: 0};
+        expect(serverDismissedAt(rec, 0)).toBe(1001);
+    });
+
+    it('should return end_at + 1 when end_at > start_at', () => {
+        const rec: CallJobReduxState = {init_at: 100, start_at: 1000, end_at: 2000};
+        expect(serverDismissedAt(rec, 0)).toBe(2001);
+    });
+
+    it('should return error_at + 1 when error_at is the largest', () => {
+        const rec: CallJobReduxState = {init_at: 100, start_at: 1000, end_at: 2000, error_at: 3000};
+        expect(serverDismissedAt(rec, 0)).toBe(3001);
+    });
+
+    it('should return hostChangeAt + 1 when hostChangeAt is the largest', () => {
+        const rec: CallJobReduxState = {init_at: 100, start_at: 1000, end_at: 0};
+        expect(serverDismissedAt(rec, 5000)).toBe(5001);
+    });
+
+    it('should handle all fields set and pick the maximum', () => {
+        const rec: CallJobReduxState = {init_at: 100, start_at: 1000, end_at: 2000, error_at: 1500};
+        expect(serverDismissedAt(rec, 1800)).toBe(2001);
+    });
+
+    it('should return 1 when recording has all zero timestamps', () => {
+        const rec: CallJobReduxState = {init_at: 0, start_at: 0, end_at: 0};
+        expect(serverDismissedAt(rec, 0)).toBe(1);
+    });
+});

--- a/webapp/src/utils/clock_skew.ts
+++ b/webapp/src/utils/clock_skew.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {CallJobReduxState} from 'src/types/types';
+
+// serverDismissedAt computes a dismissed-at timestamp using only
+// server-side timestamps, avoiding cross-clock comparisons when the
+// client and server clocks are out of sync.
+//
+// The returned value is guaranteed to be greater than every known
+// server timestamp, so the banner's show/hide checks (which compare
+// dismissedAt against start_at, end_at, hostChangeAt, etc.) work
+// correctly regardless of clock skew.
+//
+// A new server-side event (recording restart, host change, error) will
+// have a timestamp greater than this value, causing the banner to
+// re-appear as expected.
+export function serverDismissedAt(recording: CallJobReduxState | undefined, hostChangeAt: number): number {
+    return Math.max(
+        recording?.start_at || 0,
+        recording?.end_at || 0,
+        recording?.error_at || 0,
+        hostChangeAt || 0,
+    ) + 1;
+}


### PR DESCRIPTION
#### Summary
When the client and server clocks are out of sync (e.g. air-gapped environments without NTP), two bugs occur during recording active:

1. The call timer displays negative values because it computes Date.now() - startAt where startAt is a server timestamp.

2. The recording notification cannot be dismissed because the dismiss handler stores Date.now() (client clock) but the show/hide logic compares it against server timestamps (start_at, end_at, etc).

Fix the timer by capturing an adjusted start time on mount that is clamped to the client's current time, so it always counts up from 0.

Fix the dismissal by using the latest server-side timestamp + 1 as the dismissed-at value, keeping all comparisons in the same clock domain.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68370

#### Testing
To test, I ran server with self-signed TLS cert, and configured same self-signed cert for offloader/recorder. TLS allows connection to call from an external machine. I deployed main branch of plugin without feature changes. I disabled clock sync on external machine and set time several minutes behind server, then connected call and started recording and verified the call time was negative and the recording notification would not dismiss. Then I deployed the feature branch of calls plugin and repeated test, verifying that the call time starts from 0:00 and counts up, and that the recording notification can be dismissed.

#### Release Note

```release-note
Fix negative time call duration display when client clock behind server
Allow dismissal of recording notification when client clock behind server
```
