### PR TITLE
[MM-68778] Persist Props on screen on/off toggle

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -200,8 +200,12 @@ func (p *Plugin) handleClientMessageTypeScreen(us *session, msg clientMessage, h
 		}
 	}
 
-	// Note: Screen sharing stats are persisted when users leave or call ends,
-	// no need to write to DB on every toggle for performance.
+	// Props.ScreenSharingSessionID and ScreenStartAt must be persisted on every
+	// toggle: getCallState reloads from the DB on each handler invocation, so
+	// without this write the next screen_on/screen_off would see stale state.
+	if err := p.store.UpdateCall(&state.Call); err != nil {
+		return fmt.Errorf("failed to update call: %w", err)
+	}
 
 	msgType := rtc.ScreenOnMessage
 	wsMsgType := wsEventUserScreenOn


### PR DESCRIPTION
## Summary

`handleClientMessageTypeScreen` mutates `state.Call.Props.ScreenSharingSessionID` (and `ScreenStartAt`) in memory but no longer wrote them to the store after `d5fedc36` ("Add video statistics and metrics"). Because `lockCallReturnState` → `getCallState` reloads call state from the DB on every handler invocation, the next `screen_on`/`screen_off` saw stale `""` and rejected the stop with `cannot stop screen sharing, someone else is sharing already: connID=`. That also suppressed the `user_screen_off` broadcast, so neither the sharer's UI nor other viewers' egress tracks were cleaned up until the sharer disconnected.

The "screen sharing stats are persisted at call end" comment introduced with that commit was based on a misread: `ScreenSharingSessionID` and `ScreenStartAt` are call **state**, not stats — they have to be written on every toggle.

## Test plan

- [x] Smoke test on local dev: 1:1 DM in Chrome (chris) + Safari (jon). Jon starts share, then clicks Stop. Verify single click stops the share, `user_screen_off` is broadcast, and chris's screen track is cleaned up promptly (rather than after sharer disconnect).
- [x] Repeat in a regular channel call (Town Square): share starts and stops cleanly for both widget and popout viewers.
- [x] `make server` and `go test ./server` pass.

## Refs

- Jira: MM-68778
- Regression introduced by: #1125 (`d5fedc36`)