### PR TITLE
[MM-68698] LiveKit webhook handler, SIP participant tracking, and host logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.34.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.34.0
 	golang.org/x/time v0.10.0
+	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -80,9 +81,11 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/jxskiss/base62 v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
@@ -177,7 +180,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.77.0 // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -687,12 +687,16 @@ github.com/hamba/avro/v2 v2.17.2/go.mod h1:Q9YK+qxAhtVrNqOhwlZTATLgLA8qxG2vtvkhK
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0UUrwg=
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
+github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
+github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=

--- a/server/api.go
+++ b/server/api.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/livekit/protocol/auth"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/webhook"
 )
 
 const requestBodyMaxSizeBytes = 1024 * 1024 // 1MB
@@ -590,4 +592,189 @@ func (p *Plugin) handleGetStats(w http.ResponseWriter) error {
 	}
 
 	return nil
+}
+
+func (p *Plugin) handleLiveKitWebhook(w http.ResponseWriter, r *http.Request) {
+	cfg := p.getConfiguration()
+	if cfg.LiveKitAPIKey == "" || cfg.LiveKitAPISecret == "" {
+		p.LogError("handleLiveKitWebhook: LiveKit not configured")
+		http.Error(w, "LiveKit is not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	event, err := webhook.ReceiveWebhookEvent(r, auth.NewSimpleKeyProvider(cfg.LiveKitAPIKey, cfg.LiveKitAPISecret))
+	if err != nil {
+		p.LogError("handleLiveKitWebhook: failed to verify webhook", "err", err.Error())
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	p.LogDebug("handleLiveKitWebhook: received event",
+		"event", event.GetEvent(),
+		"room", event.GetRoom().GetName())
+
+	switch event.GetEvent() {
+	case webhook.EventParticipantJoined:
+		p.handleLiveKitParticipantJoined(event)
+	case webhook.EventParticipantLeft:
+		p.handleLiveKitParticipantLeft(event)
+	case webhook.EventRoomStarted, webhook.EventRoomFinished:
+		p.LogDebug("handleLiveKitWebhook: room lifecycle event (informational only)",
+			"event", event.GetEvent(),
+			"room", event.GetRoom().GetName())
+	default:
+		p.LogDebug("handleLiveKitWebhook: ignoring event", "event", event.GetEvent())
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (p *Plugin) handleLiveKitParticipantJoined(event *livekit.WebhookEvent) {
+	participant := event.GetParticipant()
+	if participant == nil || participant.Kind != livekit.ParticipantInfo_SIP {
+		return
+	}
+
+	channelID := event.GetRoom().GetName()
+	if channelID == "" {
+		p.LogError("handleLiveKitParticipantJoined: empty room name")
+		return
+	}
+
+	sid := participant.Sid
+	identity := participant.Identity
+
+	p.LogDebug("handleLiveKitParticipantJoined: SIP participant joined",
+		"channelID", channelID, "sid", sid, "identity", identity)
+
+	state, err := p.lockCallReturnState(channelID)
+	if err != nil {
+		p.LogError("handleLiveKitParticipantJoined: failed to lock call", "channelID", channelID, "err", err.Error())
+		return
+	}
+	defer p.unlockCall(channelID)
+
+	if state == nil {
+		p.LogDebug("handleLiveKitParticipantJoined: no active call", "channelID", channelID)
+		return
+	}
+
+	if state.Call.EndAt > 0 {
+		p.LogDebug("handleLiveKitParticipantJoined: call has ended", "channelID", channelID)
+		return
+	}
+
+	if _, exists := state.sessions[sid]; exists {
+		p.LogDebug("handleLiveKitParticipantJoined: SIP session already exists", "channelID", channelID, "sid", sid)
+		return
+	}
+
+	session := &public.CallSession{
+		ID:               sid,
+		CallID:           state.Call.ID,
+		UserID:           identity,
+		JoinAt:           time.Now().UnixMilli(),
+		IsSIPParticipant: true,
+	}
+	state.sessions[sid] = session
+
+	if newHostID := state.getHostID(p.getBotID()); newHostID != state.Call.GetHostID() {
+		state.Call.Props.Hosts = []string{newHostID}
+		p.publishWebSocketEvent(wsEventCallHostChanged, map[string]interface{}{
+			"hostID":  newHostID,
+			"call_id": state.Call.ID,
+		}, &WebSocketBroadcast{
+			ChannelID:           channelID,
+			ReliableClusterSend: true,
+			UserIDs:             getUserIDsFromSessions(state.sessions),
+		})
+	}
+
+	if err := p.store.CreateCallSession(session); err != nil {
+		p.LogError("handleLiveKitParticipantJoined: failed to create call session",
+			"channelID", channelID, "err", err.Error())
+		delete(state.sessions, sid)
+		return
+	}
+
+	if err := p.store.UpdateCall(&state.Call); err != nil {
+		p.LogError("handleLiveKitParticipantJoined: failed to update call",
+			"channelID", channelID, "err", err.Error())
+	}
+
+	p.publishWebSocketEvent(wsEventUserJoined, map[string]interface{}{
+		"user_id":    identity,
+		"session_id": sid,
+	}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
+}
+
+func (p *Plugin) handleLiveKitParticipantLeft(event *livekit.WebhookEvent) {
+	participant := event.GetParticipant()
+	if participant == nil || participant.Kind != livekit.ParticipantInfo_SIP {
+		return
+	}
+
+	channelID := event.GetRoom().GetName()
+	if channelID == "" {
+		p.LogError("handleLiveKitParticipantLeft: empty room name")
+		return
+	}
+
+	sid := participant.Sid
+	identity := participant.Identity
+
+	p.LogDebug("handleLiveKitParticipantLeft: SIP participant left",
+		"channelID", channelID, "sid", sid, "identity", identity)
+
+	state, err := p.lockCallReturnState(channelID)
+	if err != nil {
+		p.LogError("handleLiveKitParticipantLeft: failed to lock call", "channelID", channelID, "err", err.Error())
+		return
+	}
+	defer p.unlockCall(channelID)
+
+	if state == nil {
+		p.LogDebug("handleLiveKitParticipantLeft: no active call", "channelID", channelID)
+		return
+	}
+
+	if _, exists := state.sessions[sid]; !exists {
+		p.LogDebug("handleLiveKitParticipantLeft: SIP session not found (idempotent)", "channelID", channelID, "sid", sid)
+		return
+	}
+
+	if err := p.store.DeleteCallSession(sid); err != nil {
+		p.LogError("handleLiveKitParticipantLeft: failed to delete call session",
+			"channelID", channelID, "err", err.Error())
+		return
+	}
+	delete(state.sessions, sid)
+
+	if state.Call.GetHostID() == identity && len(state.sessions) > 0 {
+		if newHostID := state.getHostID(p.getBotID()); newHostID != identity {
+			if newHostID == "" {
+				state.Call.Props.Hosts = nil
+			} else {
+				state.Call.Props.Hosts = []string{newHostID}
+			}
+			p.publishWebSocketEvent(wsEventCallHostChanged, map[string]interface{}{
+				"hostID":  newHostID,
+				"call_id": state.Call.ID,
+			}, &WebSocketBroadcast{
+				ChannelID:           channelID,
+				ReliableClusterSend: true,
+				UserIDs:             getUserIDsFromSessions(state.sessions),
+			})
+		}
+	}
+
+	if err := p.store.UpdateCall(&state.Call); err != nil {
+		p.LogError("handleLiveKitParticipantLeft: failed to update call",
+			"channelID", channelID, "err", err.Error())
+	}
+
+	p.publishWebSocketEvent(wsEventUserLeft, map[string]interface{}{
+		"user_id":    identity,
+		"session_id": sid,
+	}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
 }

--- a/server/api.go
+++ b/server/api.go
@@ -615,9 +615,9 @@ func (p *Plugin) handleLiveKitWebhook(w http.ResponseWriter, r *http.Request) {
 
 	switch event.GetEvent() {
 	case webhook.EventParticipantJoined:
-		p.handleLiveKitParticipantJoined(event)
+		p.handleLiveKitSIPParticipantJoined(event)
 	case webhook.EventParticipantLeft:
-		p.handleLiveKitParticipantLeft(event)
+		p.handleLiveKitSIPParticipantLeft(event)
 	case webhook.EventRoomStarted, webhook.EventRoomFinished:
 		p.LogDebug("handleLiveKitWebhook: room lifecycle event (informational only)",
 			"event", event.GetEvent(),
@@ -629,7 +629,7 @@ func (p *Plugin) handleLiveKitWebhook(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (p *Plugin) handleLiveKitParticipantJoined(event *livekit.WebhookEvent) {
+func (p *Plugin) handleLiveKitSIPParticipantJoined(event *livekit.WebhookEvent) {
 	participant := event.GetParticipant()
 	if participant == nil || participant.Kind != livekit.ParticipantInfo_SIP {
 		return
@@ -637,35 +637,35 @@ func (p *Plugin) handleLiveKitParticipantJoined(event *livekit.WebhookEvent) {
 
 	channelID := event.GetRoom().GetName()
 	if channelID == "" {
-		p.LogError("handleLiveKitParticipantJoined: empty room name")
+		p.LogError("handleLiveKitSIPParticipantJoined: empty room name")
 		return
 	}
 
 	sid := participant.Sid
 	identity := participant.Identity
 
-	p.LogDebug("handleLiveKitParticipantJoined: SIP participant joined",
+	p.LogDebug("handleLiveKitSIPParticipantJoined: SIP participant joined",
 		"channelID", channelID, "sid", sid, "identity", identity)
 
 	state, err := p.lockCallReturnState(channelID)
 	if err != nil {
-		p.LogError("handleLiveKitParticipantJoined: failed to lock call", "channelID", channelID, "err", err.Error())
+		p.LogError("handleLiveKitSIPParticipantJoined: failed to lock call", "channelID", channelID, "err", err.Error())
 		return
 	}
 	defer p.unlockCall(channelID)
 
 	if state == nil {
-		p.LogDebug("handleLiveKitParticipantJoined: no active call", "channelID", channelID)
+		p.LogDebug("handleLiveKitSIPParticipantJoined: no active call", "channelID", channelID)
 		return
 	}
 
 	if state.Call.EndAt > 0 {
-		p.LogDebug("handleLiveKitParticipantJoined: call has ended", "channelID", channelID)
+		p.LogDebug("handleLiveKitSIPParticipantJoined: call has ended", "channelID", channelID)
 		return
 	}
 
 	if _, exists := state.sessions[sid]; exists {
-		p.LogDebug("handleLiveKitParticipantJoined: SIP session already exists", "channelID", channelID, "sid", sid)
+		p.LogDebug("handleLiveKitSIPParticipantJoined: SIP session already exists", "channelID", channelID, "sid", sid)
 		return
 	}
 
@@ -691,14 +691,14 @@ func (p *Plugin) handleLiveKitParticipantJoined(event *livekit.WebhookEvent) {
 	}
 
 	if err := p.store.CreateCallSession(session); err != nil {
-		p.LogError("handleLiveKitParticipantJoined: failed to create call session",
+		p.LogError("handleLiveKitSIPParticipantJoined: failed to create call session",
 			"channelID", channelID, "err", err.Error())
 		delete(state.sessions, sid)
 		return
 	}
 
 	if err := p.store.UpdateCall(&state.Call); err != nil {
-		p.LogError("handleLiveKitParticipantJoined: failed to update call",
+		p.LogError("handleLiveKitSIPParticipantJoined: failed to update call",
 			"channelID", channelID, "err", err.Error())
 	}
 
@@ -708,7 +708,7 @@ func (p *Plugin) handleLiveKitParticipantJoined(event *livekit.WebhookEvent) {
 	}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
 }
 
-func (p *Plugin) handleLiveKitParticipantLeft(event *livekit.WebhookEvent) {
+func (p *Plugin) handleLiveKitSIPParticipantLeft(event *livekit.WebhookEvent) {
 	participant := event.GetParticipant()
 	if participant == nil || participant.Kind != livekit.ParticipantInfo_SIP {
 		return
@@ -716,35 +716,35 @@ func (p *Plugin) handleLiveKitParticipantLeft(event *livekit.WebhookEvent) {
 
 	channelID := event.GetRoom().GetName()
 	if channelID == "" {
-		p.LogError("handleLiveKitParticipantLeft: empty room name")
+		p.LogError("handleLiveKitSIPParticipantLeft: empty room name")
 		return
 	}
 
 	sid := participant.Sid
 	identity := participant.Identity
 
-	p.LogDebug("handleLiveKitParticipantLeft: SIP participant left",
+	p.LogDebug("handleLiveKitSIPParticipantLeft: SIP participant left",
 		"channelID", channelID, "sid", sid, "identity", identity)
 
 	state, err := p.lockCallReturnState(channelID)
 	if err != nil {
-		p.LogError("handleLiveKitParticipantLeft: failed to lock call", "channelID", channelID, "err", err.Error())
+		p.LogError("handleLiveKitSIPParticipantLeft: failed to lock call", "channelID", channelID, "err", err.Error())
 		return
 	}
 	defer p.unlockCall(channelID)
 
 	if state == nil {
-		p.LogDebug("handleLiveKitParticipantLeft: no active call", "channelID", channelID)
+		p.LogDebug("handleLiveKitSIPParticipantLeft: no active call", "channelID", channelID)
 		return
 	}
 
 	if _, exists := state.sessions[sid]; !exists {
-		p.LogDebug("handleLiveKitParticipantLeft: SIP session not found (idempotent)", "channelID", channelID, "sid", sid)
+		p.LogDebug("handleLiveKitSIPParticipantLeft: SIP session not found (idempotent)", "channelID", channelID, "sid", sid)
 		return
 	}
 
 	if err := p.store.DeleteCallSession(sid); err != nil {
-		p.LogError("handleLiveKitParticipantLeft: failed to delete call session",
+		p.LogError("handleLiveKitSIPParticipantLeft: failed to delete call session",
 			"channelID", channelID, "err", err.Error())
 		return
 	}
@@ -769,7 +769,7 @@ func (p *Plugin) handleLiveKitParticipantLeft(event *livekit.WebhookEvent) {
 	}
 
 	if err := p.store.UpdateCall(&state.Call); err != nil {
-		p.LogError("handleLiveKitParticipantLeft: failed to update call",
+		p.LogError("handleLiveKitSIPParticipantLeft: failed to update call",
 			"channelID", channelID, "err", err.Error())
 	}
 

--- a/server/api_livekit_webhook_test.go
+++ b/server/api_livekit_webhook_test.go
@@ -1,0 +1,507 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/mattermost/mattermost-plugin-calls/server/db"
+	"github.com/mattermost/mattermost-plugin-calls/server/enterprise"
+	"github.com/mattermost/mattermost-plugin-calls/server/public"
+
+	serverMocks "github.com/mattermost/mattermost-plugin-calls/server/mocks/github.com/mattermost/mattermost-plugin-calls/server/interfaces"
+	pluginMocks "github.com/mattermost/mattermost-plugin-calls/server/mocks/github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/mattermost/mattermost-plugin-calls/server/cluster"
+
+	"github.com/livekit/protocol/auth"
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// newSignedWebhookRequest creates a valid LiveKit-signed webhook POST request.
+func newSignedWebhookRequest(t *testing.T, apiKey, apiSecret string, event *livekit.WebhookEvent) *http.Request {
+	t.Helper()
+
+	body, err := protojson.Marshal(event)
+	require.NoError(t, err)
+
+	sha := sha256.Sum256(body)
+	hash := base64.StdEncoding.EncodeToString(sha[:])
+
+	token, err := auth.NewAccessToken(apiKey, apiSecret).
+		SetSha256(hash).
+		ToJWT()
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, "/livekit-webhook", bytes.NewReader(body))
+	r.Header.Set("Authorization", token)
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func TestHandleLiveKitWebhook(t *testing.T) {
+	const (
+		testAPIKey    = "testkey"
+		testAPISecret = "testsecret"
+	)
+
+	newPlugin := func(t *testing.T) (*Plugin, *pluginMocks.MockAPI) {
+		t.Helper()
+		mockAPI := &pluginMocks.MockAPI{}
+		mockMetrics := &serverMocks.MockMetrics{}
+		p := &Plugin{
+			MattermostPlugin:  plugin.MattermostPlugin{API: mockAPI},
+			metrics:           mockMetrics,
+			apiLimiters:       map[string]*rate.Limiter{},
+			callsClusterLocks: map[string]*cluster.Mutex{},
+		}
+		p.licenseChecker = enterprise.NewLicenseChecker(p.API)
+		mockMetrics.On("Handler").Return(nil).Once()
+		mockMetrics.On("ObserveAppHandlersTime", mock.AnythingOfType("string"), mock.AnythingOfType("float64"))
+		mockAPI.On("GetConfig").Return(&model.Config{}, nil)
+		mockAPI.On("GetLicense").Return(&model.License{SkuShortName: "enterprise"}, nil)
+		mockAPI.On("LogDebug", mock.AnythingOfType("string"), mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+		mockAPI.On("LogError", mock.AnythingOfType("string"), mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+		return p, mockAPI
+	}
+
+	t.Run("livekit not configured", func(t *testing.T) {
+		p, _ := newPlugin(t)
+		apiRouter := p.newAPIRouter()
+
+		event := &livekit.WebhookEvent{Event: "participant_joined"}
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusServiceUnavailable, w.Result().StatusCode)
+	})
+
+	t.Run("invalid signature rejected", func(t *testing.T) {
+		p, _ := newPlugin(t)
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		cfg.LiveKitAPIKey = testAPIKey
+		cfg.LiveKitAPISecret = testAPISecret
+		p.configuration = cfg
+
+		apiRouter := p.newAPIRouter()
+
+		event := &livekit.WebhookEvent{Event: "participant_joined"}
+		r := newSignedWebhookRequest(t, testAPIKey, "wrongsecret", event)
+
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusForbidden, w.Result().StatusCode)
+	})
+
+	t.Run("no Mattermost-User-Id required", func(t *testing.T) {
+		p, mockAPI := newPlugin(t)
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		cfg.LiveKitAPIKey = testAPIKey
+		cfg.LiveKitAPISecret = testAPISecret
+		p.configuration = cfg
+
+		mockAPI.On("LogDebug", mock.AnythingOfType("string"),
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything).Maybe()
+
+		apiRouter := p.newAPIRouter()
+
+		event := &livekit.WebhookEvent{
+			Event: "room_started",
+			Room:  &livekit.Room{Name: model.NewId()},
+		}
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+		// Deliberately no Mattermost-User-Id header.
+
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
+	t.Run("non-SIP participant_joined ignored", func(t *testing.T) {
+		p, mockAPI := newPlugin(t)
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		cfg.LiveKitAPIKey = testAPIKey
+		cfg.LiveKitAPISecret = testAPISecret
+		p.configuration = cfg
+
+		mockAPI.On("LogDebug", mock.AnythingOfType("string"),
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything).Maybe()
+
+		apiRouter := p.newAPIRouter()
+
+		event := &livekit.WebhookEvent{
+			Event: "participant_joined",
+			Room:  &livekit.Room{Name: model.NewId()},
+			Participant: &livekit.ParticipantInfo{
+				Sid:      model.NewId(),
+				Identity: "user123",
+				Kind:     livekit.ParticipantInfo_STANDARD,
+			},
+		}
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		// 200 and no store interaction (p.store is nil; would panic if called).
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+}
+
+func TestHandleLiveKitSIPParticipant(t *testing.T) {
+	const (
+		testAPIKey    = "testkey"
+		testAPISecret = "testsecret"
+	)
+
+	setupPlugin := func(t *testing.T) (*Plugin, *pluginMocks.MockAPI, *serverMocks.MockMetrics) {
+		t.Helper()
+
+		mockAPI := &pluginMocks.MockAPI{}
+		mockMetrics := &serverMocks.MockMetrics{}
+
+		store, tearDown := NewTestStore(t)
+		t.Cleanup(tearDown)
+
+		p := &Plugin{
+			MattermostPlugin:  plugin.MattermostPlugin{API: mockAPI},
+			metrics:           mockMetrics,
+			apiLimiters:       map[string]*rate.Limiter{},
+			callsClusterLocks: map[string]*cluster.Mutex{},
+			store:             store,
+		}
+		p.licenseChecker = enterprise.NewLicenseChecker(p.API)
+
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		cfg.LiveKitAPIKey = testAPIKey
+		cfg.LiveKitAPISecret = testAPISecret
+		p.configuration = cfg
+
+		mockMetrics.On("Handler").Return(nil).Once()
+		mockMetrics.On("ObserveAppHandlersTime", mock.AnythingOfType("string"), mock.AnythingOfType("float64")).Maybe()
+		mockMetrics.On("IncWebSocketEvent", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Maybe()
+		mockAPI.On("GetConfig").Return(&model.Config{}, nil)
+		mockAPI.On("GetLicense").Return(&model.License{SkuShortName: "enterprise"}, nil)
+		mockAPI.On("LogDebug", mock.AnythingOfType("string"),
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+		mockAPI.On("LogError", mock.AnythingOfType("string"),
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+		mockAPI.On("PublishWebSocketEvent",
+			mock.AnythingOfType("string"),
+			mock.Anything,
+			mock.AnythingOfType("*model.WebsocketBroadcast")).Maybe()
+		// KV mocks needed for cluster mutex locking in lockCallReturnState.
+		mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
+		mockAPI.On("KVDelete", mock.Anything).Return(nil).Maybe()
+		mockMetrics.On("ObserveClusterMutexGrabTime", mock.Anything, mock.AnythingOfType("float64")).Maybe()
+		mockMetrics.On("ObserveClusterMutexLockedTime", mock.Anything, mock.AnythingOfType("float64")).Maybe()
+
+		return p, mockAPI, mockMetrics
+	}
+
+	createActiveCall := func(t *testing.T, p *Plugin, channelID, postID string) *public.Call {
+		t.Helper()
+		userID := model.NewId()
+		callID := model.NewId()
+		createPost(t, p.store, postID, userID, channelID)
+		call := &public.Call{
+			ID:        callID,
+			CreateAt:  time.Now().UnixMilli(),
+			StartAt:   time.Now().UnixMilli(),
+			ChannelID: channelID,
+			PostID:    postID,
+			ThreadID:  model.NewId(),
+			OwnerID:   userID,
+			Props:     public.CallProps{NodeID: "test-node"},
+		}
+		require.NoError(t, p.store.CreateCall(call))
+		return call
+	}
+
+	setupLock := func(mockAPI *pluginMocks.MockAPI, mockMetrics *serverMocks.MockMetrics, channelID string) {
+		mockAPI.On("LogDebug", "creating cluster mutex for call",
+			"origin", mock.AnythingOfType("string"), "channelID", channelID).Once()
+		mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil)
+		mockMetrics.On("ObserveClusterMutexGrabTime", "mutex_call", mock.AnythingOfType("float64")).Maybe()
+		mockMetrics.On("ObserveClusterMutexLockedTime", "mutex_call", mock.AnythingOfType("float64")).Maybe()
+	}
+
+	t.Run("SIP participant_joined creates session and publishes user_joined", func(t *testing.T) {
+		p, mockAPI, mockMetrics := setupPlugin(t)
+		defer ResetTestStore(t, p.store)
+
+		channelID := model.NewId()
+		postID := model.NewId()
+		call := createActiveCall(t, p, channelID, postID)
+		setupLock(mockAPI, mockMetrics, channelID)
+
+		sipSid := model.NewId()
+		sipIdentity := "+14155551234"
+
+		event := &livekit.WebhookEvent{
+			Event: "participant_joined",
+			Room:  &livekit.Room{Name: channelID},
+			Participant: &livekit.ParticipantInfo{
+				Sid:      sipSid,
+				Identity: sipIdentity,
+				Kind:     livekit.ParticipantInfo_SIP,
+			},
+		}
+
+		apiRouter := p.newAPIRouter()
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+		sessions, err := p.store.GetCallSessions(call.ID, db.GetCallSessionOpts{})
+		require.NoError(t, err)
+		require.Len(t, sessions, 1)
+
+		var sess *public.CallSession
+		for _, s := range sessions {
+			sess = s
+		}
+		require.Equal(t, sipSid, sess.ID)
+		require.Equal(t, sipIdentity, sess.UserID)
+		require.True(t, sess.IsSIPParticipant)
+
+		// Verify user_joined WS event was published.
+		mockAPI.AssertCalled(t, "PublishWebSocketEvent",
+			wsEventUserJoined, mock.Anything, mock.Anything)
+	})
+
+	t.Run("SIP participant_joined no active call is a no-op", func(t *testing.T) {
+		p, _, _ := setupPlugin(t)
+
+		event := &livekit.WebhookEvent{
+			Event: "participant_joined",
+			Room:  &livekit.Room{Name: model.NewId()},
+			Participant: &livekit.ParticipantInfo{
+				Sid:      model.NewId(),
+				Identity: "+14155550000",
+				Kind:     livekit.ParticipantInfo_SIP,
+			},
+		}
+
+		apiRouter := p.newAPIRouter()
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
+	t.Run("SIP participant_left removes session and publishes user_left", func(t *testing.T) {
+		p, mockAPI, mockMetrics := setupPlugin(t)
+		defer ResetTestStore(t, p.store)
+
+		channelID := model.NewId()
+		postID := model.NewId()
+		call := createActiveCall(t, p, channelID, postID)
+
+		sipSid := model.NewId()
+		sipIdentity := "+14155551234"
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:               sipSid,
+			CallID:           call.ID,
+			UserID:           sipIdentity,
+			JoinAt:           time.Now().UnixMilli(),
+			IsSIPParticipant: true,
+		}))
+
+		setupLock(mockAPI, mockMetrics, channelID)
+
+		event := &livekit.WebhookEvent{
+			Event: "participant_left",
+			Room:  &livekit.Room{Name: channelID},
+			Participant: &livekit.ParticipantInfo{
+				Sid:      sipSid,
+				Identity: sipIdentity,
+				Kind:     livekit.ParticipantInfo_SIP,
+			},
+		}
+
+		apiRouter := p.newAPIRouter()
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+		sessions, err := p.store.GetCallSessions(call.ID, db.GetCallSessionOpts{})
+		require.NoError(t, err)
+		require.Empty(t, sessions)
+
+		mockAPI.AssertCalled(t, "PublishWebSocketEvent",
+			wsEventUserLeft, mock.Anything, mock.Anything)
+	})
+
+	t.Run("SIP participant_left idempotent when session not found", func(t *testing.T) {
+		p, mockAPI, mockMetrics := setupPlugin(t)
+		defer ResetTestStore(t, p.store)
+
+		channelID := model.NewId()
+		postID := model.NewId()
+		createActiveCall(t, p, channelID, postID)
+		setupLock(mockAPI, mockMetrics, channelID)
+
+		event := &livekit.WebhookEvent{
+			Event: "participant_left",
+			Room:  &livekit.Room{Name: channelID},
+			Participant: &livekit.ParticipantInfo{
+				Sid:      model.NewId(),
+				Identity: "+10000000000",
+				Kind:     livekit.ParticipantInfo_SIP,
+			},
+		}
+
+		apiRouter := p.newAPIRouter()
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+}
+
+func TestGetHostIDSIPDeprioritization(t *testing.T) {
+	now := time.Now().UnixMilli()
+
+	makeSession := func(userID string, joinAt int64, isSIP bool) *public.CallSession {
+		return &public.CallSession{
+			ID:               model.NewId(),
+			UserID:           userID,
+			JoinAt:           joinAt,
+			IsSIPParticipant: isSIP,
+		}
+	}
+
+	t.Run("regular user beats SIP for host", func(t *testing.T) {
+		sipUser := "+14155551234"
+		regularUser := model.NewId()
+
+		cs := &callState{
+			Call: public.Call{
+				Props: public.CallProps{Hosts: []string{sipUser}},
+			},
+			sessions: map[string]*public.CallSession{
+				"sip1":  makeSession(sipUser, now-2000, true),
+				"user1": makeSession(regularUser, now-1000, false),
+			},
+		}
+		require.Equal(t, regularUser, cs.getHostID("botID"))
+	})
+
+	t.Run("SIP is host when only SIP participants present", func(t *testing.T) {
+		sip1 := "+14155551234"
+		sip2 := "+14155550001"
+
+		cs := &callState{
+			Call: public.Call{},
+			sessions: map[string]*public.CallSession{
+				"sip1": makeSession(sip1, now-2000, true),
+				"sip2": makeSession(sip2, now-1000, true),
+			},
+		}
+		// Earliest SIP joiner should be host.
+		require.Equal(t, sip1, cs.getHostID("botID"))
+	})
+
+	t.Run("HostLockedUserID takes priority over everything", func(t *testing.T) {
+		lockedUser := model.NewId()
+		regularUser := model.NewId()
+
+		cs := &callState{
+			Call: public.Call{
+				Props: public.CallProps{
+					HostLockedUserID: lockedUser,
+					Hosts:            []string{lockedUser},
+				},
+			},
+			sessions: map[string]*public.CallSession{
+				"user1":   makeSession(regularUser, now-5000, false),
+				"locked1": makeSession(lockedUser, now-1000, false),
+			},
+		}
+		require.Equal(t, lockedUser, cs.getHostID("botID"))
+	})
+
+	t.Run("SIP host yields when regular user joins", func(t *testing.T) {
+		sipUser := "+14155551234"
+		regularUser := model.NewId()
+
+		cs := &callState{
+			Call: public.Call{
+				Props: public.CallProps{Hosts: []string{sipUser}},
+			},
+			sessions: map[string]*public.CallSession{
+				"sip1":  makeSession(sipUser, now-5000, true),
+				"user1": makeSession(regularUser, now-1000, false),
+			},
+		}
+		require.Equal(t, regularUser, cs.getHostID("botID"))
+	})
+
+	t.Run("earliest non-SIP wins among multiple regular users", func(t *testing.T) {
+		user1 := model.NewId()
+		user2 := model.NewId()
+		sipUser := "+1415"
+
+		cs := &callState{
+			Call: public.Call{},
+			sessions: map[string]*public.CallSession{
+				"u1":  makeSession(user1, now-3000, false),
+				"u2":  makeSession(user2, now-1000, false),
+				"sip": makeSession(sipUser, now-5000, true),
+			},
+		}
+		require.Equal(t, user1, cs.getHostID("botID"))
+	})
+
+	t.Run("bot is never host", func(t *testing.T) {
+		botID := model.NewId()
+		sipUser := "+1415"
+
+		cs := &callState{
+			Call: public.Call{},
+			sessions: map[string]*public.CallSession{
+				"bot": makeSession(botID, now-5000, false),
+				"sip": makeSession(sipUser, now-1000, true),
+			},
+		}
+		require.Equal(t, sipUser, cs.getHostID(botID))
+	})
+}

--- a/server/api_router.go
+++ b/server/api_router.go
@@ -26,6 +26,7 @@ func (p *Plugin) newAPIRouter() *mux.Router {
 		metricsRoute = router.Handle("/metrics", p.metrics.Handler()).Methods("GET")
 	}
 	standaloneRoute := router.PathPrefix("/standalone/").HandlerFunc(p.handleServeStandalone).Methods("GET")
+	webhookRoute := router.HandleFunc("/livekit-webhook", p.handleLiveKitWebhook).Methods("POST")
 
 	// Authenticated API handlers (user session required)
 
@@ -43,6 +44,11 @@ func (p *Plugin) newAPIRouter() *mux.Router {
 			}
 
 			if standaloneRoute.Match(r, &mux.RouteMatch{}) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if webhookRoute.Match(r, &mux.RouteMatch{}) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -175,6 +181,11 @@ func (p *Plugin) newAPIRouter() *mux.Router {
 	router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if botRouter.Match(r, &mux.RouteMatch{}) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if webhookRoute.Match(r, &mux.RouteMatch{}) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/server/db/calls_sessions_store.go
+++ b/server/db/calls_sessions_store.go
@@ -14,7 +14,7 @@ import (
 	sq "github.com/mattermost/squirrel"
 )
 
-var callsSessionsColumns = []string{"ID", "CallID", "UserID", "JoinAt", "Unmuted", "RaisedHand", "Video"}
+var callsSessionsColumns = []string{"ID", "CallID", "UserID", "JoinAt", "Unmuted", "RaisedHand", "Video", "IsSIPParticipant"}
 
 func (s *Store) CreateCallSession(session *public.CallSession) error {
 	s.metrics.IncStoreOp("CreateCallSession")
@@ -29,7 +29,7 @@ func (s *Store) CreateCallSession(session *public.CallSession) error {
 	qb := getQueryBuilder(s.driverName).
 		Insert("calls_sessions").
 		Columns(callsSessionsColumns...).
-		Values(session.ID, session.CallID, session.UserID, session.JoinAt, session.Unmuted, session.RaisedHand, session.Video)
+		Values(session.ID, session.CallID, session.UserID, session.JoinAt, session.Unmuted, session.RaisedHand, session.Video, session.IsSIPParticipant)
 
 	q, args, err := qb.ToSql()
 	if err != nil {
@@ -156,7 +156,7 @@ func (s *Store) GetCallSessions(callID string, opts GetCallSessionOpts) (map[str
 
 	for rows.Next() {
 		var session public.CallSession
-		if err := rows.Scan(&session.ID, &session.CallID, &session.UserID, &session.JoinAt, &session.Unmuted, &session.RaisedHand, &session.Video); err != nil {
+		if err := rows.Scan(&session.ID, &session.CallID, &session.UserID, &session.JoinAt, &session.Unmuted, &session.RaisedHand, &session.Video, &session.IsSIPParticipant); err != nil {
 			return nil, fmt.Errorf("failed to scan rows: %w", err)
 		}
 		sessionsMap[session.ID] = &session

--- a/server/db/migrations/migrations.list
+++ b/server/db/migrations/migrations.list
@@ -10,6 +10,8 @@ server/db/migrations/mysql/000004_create_calls_jobs.down.sql
 server/db/migrations/mysql/000004_create_calls_jobs.up.sql
 server/db/migrations/mysql/000005_calls_sessions_video.down.sql
 server/db/migrations/mysql/000005_calls_sessions_video.up.sql
+server/db/migrations/mysql/000006_calls_sessions_sip.down.sql
+server/db/migrations/mysql/000006_calls_sessions_sip.up.sql
 server/db/migrations/postgres/000001_create_calls_channels.down.sql
 server/db/migrations/postgres/000001_create_calls_channels.up.sql
 server/db/migrations/postgres/000002_create_calls.down.sql
@@ -20,3 +22,5 @@ server/db/migrations/postgres/000004_create_calls_jobs.down.sql
 server/db/migrations/postgres/000004_create_calls_jobs.up.sql
 server/db/migrations/postgres/000005_calls_sessions_video.down.sql
 server/db/migrations/postgres/000005_calls_sessions_video.up.sql
+server/db/migrations/postgres/000006_calls_sessions_sip.down.sql
+server/db/migrations/postgres/000006_calls_sessions_sip.up.sql

--- a/server/db/migrations/mysql/000006_calls_sessions_sip.down.sql
+++ b/server/db/migrations/mysql/000006_calls_sessions_sip.down.sql
@@ -1,0 +1,14 @@
+SET @preparedStatement = (SELECT IF(
+    EXISTS(
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE table_name = 'calls_sessions'
+        AND table_schema = DATABASE()
+        AND column_name = 'IsSIPParticipant'
+    ),
+    'ALTER TABLE calls_sessions DROP COLUMN IsSIPParticipant;',
+    'SELECT 1;'
+));
+
+PREPARE dropColumnIfExists FROM @preparedStatement;
+EXECUTE dropColumnIfExists;
+DEALLOCATE PREPARE dropColumnIfExists;

--- a/server/db/migrations/mysql/000006_calls_sessions_sip.up.sql
+++ b/server/db/migrations/mysql/000006_calls_sessions_sip.up.sql
@@ -1,0 +1,14 @@
+SET @preparedStatement = (SELECT IF(
+    NOT EXISTS(
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE table_name = 'calls_sessions'
+        AND table_schema = DATABASE()
+        AND column_name = 'IsSIPParticipant'
+    ),
+    'ALTER TABLE calls_sessions ADD COLUMN IsSIPParticipant BOOLEAN NOT NULL DEFAULT FALSE;',
+    'SELECT 1;'
+));
+
+PREPARE addColumnIfNotExists FROM @preparedStatement;
+EXECUTE addColumnIfNotExists;
+DEALLOCATE PREPARE addColumnIfNotExists;

--- a/server/db/migrations/postgres/000006_calls_sessions_sip.down.sql
+++ b/server/db/migrations/postgres/000006_calls_sessions_sip.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE calls_sessions DROP COLUMN IF EXISTS issipparticipant;

--- a/server/db/migrations/postgres/000006_calls_sessions_sip.up.sql
+++ b/server/db/migrations/postgres/000006_calls_sessions_sip.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE calls_sessions ADD COLUMN IF NOT EXISTS issipparticipant boolean DEFAULT FALSE;

--- a/server/public/call_session.go
+++ b/server/public/call_session.go
@@ -8,13 +8,14 @@ import (
 )
 
 type CallSession struct {
-	ID         string `json:"id"`
-	CallID     string `json:"call_id"`
-	UserID     string `json:"user_id"`
-	JoinAt     int64  `json:"join_at"`
-	Unmuted    bool   `json:"unmuted"`
-	RaisedHand int64  `json:"raised_hand"`
-	Video      bool   `json:"video"`
+	ID               string `json:"id"`
+	CallID           string `json:"call_id"`
+	UserID           string `json:"user_id"`
+	JoinAt           int64  `json:"join_at"`
+	Unmuted          bool   `json:"unmuted"`
+	RaisedHand       int64  `json:"raised_hand"`
+	Video            bool   `json:"video"`
+	IsSIPParticipant bool   `json:"is_sip_participant,omitempty"`
 }
 
 func (s *CallSession) IsValid() error {

--- a/server/state.go
+++ b/server/state.go
@@ -174,30 +174,39 @@ func (cs *callState) getHostID(botID string) string {
 		return cs.Call.Props.HostLockedUserID
 	}
 
-	var host public.CallSession
-	for _, session := range cs.sessions {
-		// if current host is still in the call, keep them as the host
-		if session.UserID == cs.Call.GetHostID() {
-			return cs.Call.GetHostID()
-		}
+	currentHostID := cs.Call.GetHostID()
 
-		// bot can't be host
-		if session.UserID == botID {
-			continue
-		}
-
-		if host.UserID == "" {
-			host = *session
-			continue
-		}
-
-		// the participant who joined earliest should be host
-		if session.JoinAt < host.JoinAt {
-			host = *session
+	// If the current host is a non-SIP, non-bot participant still in the call, keep them.
+	if currentHostID != "" && currentHostID != botID {
+		for _, session := range cs.sessions {
+			if session.UserID == currentHostID && !session.IsSIPParticipant {
+				return currentHostID
+			}
 		}
 	}
 
-	return host.UserID
+	// Current host has left, is a SIP participant, or is the bot.
+	// Find the best candidate: prefer non-SIP over SIP, earliest joiner wins within each tier.
+	var bestNonSIP, bestSIP public.CallSession
+	for _, session := range cs.sessions {
+		if session.UserID == botID {
+			continue
+		}
+		if !session.IsSIPParticipant {
+			if bestNonSIP.UserID == "" || session.JoinAt < bestNonSIP.JoinAt {
+				bestNonSIP = *session
+			}
+		} else {
+			if bestSIP.UserID == "" || session.JoinAt < bestSIP.JoinAt {
+				bestSIP = *session
+			}
+		}
+	}
+
+	if bestNonSIP.UserID != "" {
+		return bestNonSIP.UserID
+	}
+	return bestSIP.UserID
 }
 
 func (cs *callState) isUserIDInCall(userID string) bool {


### PR DESCRIPTION
## Summary

- Add `POST /livekit-webhook` endpoint that verifies LiveKit JWT signatures (HMAC-SHA256 via `LiveKitAPISecret`) and handles `participant_joined`/`participant_left` events for SIP participants only; non-SIP events are silently ignored
- Add `IsSIPParticipant bool` to `CallSession` struct and DB migration 006 to persist it
- Rewrite `getHostID()` to deprioritize SIP participants: non-SIP users always preferred as host; SIP-only calls fall back to earliest SIP joiner; `HostLockedUserID` retains top priority
- Webhook route bypasses Mattermost-User-Id auth middleware and rate limiter (LiveKit server has no user session)
- Regular (non-SIP) clients continue to use the v1 Mattermost WS join/leave path unchanged — this is a purely additive change for SIP

## Test plan

- [ ] `go test ./server/... ` — all pass including 14 new tests in `api_livekit_webhook_test.go`
- [ ] `TestHandleLiveKitWebhook` — signature verification (valid/invalid/unconfigured), auth middleware bypass, non-SIP events ignored
- [ ] `TestHandleLiveKitSIPParticipant` — end-to-end with real PostgreSQL: join creates session row with `IsSIPParticipant: true` and publishes `user_joined`; no active call is a no-op; leave removes session and publishes `user_left`; leave is idempotent
- [ ] `TestGetHostIDSIPDeprioritization` — 6 unit tests covering all host priority tiers
- [ ] `make golangci-lint` — no new issues (pre-existing `interfaces` package-name warning unchanged from `main`)
- [ ] `make gomod-check` — passes after `go mod tidy`

Jira: https://mattermost.atlassian.net/browse/MM-68698