### PR TITLE
[MM-68719] Use user_id & ession_id for LiveKit identity

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -497,23 +497,16 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// userID rides in metadata so other clients can map identity (session_id)
-	// back to a Mattermost user. LiveKit relays metadata to all participants.
-	metadata, err := json.Marshal(map[string]string{"user_id": userID})
-	if err != nil {
-		res.Err = fmt.Sprintf("failed to encode metadata: %s", err.Error())
-		res.Code = http.StatusInternalServerError
-		return
-	}
-
+	// Identity is the only LiveKit field sealed post-connect, so userID and
+	// sessionID both ride in it. The "___" separator both delimits the two
+	// halves and tags the format as an MM user (vs. "guest:" / "sip:" kinds).
 	at := auth.NewAccessToken(cfg.LiveKitAPIKey, cfg.LiveKitAPISecret)
 	grant := &auth.VideoGrant{
 		RoomJoin: true,
 		Room:     channelID,
 	}
 	at.SetVideoGrant(grant).
-		SetIdentity(sessionID).
-		SetMetadata(string(metadata)).
+		SetIdentity(userID + "___" + sessionID).
 		SetName(user.GetDisplayName(model.ShowFullName)).
 		SetValidFor(time.Hour)
 

--- a/server/api.go
+++ b/server/api.go
@@ -459,7 +459,24 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sessionID := r.URL.Query().Get("session_id")
+	if sessionID == "" {
+		res.Err = "session_id is required"
+		res.Code = http.StatusBadRequest
+		return
+	}
+
 	if !p.API.HasPermissionToChannel(userID, channelID, model.PermissionReadChannel) {
+		res.Err = "Forbidden"
+		res.Code = http.StatusForbidden
+		return
+	}
+
+	// The session must belong to the requesting user. Without this check a
+	// client could mint a token claiming any session_id, breaking the
+	// invariant that LiveKit identity == owner's plugin-WS session.
+	us := p.getSessionByOriginalID(sessionID)
+	if us == nil || us.userID != userID {
 		res.Err = "Forbidden"
 		res.Code = http.StatusForbidden
 		return
@@ -480,13 +497,23 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// userID rides in metadata so other clients can map identity (session_id)
+	// back to a Mattermost user. LiveKit relays metadata to all participants.
+	metadata, err := json.Marshal(map[string]string{"user_id": userID})
+	if err != nil {
+		res.Err = fmt.Sprintf("failed to encode metadata: %s", err.Error())
+		res.Code = http.StatusInternalServerError
+		return
+	}
+
 	at := auth.NewAccessToken(cfg.LiveKitAPIKey, cfg.LiveKitAPISecret)
 	grant := &auth.VideoGrant{
 		RoomJoin: true,
 		Room:     channelID,
 	}
 	at.SetVideoGrant(grant).
-		SetIdentity(userID).
+		SetIdentity(sessionID).
+		SetMetadata(string(metadata)).
 		SetName(user.GetDisplayName(model.ShowFullName)).
 		SetValidFor(time.Hour)
 

--- a/server/api_livekit_test.go
+++ b/server/api_livekit_test.go
@@ -261,7 +261,7 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		verifier, err := auth.ParseAPIToken(tokenResp["token"])
 		require.NoError(t, err)
 		require.Equal(t, "testkey", verifier.APIKey())
-		require.Equal(t, sessionID, verifier.Identity())
+		require.Equal(t, userID+"___"+sessionID, verifier.Identity())
 
 		_, claims, err := verifier.Verify("testsecret")
 		require.NoError(t, err)
@@ -269,12 +269,7 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		require.NotNil(t, claims.Video)
 		require.True(t, claims.Video.RoomJoin)
 		require.Equal(t, channelID, claims.Video.Room)
-
-		// userID rides in metadata.
-		var metadata map[string]string
-		err = json.Unmarshal([]byte(claims.Metadata), &metadata)
-		require.NoError(t, err)
-		require.Equal(t, userID, metadata["user_id"])
+		require.Empty(t, claims.Metadata)
 	})
 
 	t.Run("session matched by originalConnID after reconnect", func(t *testing.T) {
@@ -315,7 +310,7 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 
 		verifier, err := auth.ParseAPIToken(tokenResp["token"])
 		require.NoError(t, err)
-		require.Equal(t, originalConnID, verifier.Identity())
+		require.Equal(t, userID+"___"+originalConnID, verifier.Identity())
 	})
 
 	t.Run("unauthenticated", func(t *testing.T) {

--- a/server/api_livekit_test.go
+++ b/server/api_livekit_test.go
@@ -34,6 +34,7 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		},
 		metrics:     mockMetrics,
 		apiLimiters: map[string]*rate.Limiter{},
+		sessions:    map[string]*session{},
 	}
 
 	p.licenseChecker = enterprise.NewLicenseChecker(p.API)
@@ -72,14 +73,79 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		require.Equal(t, "channel_id is required", res.Msg)
 	})
 
+	t.Run("missing session_id", func(t *testing.T) {
+		userID := model.NewId()
+		channelID := model.NewId()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s", channelID), nil)
+		r.Header.Set("Mattermost-User-Id", userID)
+
+		apiRouter.ServeHTTP(w, r)
+
+		resp := w.Result()
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var res httpResponse
+		err := json.NewDecoder(resp.Body).Decode(&res)
+		require.NoError(t, err)
+		require.Equal(t, "session_id is required", res.Msg)
+	})
+
 	t.Run("no channel permission", func(t *testing.T) {
 		userID := model.NewId()
 		channelID := model.NewId()
+		sessionID := model.NewId()
 
 		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(false).Once()
 
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s", channelID), nil)
+		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s&session_id=%s", channelID, sessionID), nil)
+		r.Header.Set("Mattermost-User-Id", userID)
+
+		apiRouter.ServeHTTP(w, r)
+
+		resp := w.Result()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		var res httpResponse
+		err := json.NewDecoder(resp.Body).Decode(&res)
+		require.NoError(t, err)
+		require.Equal(t, "Forbidden", res.Msg)
+	})
+
+	t.Run("session_id not found", func(t *testing.T) {
+		userID := model.NewId()
+		channelID := model.NewId()
+		sessionID := model.NewId()
+
+		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(true).Once()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s&session_id=%s", channelID, sessionID), nil)
+		r.Header.Set("Mattermost-User-Id", userID)
+
+		apiRouter.ServeHTTP(w, r)
+
+		resp := w.Result()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+		var res httpResponse
+		err := json.NewDecoder(resp.Body).Decode(&res)
+		require.NoError(t, err)
+		require.Equal(t, "Forbidden", res.Msg)
+	})
+
+	t.Run("session_id owned by different user", func(t *testing.T) {
+		userID := model.NewId()
+		otherUserID := model.NewId()
+		channelID := model.NewId()
+		sessionID := model.NewId()
+
+		p.sessions[sessionID] = &session{userID: otherUserID, connID: sessionID, originalConnID: sessionID}
+		t.Cleanup(func() { delete(p.sessions, sessionID) })
+
+		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(true).Once()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s&session_id=%s", channelID, sessionID), nil)
 		r.Header.Set("Mattermost-User-Id", userID)
 
 		apiRouter.ServeHTTP(w, r)
@@ -95,12 +161,16 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 	t.Run("livekit not configured", func(t *testing.T) {
 		userID := model.NewId()
 		channelID := model.NewId()
+		sessionID := model.NewId()
+
+		p.sessions[sessionID] = &session{userID: userID, connID: sessionID, originalConnID: sessionID}
+		t.Cleanup(func() { delete(p.sessions, sessionID) })
 
 		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(true).Once()
 		mockAPI.On("LoadPluginConfiguration", mock.AnythingOfType("*main.configuration")).Return(nil).Once()
 
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s", channelID), nil)
+		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s&session_id=%s", channelID, sessionID), nil)
 		r.Header.Set("Mattermost-User-Id", userID)
 
 		apiRouter.ServeHTTP(w, r)
@@ -116,6 +186,7 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 	t.Run("get user error", func(t *testing.T) {
 		userID := model.NewId()
 		channelID := model.NewId()
+		sessionID := model.NewId()
 
 		cfg := &configuration{}
 		cfg.SetDefaults()
@@ -124,13 +195,16 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		cfg.LiveKitAPISecret = "testsecret"
 		p.configuration = cfg
 
+		p.sessions[sessionID] = &session{userID: userID, connID: sessionID, originalConnID: sessionID}
+		t.Cleanup(func() { delete(p.sessions, sessionID) })
+
 		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(true).Once()
 		mockAPI.On("GetUser", userID).Return(nil, &model.AppError{
 			Message: "user not found",
 		}).Once()
 
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s", channelID), nil)
+		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s&session_id=%s", channelID, sessionID), nil)
 		r.Header.Set("Mattermost-User-Id", userID)
 
 		apiRouter.ServeHTTP(w, r)
@@ -146,6 +220,7 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		userID := model.NewId()
 		channelID := model.NewId()
+		sessionID := model.NewId()
 
 		cfg := &configuration{}
 		cfg.SetDefaults()
@@ -153,6 +228,9 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		cfg.LiveKitAPIKey = "testkey"
 		cfg.LiveKitAPISecret = "testsecret"
 		p.configuration = cfg
+
+		p.sessions[sessionID] = &session{userID: userID, connID: sessionID, originalConnID: sessionID}
+		t.Cleanup(func() { delete(p.sessions, sessionID) })
 
 		user := &model.User{
 			Id:        userID,
@@ -165,7 +243,7 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		mockAPI.On("GetUser", userID).Return(user, nil).Once()
 
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s", channelID), nil)
+		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s&session_id=%s", channelID, sessionID), nil)
 		r.Header.Set("Mattermost-User-Id", userID)
 
 		apiRouter.ServeHTTP(w, r)
@@ -183,7 +261,7 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		verifier, err := auth.ParseAPIToken(tokenResp["token"])
 		require.NoError(t, err)
 		require.Equal(t, "testkey", verifier.APIKey())
-		require.Equal(t, userID, verifier.Identity())
+		require.Equal(t, sessionID, verifier.Identity())
 
 		_, claims, err := verifier.Verify("testsecret")
 		require.NoError(t, err)
@@ -191,6 +269,53 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 		require.NotNil(t, claims.Video)
 		require.True(t, claims.Video.RoomJoin)
 		require.Equal(t, channelID, claims.Video.Room)
+
+		// userID rides in metadata.
+		var metadata map[string]string
+		err = json.Unmarshal([]byte(claims.Metadata), &metadata)
+		require.NoError(t, err)
+		require.Equal(t, userID, metadata["user_id"])
+	})
+
+	t.Run("session matched by originalConnID after reconnect", func(t *testing.T) {
+		userID := model.NewId()
+		channelID := model.NewId()
+		originalConnID := model.NewId()
+		currentConnID := model.NewId()
+
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		cfg.LiveKitURL = "wss://lk.example.com"
+		cfg.LiveKitAPIKey = "testkey"
+		cfg.LiveKitAPISecret = "testsecret"
+		p.configuration = cfg
+
+		// After a WS reconnect, p.sessions is keyed by the current connID,
+		// but the client sends the original connID — getSessionByOriginalID
+		// must fall back to scanning the originalConnID field.
+		p.sessions[currentConnID] = &session{userID: userID, connID: currentConnID, originalConnID: originalConnID}
+		t.Cleanup(func() { delete(p.sessions, currentConnID) })
+
+		user := &model.User{Id: userID, Username: "testuser"}
+
+		mockAPI.On("HasPermissionToChannel", userID, channelID, model.PermissionReadChannel).Return(true).Once()
+		mockAPI.On("GetUser", userID).Return(user, nil).Once()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", fmt.Sprintf("/livekit-token?channel_id=%s&session_id=%s", channelID, originalConnID), nil)
+		r.Header.Set("Mattermost-User-Id", userID)
+
+		apiRouter.ServeHTTP(w, r)
+
+		resp := w.Result()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var tokenResp map[string]string
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+		verifier, err := auth.ParseAPIToken(tokenResp["token"])
+		require.NoError(t, err)
+		require.Equal(t, originalConnID, verifier.Identity())
 	})
 
 	t.Run("unauthenticated", func(t *testing.T) {

--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -62,7 +62,8 @@ function createMockRoom(): MockRoom {
         switchActiveDevice: jest.fn().mockResolvedValue(null),
         localParticipant: {
             sid: 'me-sid',
-            identity: 'me-id',
+            identity: 'me-session',
+            metadata: JSON.stringify({user_id: 'me-id'}),
             getTrackPublication: jest.fn(),
             setMicrophoneEnabled: jest.fn().mockResolvedValue(null),
             audioTrackPublications: new Map(),
@@ -173,11 +174,14 @@ describe('CallClient', () => {
     });
 
     describe('connect', () => {
-        it('fetches a token and calls room.connect', async () => {
+        it('fetches a token (with channel_id + session_id) and calls room.connect', async () => {
             await client.connect({channelID: 'test-channel'});
 
+            const fetchURL = (RestClient.fetch as jest.Mock).mock.calls[0][0];
+            expect(fetchURL).toContain('channel_id=test-channel');
+            expect(fetchURL).toContain('session_id=orig-conn-id');
             expect(RestClient.fetch).toHaveBeenCalledWith(
-                expect.stringContaining('test-channel'),
+                expect.any(String),
                 expect.objectContaining({method: 'GET'}),
             );
             expect(mockWebSocketClient.connect).toHaveBeenCalled();
@@ -227,20 +231,22 @@ describe('CallClient', () => {
             await client.connect({channelID: 'test-channel'});
             mockRoom.fire(RoomEvent.Connected);
 
-            // Local session_id is the WS originalConnID, not LiveKit's sid.
-            expect(muteListener).toHaveBeenCalledWith('orig-conn-id', 'me-id');
+            // session_id = participant.identity; user_id parsed from participant.metadata.
+            expect(muteListener).toHaveBeenCalledWith('me-session', 'me-id');
         });
 
         it('seeds USER_JOINED + MUTE for each remote participant in the room', async () => {
             mockRoom.localParticipant.getTrackPublication.mockReturnValue({isMuted: false});
             mockRoom.remoteParticipants.set('r1', {
-                sid: 'r1',
-                identity: 'remote-1',
+                sid: 'r1-sid',
+                identity: 'r1-session',
+                metadata: JSON.stringify({user_id: 'remote-1'}),
                 getTrackPublication: jest.fn(() => ({isMuted: true})),
             });
             mockRoom.remoteParticipants.set('r2', {
-                sid: 'r2',
-                identity: 'remote-2',
+                sid: 'r2-sid',
+                identity: 'r2-session',
+                metadata: JSON.stringify({user_id: 'remote-2'}),
                 getTrackPublication: jest.fn(() => ({isMuted: false})),
             });
 
@@ -254,15 +260,15 @@ describe('CallClient', () => {
             await client.connect({channelID: 'test-channel'});
             mockRoom.fire(RoomEvent.Connected);
 
-            expect(userJoinedListener).toHaveBeenCalledWith('r1', 'remote-1', true);
-            expect(muteListener).toHaveBeenCalledWith('r1', 'remote-1');
-            expect(userJoinedListener).toHaveBeenCalledWith('r2', 'remote-2', true);
-            expect(unmuteListener).toHaveBeenCalledWith('r2', 'remote-2');
+            expect(userJoinedListener).toHaveBeenCalledWith('r1-session', 'remote-1', true);
+            expect(muteListener).toHaveBeenCalledWith('r1-session', 'remote-1');
+            expect(userJoinedListener).toHaveBeenCalledWith('r2-session', 'remote-2', true);
+            expect(unmuteListener).toHaveBeenCalledWith('r2-session', 'remote-2');
         });
     });
 
     describe('TrackMuted / TrackUnmuted', () => {
-        it('emits MUTE with (sid, identity) when mic track is muted', async () => {
+        it('emits MUTE with (identity, user_id-from-metadata) when mic track is muted', async () => {
             await client.connect({channelID: 'test-channel'});
             const muteListener = jest.fn();
             client.on(CALL_EVENT.MUTE, muteListener);
@@ -270,13 +276,13 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackMuted,
                 {source: Track.Source.Microphone},
-                {sid: 'p1', identity: 'user1'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
             );
 
-            expect(muteListener).toHaveBeenCalledWith('p1', 'user1');
+            expect(muteListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
 
-        it('emits UNMUTE with (sid, identity) when mic track is unmuted', async () => {
+        it('emits UNMUTE with (identity, user_id-from-metadata) when mic track is unmuted', async () => {
             await client.connect({channelID: 'test-channel'});
             const unmuteListener = jest.fn();
             client.on(CALL_EVENT.UNMUTE, unmuteListener);
@@ -284,10 +290,10 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackUnmuted,
                 {source: Track.Source.Microphone},
-                {sid: 'p1', identity: 'user1'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
             );
 
-            expect(unmuteListener).toHaveBeenCalledWith('p1', 'user1');
+            expect(unmuteListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
 
         it('does not emit when a non-microphone track is muted', async () => {
@@ -298,7 +304,7 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackMuted,
                 {source: Track.Source.ScreenShare},
-                {sid: 'p1', identity: 'user1'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
             );
 
             expect(muteListener).not.toHaveBeenCalled();
@@ -314,10 +320,10 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackPublished,
                 {source: Track.Source.Microphone, isMuted: true},
-                {sid: 'p1', identity: 'user1'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
             );
 
-            expect(muteListener).toHaveBeenCalledWith('p1', 'user1');
+            expect(muteListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
 
         it('emits UNMUTE for a freshly-published unmuted mic publication (covers first-unmute)', async () => {
@@ -328,10 +334,10 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackPublished,
                 {source: Track.Source.Microphone, isMuted: false},
-                {sid: 'p1', identity: 'user1'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
             );
 
-            expect(unmuteListener).toHaveBeenCalledWith('p1', 'user1');
+            expect(unmuteListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
 
         it('emits MUTE when a remote unpublishes (no track == muted)', async () => {
@@ -342,10 +348,10 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackUnpublished,
                 {source: Track.Source.Microphone},
-                {sid: 'p1', identity: 'user1'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
             );
 
-            expect(muteListener).toHaveBeenCalledWith('p1', 'user1');
+            expect(muteListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
     });
 
@@ -366,8 +372,8 @@ describe('CallClient', () => {
                 mockRoom.localParticipant,
             );
 
-            // Local session_id is the WS originalConnID, not LiveKit's sid.
-            expect(unmuteListener).toHaveBeenCalledWith('orig-conn-id', 'me-id');
+            // session_id = participant.identity; user_id parsed from participant.metadata.
+            expect(unmuteListener).toHaveBeenCalledWith('me-session', 'me-id');
         });
 
         it('emits MUTE on local unpublish', async () => {
@@ -381,8 +387,8 @@ describe('CallClient', () => {
                 mockRoom.localParticipant,
             );
 
-            // Local session_id is the WS originalConnID, not LiveKit's sid.
-            expect(muteListener).toHaveBeenCalledWith('orig-conn-id', 'me-id');
+            // session_id = participant.identity; user_id parsed from participant.metadata.
+            expect(muteListener).toHaveBeenCalledWith('me-session', 'me-id');
         });
 
         it('does nothing for non-microphone local tracks', async () => {
@@ -404,7 +410,7 @@ describe('CallClient', () => {
     });
 
     describe('TrackSubscribed (remote audio routing)', () => {
-        it('emits REMOTE_VOICE_STREAM with stream + participant.sid for mic source', async () => {
+        it('emits REMOTE_VOICE_STREAM with stream + participant.identity for mic source', async () => {
             await client.connect({channelID: 'test-channel'});
             const remoteVoiceListener = jest.fn();
             client.on(CALL_EVENT.REMOTE_VOICE_STREAM, remoteVoiceListener);
@@ -413,10 +419,10 @@ describe('CallClient', () => {
                 RoomEvent.TrackSubscribed,
                 {source: Track.Source.Microphone, mediaStreamTrack: {}},
                 {},
-                {sid: 'p1', identity: 'user1'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
             );
 
-            expect(remoteVoiceListener).toHaveBeenCalledWith(expect.anything(), 'p1');
+            expect(remoteVoiceListener).toHaveBeenCalledWith(expect.anything(), 'p1-session');
         });
 
         it('does not emit for non-microphone tracks', async () => {
@@ -428,7 +434,7 @@ describe('CallClient', () => {
                 RoomEvent.TrackSubscribed,
                 {source: Track.Source.ScreenShare, mediaStreamTrack: {}},
                 {},
-                {sid: 'p1', identity: 'user1'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
             );
 
             expect(remoteVoiceListener).not.toHaveBeenCalled();
@@ -441,9 +447,9 @@ describe('CallClient', () => {
             const userJoinedListener = jest.fn();
             client.on(CALL_EVENT.USER_JOINED, userJoinedListener);
 
-            mockRoom.fire(RoomEvent.ParticipantConnected, {sid: 'p1', identity: 'user1'});
+            mockRoom.fire(RoomEvent.ParticipantConnected, {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})});
 
-            expect(userJoinedListener).toHaveBeenCalledWith('p1', 'user1');
+            expect(userJoinedListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
 
         it('emits USER_LEFT when a remote participant disconnects', async () => {
@@ -451,9 +457,9 @@ describe('CallClient', () => {
             const userLeftListener = jest.fn();
             client.on(CALL_EVENT.USER_LEFT, userLeftListener);
 
-            mockRoom.fire(RoomEvent.ParticipantDisconnected, {sid: 'p1', identity: 'user1'});
+            mockRoom.fire(RoomEvent.ParticipantDisconnected, {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})});
 
-            expect(userLeftListener).toHaveBeenCalledWith('p1', 'user1');
+            expect(userLeftListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
     });
 
@@ -538,11 +544,11 @@ describe('CallClient', () => {
             client.on(CALL_EVENT.USERS_VOICE_ACTIVITY_CHANGED, listener);
 
             mockRoom.fire(RoomEvent.ActiveSpeakersChanged, [
-                {sid: 'p1', identity: 'u1'},
-                {sid: 'p2', identity: 'u2'},
+                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'u1'})},
+                {sid: 'p2-sid', identity: 'p2-session', metadata: JSON.stringify({user_id: 'u2'})},
             ]);
 
-            expect(listener).toHaveBeenCalledWith(['u1', 'u2'], ['p1', 'p2']);
+            expect(listener).toHaveBeenCalledWith(['u1', 'u2'], ['p1-session', 'p2-session']);
         });
 
         it('emits empty arrays when no one is speaking', async () => {

--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -62,8 +62,7 @@ function createMockRoom(): MockRoom {
         switchActiveDevice: jest.fn().mockResolvedValue(null),
         localParticipant: {
             sid: 'me-sid',
-            identity: 'me-session',
-            metadata: JSON.stringify({user_id: 'me-id'}),
+            identity: 'me-id___me-session',
             getTrackPublication: jest.fn(),
             setMicrophoneEnabled: jest.fn().mockResolvedValue(null),
             audioTrackPublications: new Map(),
@@ -231,7 +230,7 @@ describe('CallClient', () => {
             await client.connect({channelID: 'test-channel'});
             mockRoom.fire(RoomEvent.Connected);
 
-            // session_id = participant.identity; user_id parsed from participant.metadata.
+            // session_id and user_id are parsed out of participant.identity ("userID___sessionID").
             expect(muteListener).toHaveBeenCalledWith('me-session', 'me-id');
         });
 
@@ -239,14 +238,12 @@ describe('CallClient', () => {
             mockRoom.localParticipant.getTrackPublication.mockReturnValue({isMuted: false});
             mockRoom.remoteParticipants.set('r1', {
                 sid: 'r1-sid',
-                identity: 'r1-session',
-                metadata: JSON.stringify({user_id: 'remote-1'}),
+                identity: 'remote-1___r1-session',
                 getTrackPublication: jest.fn(() => ({isMuted: true})),
             });
             mockRoom.remoteParticipants.set('r2', {
                 sid: 'r2-sid',
-                identity: 'r2-session',
-                metadata: JSON.stringify({user_id: 'remote-2'}),
+                identity: 'remote-2___r2-session',
                 getTrackPublication: jest.fn(() => ({isMuted: false})),
             });
 
@@ -268,7 +265,7 @@ describe('CallClient', () => {
     });
 
     describe('TrackMuted / TrackUnmuted', () => {
-        it('emits MUTE with (identity, user_id-from-metadata) when mic track is muted', async () => {
+        it('emits MUTE with (session_id, user_id) parsed from identity when mic track is muted', async () => {
             await client.connect({channelID: 'test-channel'});
             const muteListener = jest.fn();
             client.on(CALL_EVENT.MUTE, muteListener);
@@ -276,13 +273,13 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackMuted,
                 {source: Track.Source.Microphone},
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
+                {sid: 'p1-sid', identity: 'user1___p1-session'},
             );
 
             expect(muteListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
 
-        it('emits UNMUTE with (identity, user_id-from-metadata) when mic track is unmuted', async () => {
+        it('emits UNMUTE with (session_id, user_id) parsed from identity when mic track is unmuted', async () => {
             await client.connect({channelID: 'test-channel'});
             const unmuteListener = jest.fn();
             client.on(CALL_EVENT.UNMUTE, unmuteListener);
@@ -290,7 +287,7 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackUnmuted,
                 {source: Track.Source.Microphone},
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
+                {sid: 'p1-sid', identity: 'user1___p1-session'},
             );
 
             expect(unmuteListener).toHaveBeenCalledWith('p1-session', 'user1');
@@ -304,7 +301,7 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackMuted,
                 {source: Track.Source.ScreenShare},
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
+                {sid: 'p1-sid', identity: 'user1___p1-session'},
             );
 
             expect(muteListener).not.toHaveBeenCalled();
@@ -320,7 +317,7 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackPublished,
                 {source: Track.Source.Microphone, isMuted: true},
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
+                {sid: 'p1-sid', identity: 'user1___p1-session'},
             );
 
             expect(muteListener).toHaveBeenCalledWith('p1-session', 'user1');
@@ -334,7 +331,7 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackPublished,
                 {source: Track.Source.Microphone, isMuted: false},
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
+                {sid: 'p1-sid', identity: 'user1___p1-session'},
             );
 
             expect(unmuteListener).toHaveBeenCalledWith('p1-session', 'user1');
@@ -348,7 +345,7 @@ describe('CallClient', () => {
             mockRoom.fire(
                 RoomEvent.TrackUnpublished,
                 {source: Track.Source.Microphone},
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
+                {sid: 'p1-sid', identity: 'user1___p1-session'},
             );
 
             expect(muteListener).toHaveBeenCalledWith('p1-session', 'user1');
@@ -372,7 +369,7 @@ describe('CallClient', () => {
                 mockRoom.localParticipant,
             );
 
-            // session_id = participant.identity; user_id parsed from participant.metadata.
+            // session_id and user_id are parsed out of participant.identity ("userID___sessionID").
             expect(unmuteListener).toHaveBeenCalledWith('me-session', 'me-id');
         });
 
@@ -387,7 +384,7 @@ describe('CallClient', () => {
                 mockRoom.localParticipant,
             );
 
-            // session_id = participant.identity; user_id parsed from participant.metadata.
+            // session_id and user_id are parsed out of participant.identity ("userID___sessionID").
             expect(muteListener).toHaveBeenCalledWith('me-session', 'me-id');
         });
 
@@ -410,7 +407,7 @@ describe('CallClient', () => {
     });
 
     describe('TrackSubscribed (remote audio routing)', () => {
-        it('emits REMOTE_VOICE_STREAM with stream + participant.identity for mic source', async () => {
+        it('emits REMOTE_VOICE_STREAM with stream + session_id parsed from identity for mic source', async () => {
             await client.connect({channelID: 'test-channel'});
             const remoteVoiceListener = jest.fn();
             client.on(CALL_EVENT.REMOTE_VOICE_STREAM, remoteVoiceListener);
@@ -419,7 +416,7 @@ describe('CallClient', () => {
                 RoomEvent.TrackSubscribed,
                 {source: Track.Source.Microphone, mediaStreamTrack: {}},
                 {},
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
+                {sid: 'p1-sid', identity: 'user1___p1-session'},
             );
 
             expect(remoteVoiceListener).toHaveBeenCalledWith(expect.anything(), 'p1-session');
@@ -434,7 +431,7 @@ describe('CallClient', () => {
                 RoomEvent.TrackSubscribed,
                 {source: Track.Source.ScreenShare, mediaStreamTrack: {}},
                 {},
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})},
+                {sid: 'p1-sid', identity: 'user1___p1-session'},
             );
 
             expect(remoteVoiceListener).not.toHaveBeenCalled();
@@ -447,7 +444,7 @@ describe('CallClient', () => {
             const userJoinedListener = jest.fn();
             client.on(CALL_EVENT.USER_JOINED, userJoinedListener);
 
-            mockRoom.fire(RoomEvent.ParticipantConnected, {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})});
+            mockRoom.fire(RoomEvent.ParticipantConnected, {sid: 'p1-sid', identity: 'user1___p1-session'});
 
             expect(userJoinedListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
@@ -457,7 +454,7 @@ describe('CallClient', () => {
             const userLeftListener = jest.fn();
             client.on(CALL_EVENT.USER_LEFT, userLeftListener);
 
-            mockRoom.fire(RoomEvent.ParticipantDisconnected, {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'user1'})});
+            mockRoom.fire(RoomEvent.ParticipantDisconnected, {sid: 'p1-sid', identity: 'user1___p1-session'});
 
             expect(userLeftListener).toHaveBeenCalledWith('p1-session', 'user1');
         });
@@ -544,8 +541,8 @@ describe('CallClient', () => {
             client.on(CALL_EVENT.USERS_VOICE_ACTIVITY_CHANGED, listener);
 
             mockRoom.fire(RoomEvent.ActiveSpeakersChanged, [
-                {sid: 'p1-sid', identity: 'p1-session', metadata: JSON.stringify({user_id: 'u1'})},
-                {sid: 'p2-sid', identity: 'p2-session', metadata: JSON.stringify({user_id: 'u2'})},
+                {sid: 'p1-sid', identity: 'u1___p1-session'},
+                {sid: 'p2-sid', identity: 'u2___p2-session'},
             ]);
 
             expect(listener).toHaveBeenCalledWith(['u1', 'u2'], ['p1-session', 'p2-session']);

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -40,9 +40,22 @@ export type RtcTokenResponse = {
     url: string;
 };
 
-export async function fetchRtcToken(channelID: string): Promise<RtcTokenResponse> {
-    const url = `${getPluginPath()}/${CALL_TOKEN_API_PATH}?channel_id=${encodeURIComponent(channelID)}`;
+export async function fetchRtcToken(channelID: string, sessionID: string): Promise<RtcTokenResponse> {
+    const params = new URLSearchParams({channel_id: channelID, session_id: sessionID});
+    const url = `${getPluginPath()}/${CALL_TOKEN_API_PATH}?${params.toString()}`;
     return RestClient.fetch<RtcTokenResponse>(url, {method: 'GET'});
+}
+
+// LiveKit identity is the plugin-WS session_id; userID rides in metadata.
+function userIDFromMetadata(p: Participant): string {
+    if (!p.metadata) {
+        return '';
+    }
+    try {
+        return JSON.parse(p.metadata).user_id ?? '';
+    } catch {
+        return '';
+    }
 }
 
 export default class CallClient extends EventEmitter {
@@ -133,7 +146,7 @@ export default class CallClient extends EventEmitter {
         let token: string;
         let url: string;
         try {
-            const response = await fetchRtcToken(connectPayload.channelID);
+            const response = await fetchRtcToken(connectPayload.channelID, connID);
             token = response.token;
             url = response.url;
 
@@ -349,34 +362,7 @@ export default class CallClient extends EventEmitter {
     }
 
     public getSessionID() {
-        // The server's plugin-WS broadcasts (user_joined, call_state, etc.) use the
-        // WS originalConnID as session_id. Aligning with that here so the "(you)"
-        // check in the UI matches the session populated via USERS_STATES, instead
-        // of LiveKit's sid which the server doesn't know about.
-        // Once MM-68557 lands (server encodes session_id in LiveKit identity), this
-        // can be derived from participant.identity instead.
-        if (this.websocketClient?.getOriginalConnID()) {
-            return this.websocketClient.getOriginalConnID();
-        }
-
-        if (this.room?.localParticipant?.sid) {
-            return this.room.localParticipant.sid;
-        }
-
-        return null;
-    }
-
-    /**
-     * TODO: This is a temporary fix to align the session_id with the server's broadcasts.
-     * Returns the canonical session_id for a LiveKit Participant. For the LOCAL
-     * participant we use the WS originalConnID (matches what the server broadcasts);
-     * for REMOTE participants we use LiveKit's sid (best we have until MM-68557).
-     */
-    private sessionIDForParticipant(p: Participant): string {
-        if (this.room && p === this.room.localParticipant) {
-            return this.websocketClient?.getOriginalConnID() ?? p.sid;
-        }
-        return p.sid;
+        return this.room?.localParticipant?.identity ?? null;
     }
 
     private handleWebsocketOpened(originalConnID: string, prevConnID: string, isReconnect: boolean) {
@@ -447,21 +433,17 @@ export default class CallClient extends EventEmitter {
         void this.requestMicrophonePermission();
 
         // Seed the initial state for everyone already in the room (local + remote).
-        // Use WS originalConnID as our local session_id — it's what the server uses
-        // in its broadcasts. Without this alignment, USERS_STATES (server snapshot)
-        // would create a second session entry for us alongside the LiveKit-sid one.
         const localParticipant = this.room.localParticipant;
-        const localSessionID = this.websocketClient?.getOriginalConnID() ?? localParticipant.sid;
-        this.emit(CALL_EVENT.USER_JOINED, localSessionID, localParticipant.identity, true);
+        this.emit(CALL_EVENT.USER_JOINED, localParticipant.identity, userIDFromMetadata(localParticipant), true);
 
         const isLocalMicMuted = localParticipant.getTrackPublication(Track.Source.Microphone)?.isMuted ?? true;
-        this.emit(isLocalMicMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, localSessionID, localParticipant.identity);
+        this.emit(isLocalMicMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, localParticipant.identity, userIDFromMetadata(localParticipant));
 
         for (const remoteParticipant of this.room.remoteParticipants.values()) {
-            this.emit(CALL_EVENT.USER_JOINED, remoteParticipant.sid, remoteParticipant.identity, true);
+            this.emit(CALL_EVENT.USER_JOINED, remoteParticipant.identity, userIDFromMetadata(remoteParticipant), true);
 
             const isRemoteMicMuted = remoteParticipant.getTrackPublication(Track.Source.Microphone)?.isMuted ?? true;
-            this.emit(isRemoteMicMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, remoteParticipant.sid, remoteParticipant.identity);
+            this.emit(isRemoteMicMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
         }
 
         this.emit(CALL_EVENT.CONNECTED);
@@ -522,9 +504,9 @@ export default class CallClient extends EventEmitter {
     private handleTrackSubscribed(track: RemoteTrack, _pub: RemoteTrackPublication, participant: RemoteParticipant) {
         if (track.source === Track.Source.Microphone) {
             const stream = new MediaStream([track.mediaStreamTrack]);
-            this.emit(CALL_EVENT.REMOTE_VOICE_STREAM, stream, participant.sid);
+            this.emit(CALL_EVENT.REMOTE_VOICE_STREAM, stream, participant.identity);
 
-            logDebug(`CallClient: subscribed to remote track from ${participant.identity}`);
+            logDebug(`CallClient: subscribed to remote track from ${userIDFromMetadata(participant)}`);
         }
     }
 
@@ -534,9 +516,9 @@ export default class CallClient extends EventEmitter {
      */
     private handleLocalTrackPublished(localTrackPublication: LocalTrackPublication, localParticipant: LocalParticipant) {
         if (localTrackPublication.source === Track.Source.Microphone) {
-            this.emit(localTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, this.sessionIDForParticipant(localParticipant), localParticipant.identity);
+            this.emit(localTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, localParticipant.identity, userIDFromMetadata(localParticipant));
 
-            logDebug(`CallClient: local track published from ${localParticipant.identity}`, localTrackPublication);
+            logDebug(`CallClient: local track published from ${userIDFromMetadata(localParticipant)}`, localTrackPublication);
         }
     }
 
@@ -546,9 +528,9 @@ export default class CallClient extends EventEmitter {
      */
     private handleLocalTrackUnpublished(localTrackPublication: LocalTrackPublication, localParticipant: LocalParticipant) {
         if (localTrackPublication.source === Track.Source.Microphone) {
-            this.emit(CALL_EVENT.MUTE, this.sessionIDForParticipant(localParticipant), localParticipant.identity);
+            this.emit(CALL_EVENT.MUTE, localParticipant.identity, userIDFromMetadata(localParticipant));
 
-            logDebug(`CallClient: local track unpublished from ${localParticipant.identity}`, localTrackPublication);
+            logDebug(`CallClient: local track unpublished from ${userIDFromMetadata(localParticipant)}`, localTrackPublication);
         }
     }
 
@@ -558,9 +540,9 @@ export default class CallClient extends EventEmitter {
      */
     private handleTrackPublished(remoteTrackPublication: RemoteTrackPublication, remoteParticipant: RemoteParticipant) {
         if (remoteTrackPublication.source === Track.Source.Microphone) {
-            this.emit(remoteTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, remoteParticipant.sid, remoteParticipant.identity);
+            this.emit(remoteTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
 
-            logDebug(`CallClient: remote track published from ${remoteParticipant.identity}`, remoteTrackPublication);
+            logDebug(`CallClient: remote track published from ${userIDFromMetadata(remoteParticipant)}`, remoteTrackPublication);
         }
     }
 
@@ -570,9 +552,9 @@ export default class CallClient extends EventEmitter {
      */
     private handleTrackUnpublished(remoteTrackPublication: RemoteTrackPublication, remoteParticipant: RemoteParticipant) {
         if (remoteTrackPublication.source === Track.Source.Microphone) {
-            this.emit(CALL_EVENT.MUTE, remoteParticipant.sid, remoteParticipant.identity);
+            this.emit(CALL_EVENT.MUTE, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
 
-            logDebug(`CallClient: remote track unpublished from ${remoteParticipant.identity}`, remoteTrackPublication);
+            logDebug(`CallClient: remote track unpublished from ${userIDFromMetadata(remoteParticipant)}`, remoteTrackPublication);
         }
     }
 
@@ -582,9 +564,9 @@ export default class CallClient extends EventEmitter {
      */
     private handleTrackMuted(trackPublication: TrackPublication, participant: Participant) {
         if (trackPublication.source === Track.Source.Microphone) {
-            this.emit(CALL_EVENT.MUTE, this.sessionIDForParticipant(participant), participant.identity);
+            this.emit(CALL_EVENT.MUTE, participant.identity, userIDFromMetadata(participant));
 
-            logDebug(`CallClient: track muted from ${participant.identity}`, trackPublication);
+            logDebug(`CallClient: track muted from ${userIDFromMetadata(participant)}`, trackPublication);
         }
     }
 
@@ -594,9 +576,9 @@ export default class CallClient extends EventEmitter {
      */
     private handleTrackUnmuted(trackPublication: TrackPublication, participant: Participant) {
         if (trackPublication.source === Track.Source.Microphone) {
-            this.emit(CALL_EVENT.UNMUTE, this.sessionIDForParticipant(participant), participant.identity);
+            this.emit(CALL_EVENT.UNMUTE, participant.identity, userIDFromMetadata(participant));
 
-            logDebug(`CallClient: track unmuted from ${participant.identity}`, trackPublication);
+            logDebug(`CallClient: track unmuted from ${userIDFromMetadata(participant)}`, trackPublication);
         }
     }
 
@@ -605,9 +587,9 @@ export default class CallClient extends EventEmitter {
      * Emits USER_JOINED so the dispatcher can populate Redux + play the join sound.
      */
     private handleParticipantConnected(remoteParticipant: RemoteParticipant) {
-        this.emit(CALL_EVENT.USER_JOINED, remoteParticipant.sid, remoteParticipant.identity);
+        this.emit(CALL_EVENT.USER_JOINED, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
 
-        logDebug(`CallClient: participant connected ${remoteParticipant.identity}`);
+        logDebug(`CallClient: participant connected ${userIDFromMetadata(remoteParticipant)}`);
     }
 
     /**
@@ -615,9 +597,9 @@ export default class CallClient extends EventEmitter {
      * Emits USER_LEFT so the dispatcher can drop the session from Redux.
      */
     private handleParticipantDisconnected(remoteParticipant: RemoteParticipant) {
-        this.emit(CALL_EVENT.USER_LEFT, remoteParticipant.sid, remoteParticipant.identity);
+        this.emit(CALL_EVENT.USER_LEFT, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
 
-        logDebug(`CallClient: participant disconnected ${remoteParticipant.identity}`);
+        logDebug(`CallClient: participant disconnected ${userIDFromMetadata(remoteParticipant)}`);
     }
 
     private handleMediaDevicesError(err: Error) {
@@ -637,8 +619,8 @@ export default class CallClient extends EventEmitter {
         // This is fine as data structure but if we ever want to have audio
         // level then it would be better to have a tuple of [user_id, session_id, audio_level]
         for (const participant of participants) {
-            user_ids.push(participant.identity);
-            session_ids.push(this.sessionIDForParticipant(participant));
+            user_ids.push(userIDFromMetadata(participant));
+            session_ids.push(participant.identity);
         }
 
         this.emit(

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -46,16 +46,21 @@ export async function fetchRtcToken(channelID: string, sessionID: string): Promi
     return RestClient.fetch<RtcTokenResponse>(url, {method: 'GET'});
 }
 
-// LiveKit identity is the plugin-WS session_id; userID rides in metadata.
-function userIDFromMetadata(p: Participant): string {
-    if (!p.metadata) {
-        return '';
+// MM-user identity is "userID___sessionID" — both halves are sealed by the
+// LiveKit token signature, so neither can be tampered with post-connect.
+// Guest/SIP participants use "guest:" / "sip:" prefixes (no "___"); for those
+// userID is empty and the whole identity is used as the session key.
+const MM_IDENTITY_SEP = '___';
+
+function parseIdentity(p: Participant): {userID: string; sessionID: string} {
+    const idx = p.identity.indexOf(MM_IDENTITY_SEP);
+    if (idx < 0) {
+        return {userID: '', sessionID: p.identity};
     }
-    try {
-        return JSON.parse(p.metadata).user_id ?? '';
-    } catch {
-        return '';
-    }
+    return {
+        userID: p.identity.slice(0, idx),
+        sessionID: p.identity.slice(idx + MM_IDENTITY_SEP.length),
+    };
 }
 
 export default class CallClient extends EventEmitter {
@@ -362,7 +367,10 @@ export default class CallClient extends EventEmitter {
     }
 
     public getSessionID() {
-        return this.room?.localParticipant?.identity ?? null;
+        if (!this.room?.localParticipant) {
+            return null;
+        }
+        return parseIdentity(this.room.localParticipant).sessionID;
     }
 
     private handleWebsocketOpened(originalConnID: string, prevConnID: string, isReconnect: boolean) {
@@ -434,16 +442,18 @@ export default class CallClient extends EventEmitter {
 
         // Seed the initial state for everyone already in the room (local + remote).
         const localParticipant = this.room.localParticipant;
-        this.emit(CALL_EVENT.USER_JOINED, localParticipant.identity, userIDFromMetadata(localParticipant), true);
+        const local = parseIdentity(localParticipant);
+        this.emit(CALL_EVENT.USER_JOINED, local.sessionID, local.userID, true);
 
         const isLocalMicMuted = localParticipant.getTrackPublication(Track.Source.Microphone)?.isMuted ?? true;
-        this.emit(isLocalMicMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, localParticipant.identity, userIDFromMetadata(localParticipant));
+        this.emit(isLocalMicMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, local.sessionID, local.userID);
 
         for (const remoteParticipant of this.room.remoteParticipants.values()) {
-            this.emit(CALL_EVENT.USER_JOINED, remoteParticipant.identity, userIDFromMetadata(remoteParticipant), true);
+            const remote = parseIdentity(remoteParticipant);
+            this.emit(CALL_EVENT.USER_JOINED, remote.sessionID, remote.userID, true);
 
             const isRemoteMicMuted = remoteParticipant.getTrackPublication(Track.Source.Microphone)?.isMuted ?? true;
-            this.emit(isRemoteMicMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
+            this.emit(isRemoteMicMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, remote.sessionID, remote.userID);
         }
 
         this.emit(CALL_EVENT.CONNECTED);
@@ -504,9 +514,10 @@ export default class CallClient extends EventEmitter {
     private handleTrackSubscribed(track: RemoteTrack, _pub: RemoteTrackPublication, participant: RemoteParticipant) {
         if (track.source === Track.Source.Microphone) {
             const stream = new MediaStream([track.mediaStreamTrack]);
-            this.emit(CALL_EVENT.REMOTE_VOICE_STREAM, stream, participant.identity);
+            const {sessionID, userID} = parseIdentity(participant);
+            this.emit(CALL_EVENT.REMOTE_VOICE_STREAM, stream, sessionID);
 
-            logDebug(`CallClient: subscribed to remote track from ${userIDFromMetadata(participant)}`);
+            logDebug(`CallClient: subscribed to remote track from ${userID}`);
         }
     }
 
@@ -516,9 +527,10 @@ export default class CallClient extends EventEmitter {
      */
     private handleLocalTrackPublished(localTrackPublication: LocalTrackPublication, localParticipant: LocalParticipant) {
         if (localTrackPublication.source === Track.Source.Microphone) {
-            this.emit(localTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, localParticipant.identity, userIDFromMetadata(localParticipant));
+            const {sessionID, userID} = parseIdentity(localParticipant);
+            this.emit(localTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, sessionID, userID);
 
-            logDebug(`CallClient: local track published from ${userIDFromMetadata(localParticipant)}`, localTrackPublication);
+            logDebug(`CallClient: local track published from ${userID}`, localTrackPublication);
         }
     }
 
@@ -528,9 +540,10 @@ export default class CallClient extends EventEmitter {
      */
     private handleLocalTrackUnpublished(localTrackPublication: LocalTrackPublication, localParticipant: LocalParticipant) {
         if (localTrackPublication.source === Track.Source.Microphone) {
-            this.emit(CALL_EVENT.MUTE, localParticipant.identity, userIDFromMetadata(localParticipant));
+            const {sessionID, userID} = parseIdentity(localParticipant);
+            this.emit(CALL_EVENT.MUTE, sessionID, userID);
 
-            logDebug(`CallClient: local track unpublished from ${userIDFromMetadata(localParticipant)}`, localTrackPublication);
+            logDebug(`CallClient: local track unpublished from ${userID}`, localTrackPublication);
         }
     }
 
@@ -540,9 +553,10 @@ export default class CallClient extends EventEmitter {
      */
     private handleTrackPublished(remoteTrackPublication: RemoteTrackPublication, remoteParticipant: RemoteParticipant) {
         if (remoteTrackPublication.source === Track.Source.Microphone) {
-            this.emit(remoteTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
+            const {sessionID, userID} = parseIdentity(remoteParticipant);
+            this.emit(remoteTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, sessionID, userID);
 
-            logDebug(`CallClient: remote track published from ${userIDFromMetadata(remoteParticipant)}`, remoteTrackPublication);
+            logDebug(`CallClient: remote track published from ${userID}`, remoteTrackPublication);
         }
     }
 
@@ -552,9 +566,10 @@ export default class CallClient extends EventEmitter {
      */
     private handleTrackUnpublished(remoteTrackPublication: RemoteTrackPublication, remoteParticipant: RemoteParticipant) {
         if (remoteTrackPublication.source === Track.Source.Microphone) {
-            this.emit(CALL_EVENT.MUTE, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
+            const {sessionID, userID} = parseIdentity(remoteParticipant);
+            this.emit(CALL_EVENT.MUTE, sessionID, userID);
 
-            logDebug(`CallClient: remote track unpublished from ${userIDFromMetadata(remoteParticipant)}`, remoteTrackPublication);
+            logDebug(`CallClient: remote track unpublished from ${userID}`, remoteTrackPublication);
         }
     }
 
@@ -564,9 +579,10 @@ export default class CallClient extends EventEmitter {
      */
     private handleTrackMuted(trackPublication: TrackPublication, participant: Participant) {
         if (trackPublication.source === Track.Source.Microphone) {
-            this.emit(CALL_EVENT.MUTE, participant.identity, userIDFromMetadata(participant));
+            const {sessionID, userID} = parseIdentity(participant);
+            this.emit(CALL_EVENT.MUTE, sessionID, userID);
 
-            logDebug(`CallClient: track muted from ${userIDFromMetadata(participant)}`, trackPublication);
+            logDebug(`CallClient: track muted from ${userID}`, trackPublication);
         }
     }
 
@@ -576,9 +592,10 @@ export default class CallClient extends EventEmitter {
      */
     private handleTrackUnmuted(trackPublication: TrackPublication, participant: Participant) {
         if (trackPublication.source === Track.Source.Microphone) {
-            this.emit(CALL_EVENT.UNMUTE, participant.identity, userIDFromMetadata(participant));
+            const {sessionID, userID} = parseIdentity(participant);
+            this.emit(CALL_EVENT.UNMUTE, sessionID, userID);
 
-            logDebug(`CallClient: track unmuted from ${userIDFromMetadata(participant)}`, trackPublication);
+            logDebug(`CallClient: track unmuted from ${userID}`, trackPublication);
         }
     }
 
@@ -587,9 +604,10 @@ export default class CallClient extends EventEmitter {
      * Emits USER_JOINED so the dispatcher can populate Redux + play the join sound.
      */
     private handleParticipantConnected(remoteParticipant: RemoteParticipant) {
-        this.emit(CALL_EVENT.USER_JOINED, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
+        const {sessionID, userID} = parseIdentity(remoteParticipant);
+        this.emit(CALL_EVENT.USER_JOINED, sessionID, userID);
 
-        logDebug(`CallClient: participant connected ${userIDFromMetadata(remoteParticipant)}`);
+        logDebug(`CallClient: participant connected ${userID}`);
     }
 
     /**
@@ -597,9 +615,10 @@ export default class CallClient extends EventEmitter {
      * Emits USER_LEFT so the dispatcher can drop the session from Redux.
      */
     private handleParticipantDisconnected(remoteParticipant: RemoteParticipant) {
-        this.emit(CALL_EVENT.USER_LEFT, remoteParticipant.identity, userIDFromMetadata(remoteParticipant));
+        const {sessionID, userID} = parseIdentity(remoteParticipant);
+        this.emit(CALL_EVENT.USER_LEFT, sessionID, userID);
 
-        logDebug(`CallClient: participant disconnected ${userIDFromMetadata(remoteParticipant)}`);
+        logDebug(`CallClient: participant disconnected ${userID}`);
     }
 
     private handleMediaDevicesError(err: Error) {
@@ -619,8 +638,9 @@ export default class CallClient extends EventEmitter {
         // This is fine as data structure but if we ever want to have audio
         // level then it would be better to have a tuple of [user_id, session_id, audio_level]
         for (const participant of participants) {
-            user_ids.push(userIDFromMetadata(participant));
-            session_ids.push(participant.identity);
+            const {sessionID, userID} = parseIdentity(participant);
+            user_ids.push(userID);
+            session_ids.push(sessionID);
         }
 
         this.emit(


### PR DESCRIPTION
## Summary

Stacks on #1174. Server now issues LiveKit tokens with `Identity = plugin-WS session_id` (originalConnID) and `metadata.user_id = userID`, instead of `Identity = userID`. This:

- Removes the local-vs-remote session_id asymmetry #1174 introduced (`sessionIDForParticipant`, `getSessionID` fallback) — session_id is now a single canonical value across plugin-WS broadcasts and LiveKit events.
- Lets one Mattermost user hold multiple sessions in a call (LiveKit identity uniqueness no longer kicks duplicates).
- Fixes remote-participant VAD: active-speaker session_ids (LK identity) now match reducer-state keys.

## Server

`GET /livekit-token` now requires `session_id` and rejects it (403) unless the session exists in `p.sessions` and belongs to the requesting user — without this, a client could mint a token claiming any session_id. Validation uses the existing `getSessionByOriginalID` helper so a WS reconnect mid-call still works.

## Client

`fetchRtcToken` passes `session_id` from the connID returned by `websocketClient.ready()`. Removed the temporary workarounds in `call_client.ts`; `getSessionID()` returns `localParticipant.identity` and a new `userIDFromMetadata()` helper parses `participant.metadata`.

## Notes

- Targets #1174's branch; squash-merging this PR will fold both changes into that PR's diff.
- SIP webhook path (`handleLiveKitParticipantJoined`) is unaffected — SIP participants have no plugin-WS session and continue using `participant.Sid` as session_id.

## Test plan

- [x] Server: `TestHandleGetLiveKitToken` covers missing session_id, not-found, owned-by-different-user, reconnect (originalConnID match), success (identity == sessionID, metadata.user_id == userID).
- [x] Webapp: full jest suite passes (315/315); call_client tests updated to flow new (identity, user_id-from-metadata) pairs through every emit.
- [ ] Manual: start a call from two tabs as the same user — both sessions should stay connected (no LiveKit identity-collision kick).
- [ ] Manual: confirm remote-participant voice activity indicator lights up.