### PR TITLE
[MM-68757] Add make targets for single-platform plugin bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,26 @@ else
 dist: apply server webapp standalone bundle
 endif
 
+## Builds a single-platform "linux-amd64" bundle.
+.PHONY: dist-linux-amd64
+dist-linux-amd64:
+	./build/build-platform-bundle.sh linux-amd64
+
+## Builds a single-platform "linux-arm64" bundle.
+.PHONY: dist-linux-arm64
+dist-linux-arm64:
+	./build/build-platform-bundle.sh linux-arm64
+
+## Builds a single-platform "freebsd-amd64" bundle.
+.PHONY: dist-freebsd-amd64
+dist-freebsd-amd64:
+	./build/build-platform-bundle.sh freebsd-amd64
+
+## Builds a single-platform "openbsd-amd64" bundle.
+.PHONY: dist-openbsd-amd64
+dist-openbsd-amd64:
+	./build/build-platform-bundle.sh openbsd-amd64
+
 ## Builds and installs the plugin to a server.
 .PHONY: deploy
 deploy: dist

--- a/build/build-platform-bundle.sh
+++ b/build/build-platform-bundle.sh
@@ -62,15 +62,13 @@ done
 echo "Trimming staged plugin.json executables map..."
 tmp=$(mktemp)
 jq --arg platform "$PLATFORM" --arg path "server/dist/${BINARY}" \
-    '.server = {executables: {($platform): $path}, executable: ""}' \
+    '.server.executables = {($platform): $path} | .server.executable = ""' \
     "$MANIFEST" > "$tmp"
 mv "$tmp" "$MANIFEST"
 
 VERSION=$(jq -r '.version' "$MANIFEST")
 BUNDLE_NAME="com.mattermost.calls-${VERSION/+/-}-${PLATFORM}-slim.tar.gz"
 BUNDLE="$DIST_DIR/$BUNDLE_NAME"
-
-rm -f "$DIST_DIR"/com.mattermost.calls-*-slim.tar.gz
 
 echo "Repackaging as ${BUNDLE_NAME}..."
 cd "$DIST_DIR"

--- a/build/build-platform-bundle.sh
+++ b/build/build-platform-bundle.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Build a lightweight plugin bundle for Mattermost Cloud instance.
+#
+# Invoked via Make: `make dist-linux-amd64` (or any of the dist-<platform>
+# targets). The Make target is the canonical entry point.
+# Direct invocation also works: `./build/build-platform-bundle.sh <platform>`
+# Supported platforms: linux-amd64, linux-arm64, freebsd-amd64, openbsd-amd64.
+
+set -euo pipefail
+shopt -s nullglob
+
+if [[ $# -lt 1 ]]; then
+    echo "error: platform argument is required" >&2
+    echo "Usage: $0 <platform>" >&2
+    echo "  platform: linux-amd64, linux-arm64, freebsd-amd64, openbsd-amd64" >&2
+    exit 1
+fi
+
+PLATFORM="$1"
+
+case "$PLATFORM" in
+    linux-amd64|linux-arm64|freebsd-amd64|openbsd-amd64) ;;
+    -h|--help)
+        echo "Usage: $0 <platform>"
+        echo "  platform: linux-amd64, linux-arm64, freebsd-amd64, openbsd-amd64"
+        exit 0
+        ;;
+    *)
+        echo "error: unsupported platform '$PLATFORM'" >&2
+        echo "supported: linux-amd64, linux-arm64, freebsd-amd64, openbsd-amd64" >&2
+        exit 1
+        ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v jq >/dev/null; then
+    echo "error: jq is required" >&2
+    exit 1
+fi
+
+# Ensure the dev-mode branch (host-only build) is not active.
+unset MM_SERVICESETTINGS_ENABLEDEVELOPER
+
+echo "Running make dist"
+make dist
+
+DIST_DIR="$REPO_ROOT/dist"
+PLUGIN_DIR="$DIST_DIR/com.mattermost.calls"
+SERVER_DIST="$PLUGIN_DIR/server/dist"
+MANIFEST="$PLUGIN_DIR/plugin.json"
+BINARY="plugin-${PLATFORM}"
+
+echo "Pruning server binaries to ${PLATFORM} only..."
+for f in "$SERVER_DIST"/plugin-*; do
+    [[ "$(basename "$f")" == "$BINARY" ]] && continue
+    rm "$f"
+done
+
+echo "Trimming staged plugin.json executables map..."
+tmp=$(mktemp)
+jq --arg platform "$PLATFORM" --arg path "server/dist/${BINARY}" \
+    '.server = {executables: {($platform): $path}, executable: ""}' \
+    "$MANIFEST" > "$tmp"
+mv "$tmp" "$MANIFEST"
+
+VERSION=$(jq -r '.version' "$MANIFEST")
+BUNDLE_NAME="com.mattermost.calls-${VERSION/+/-}-${PLATFORM}-slim.tar.gz"
+BUNDLE="$DIST_DIR/$BUNDLE_NAME"
+
+rm -f "$DIST_DIR"/com.mattermost.calls-*-slim.tar.gz
+
+echo "Repackaging as ${BUNDLE_NAME}..."
+cd "$DIST_DIR"
+if [[ "$(uname)" == "Darwin" ]]; then
+    tar --disable-copyfile -czf "$BUNDLE_NAME" com.mattermost.calls/
+else
+    tar -czf "$BUNDLE_NAME" com.mattermost.calls/
+fi
+
+BUNDLE_SIZE=$(ls -lh "$BUNDLE" | awk '{print $5}')
+ORIGINAL_BUNDLE="$DIST_DIR/com.mattermost.calls-${VERSION}.tar.gz"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    BUNDLE_CREATED=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M:%S" "$BUNDLE")
+    stat_bytes() { stat -f%z "$1"; }
+else
+    BUNDLE_CREATED=$(stat -c "%y" "$BUNDLE" | cut -d'.' -f1)
+    stat_bytes() { stat -c%s "$1"; }
+fi
+
+if [[ -f "$ORIGINAL_BUNDLE" ]]; then
+    ORIGINAL_SIZE=$(ls -lh "$ORIGINAL_BUNDLE" | awk '{print $5}')
+    slim_bytes=$(stat_bytes "$BUNDLE")
+    orig_bytes=$(stat_bytes "$ORIGINAL_BUNDLE")
+    reduction_pct=$(( 100 - (slim_bytes * 100 / orig_bytes) ))
+    SIZE_LINE="$BUNDLE_SIZE  (-${reduction_pct}%)"
+    FULL_LINE="$ORIGINAL_SIZE (multi-arch)"
+else
+    SIZE_LINE="$BUNDLE_SIZE"
+    FULL_LINE="(not found)"
+fi
+
+echo
+echo "=========================================="
+echo "Bundle:       $BUNDLE_NAME"
+echo "Path:         $BUNDLE"
+echo "Size:         $SIZE_LINE"
+echo "Full Bundle:  $FULL_LINE"
+echo "Platform:     $PLATFORM"
+echo "Created:      $BUNDLE_CREATED"
+echo "=========================================="

--- a/build/build-platform-bundle.sh
+++ b/build/build-platform-bundle.sh
@@ -52,6 +52,13 @@ PLUGIN_DIR="$DIST_DIR/com.mattermost.calls"
 SERVER_DIST="$PLUGIN_DIR/server/dist"
 MANIFEST="$PLUGIN_DIR/plugin.json"
 BINARY="plugin-${PLATFORM}"
+TARGET_BINARY="$SERVER_DIST/$BINARY"
+
+if [[ ! -f "$TARGET_BINARY" ]]; then
+    echo "error: expected binary not found: $TARGET_BINARY" >&2
+    echo "  (Makefile may be out of sync with this script's supported platforms)" >&2
+    exit 1
+fi
 
 echo "Pruning server binaries to ${PLATFORM} only..."
 for f in "$SERVER_DIST"/plugin-*; do


### PR DESCRIPTION
#### Summary
This pull request introduces support for building lightweight, single-platform plugin bundles for several operating systems and architectures. The main changes add new Makefile targets and a build script that creates "slim" plugin bundles containing only the relevant server binary and a trimmed manifest for each target platform.

  make dist-linux-amd64
  make dist-linux-arm64
  make dist-freebsd-amd64
  make dist-openbsd-amd64

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-68757


#### Screenshots
<img width="1748" height="410" alt="CleanShot 2026-05-13 at 7  13 09@2x" src="https://github.com/user-attachments/assets/2cceea17-98fe-4245-b948-cfa1dafab350" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the Schema Migration Template as a starting point to capture these details as release notes.
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.

Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.

NONE
-->
```release-note

```
