### PR TITLE
[MM-68563] Replace RTCMonitor with LiveKit ConnectionQuality

### DIFF
--- a/livekit.yaml
+++ b/livekit.yaml
@@ -6,6 +6,6 @@ rtc:
   udp_port: 7882
   use_ice_lite: true
 keys:
-  devkey: secret
+  devkey: this-is-a-32-plus-character-dev-secret
 logging:
   level: info

--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Room, RoomEvent, Track} from 'livekit-client';
+import {ConnectionQuality, Room, RoomEvent, Track} from 'livekit-client';
 import RestClient from 'src/clients/rest';
 import {WebSocketClient} from 'src/clients/websocket';
 import {WEBSOCKET_EVENT} from 'src/clients/websocket/constants';
@@ -556,6 +556,28 @@ describe('CallClient', () => {
             mockRoom.fire(RoomEvent.ActiveSpeakersChanged, []);
 
             expect(listener).toHaveBeenCalledWith([], []);
+        });
+    });
+
+    describe('ConnectionQualityChanged', () => {
+        it('emits QUALITY_CHANGED for the local participant', async () => {
+            await client.connect({channelID: 'test-channel'});
+            const listener = jest.fn();
+            client.on(CALL_EVENT.QUALITY_CHANGED, listener);
+
+            mockRoom.fire(RoomEvent.ConnectionQualityChanged, ConnectionQuality.Poor, mockRoom.localParticipant);
+
+            expect(listener).toHaveBeenCalledWith(ConnectionQuality.Poor);
+        });
+
+        it('ignores quality updates for remote participants', async () => {
+            await client.connect({channelID: 'test-channel'});
+            const listener = jest.fn();
+            client.on(CALL_EVENT.QUALITY_CHANGED, listener);
+
+            mockRoom.fire(RoomEvent.ConnectionQualityChanged, ConnectionQuality.Poor, {sid: 'r1-sid', identity: 'r1___r1-session'});
+
+            expect(listener).not.toHaveBeenCalled();
         });
     });
 

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -7,6 +7,7 @@ import type {EmojiData} from '@mattermost/calls-common/lib/types';
 import {ClientConfig} from '@mattermost/types/config';
 import {EventEmitter} from 'events';
 import {
+    ConnectionQuality,
     ConnectionState,
     DisconnectReason,
     LocalParticipant,
@@ -88,6 +89,7 @@ export default class CallClient extends EventEmitter {
         room.on(RoomEvent.MediaDevicesError, this.handleMediaDevicesError.bind(this));
         room.on(RoomEvent.ActiveSpeakersChanged, this.handleActiveSpeakersChanged.bind(this));
         room.on(RoomEvent.MediaDevicesChanged, this.handleMediaDevicesChanged.bind(this));
+        room.on(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged.bind(this));
     }
 
     public async connect(connectPayload: ConnectPayload): Promise<void> {
@@ -620,6 +622,19 @@ export default class CallClient extends EventEmitter {
         this.emit(CALL_EVENT.USER_LEFT, sessionID, userID);
 
         logDebug(`CallClient: participant disconnected ${userID}`);
+    }
+
+    /**
+     * Fires when LiveKit publishes a new ConnectionQuality value for any participant.
+     * We only surface the local participant's quality — the SFU's view of our own
+     * uplink/downlink path is what drives the "call quality degraded" banner.
+     */
+    private handleConnectionQualityChanged(quality: ConnectionQuality, participant: Participant) {
+        if (!this.room || participant !== this.room.localParticipant) {
+            return;
+        }
+
+        this.emit(CALL_EVENT.QUALITY_CHANGED, quality);
     }
 
     private handleMediaDevicesError(err: Error) {

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -624,19 +624,6 @@ export default class CallClient extends EventEmitter {
         logDebug(`CallClient: participant disconnected ${userID}`);
     }
 
-    /**
-     * Fires when LiveKit publishes a new ConnectionQuality value for any participant.
-     * We only surface the local participant's quality — the SFU's view of our own
-     * uplink/downlink path is what drives the "call quality degraded" banner.
-     */
-    private handleConnectionQualityChanged(quality: ConnectionQuality, participant: Participant) {
-        if (!this.room || participant !== this.room.localParticipant) {
-            return;
-        }
-
-        this.emit(CALL_EVENT.QUALITY_CHANGED, quality);
-    }
-
     private handleMediaDevicesError(err: Error) {
         logErr('CallClient: media device error', err);
         this.emit(CALL_EVENT.ERROR, err);
@@ -697,6 +684,16 @@ export default class CallClient extends EventEmitter {
         }
 
         this.emit(CALL_EVENT.DEVICE_CHANGE, this.audioDevices, []);
+    }
+
+    /**
+     * Fires when LiveKit publishes a new ConnectionQuality value for any participant.
+     * We only surface the local participant's quality and not the remote participants' quality.
+     */
+    private handleConnectionQualityChanged(quality: ConnectionQuality, participant: Participant) {
+        if (this.room && this.room.localParticipant === participant) {
+            this.emit(CALL_EVENT.QUALITY_CHANGED, quality);
+        }
     }
 
     private async enumerateDevices(): Promise<MediaDevices> {

--- a/webapp/src/clients/call/constants.ts
+++ b/webapp/src/clients/call/constants.ts
@@ -17,6 +17,7 @@ export const CALL_EVENT = {
     USER_LEFT: 'userLeft',
     DEVICE_CHANGE: 'devicechange',
     DEVICE_FALLBACK: 'devicefallback',
+    QUALITY_CHANGED: 'qualityChanged',
 } as const;
 
 // Plugin call API routes

--- a/webapp/src/clients/call/constants.ts
+++ b/webapp/src/clients/call/constants.ts
@@ -1,7 +1,11 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// CallClient emitted public event names.
+import {ConnectionQuality} from 'livekit-client';
+
+/**
+ * CallClient emitted public event names.
+ */
 export const CALL_EVENT = {
     CONNECTED: 'connect',
     DISCONNECTED: 'close',
@@ -19,6 +23,8 @@ export const CALL_EVENT = {
     DEVICE_FALLBACK: 'devicefallback',
     QUALITY_CHANGED: 'qualityChanged',
 } as const;
+
+export {ConnectionQuality as CONNECTION_QUALITY};
 
 // Plugin call API routes
 export const CALL_TOKEN_API_PATH = 'livekit-token';

--- a/webapp/src/clients/calls/index.ts
+++ b/webapp/src/clients/calls/index.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable max-lines */
 
-import {parseRTCStats, RTCMonitor, RTCPeer} from '@mattermost/calls-common';
+import {parseRTCStats, RTCPeer} from '@mattermost/calls-common';
 import type {CallsClientJoinData, EmojiData, RTPEncodingParameters, TrackInfo} from '@mattermost/calls-common/lib/types';
 import {EventEmitter} from 'events';
 import {strToU8, zlibSync} from 'fflate';
@@ -44,8 +44,6 @@ export const DefaultVideoTrackOptions: MediaTrackConstraints = {
     },
 };
 
-const rtcMonitorInterval = 10000;
-
 export default class CallsClient extends EventEmitter {
     public channelID: string;
     private readonly config: CallsClientConfig;
@@ -71,7 +69,6 @@ export default class CallsClient extends EventEmitter {
     private closed = false;
     private connected = false;
     public initTime = Date.now();
-    private rtcMonitor: RTCMonitor | null = null;
     private av1Codec: Awaited<ReturnType<typeof RTCPeer.getVideoCodec>> = null;
     private defaultAudioTrackOptions: MediaTrackConstraints;
     private defaultVideoTrackOptions: MediaTrackConstraints;
@@ -532,18 +529,6 @@ export default class CallsClient extends EventEmitter {
 
             this.collectICEStats();
 
-            this.rtcMonitor = new RTCMonitor({
-                peer,
-                logger: {
-                    logDebug,
-                    logErr,
-                    logWarn,
-                    logInfo,
-                },
-                monitorInterval: rtcMonitorInterval,
-            });
-            this.rtcMonitor.on('mos', (mos: number) => this.emit('mos', mos));
-
             const sdpHandler = (sdp: RTCSessionDescription) => {
                 const payload = JSON.stringify(sdp);
 
@@ -620,7 +605,6 @@ export default class CallsClient extends EventEmitter {
                 logDebug('rtc connected');
 
                 this.emit('connect');
-                this.rtcMonitor?.start();
                 this.connected = true;
             });
 
@@ -670,7 +654,6 @@ export default class CallsClient extends EventEmitter {
         this.removeAllListeners('unmute');
         this.removeAllListeners('raise_hand');
         this.removeAllListeners('lower_hand');
-        this.removeAllListeners('mos');
         this.removeAllListeners('video_on');
         this.removeAllListeners('video_off');
         window.removeEventListener('beforeunload', this.onBeforeUnload);
@@ -833,8 +816,6 @@ export default class CallsClient extends EventEmitter {
             return;
         }
 
-        this.rtcMonitor?.stop();
-
         this.closed = true;
         if (this.peer) {
             this.getStats().then((stats) => {
@@ -898,14 +879,6 @@ export default class CallsClient extends EventEmitter {
                 return;
             }
         }
-
-        // NOTE: we purposely clear the monitor's stats cache upon unmuting
-        // in order to skip some calculations since upon muting we actually
-        // stop sending packets which would result in stats to be skewed as
-        // soon as we resume sending.
-        // This is not perfect but it avoids having to constantly send
-        // silence frames when muted.
-        this.rtcMonitor?.clearCache();
 
         if (this.audioTrack) {
             if (this.voiceTrackAdded) {
@@ -1098,14 +1071,6 @@ export default class CallsClient extends EventEmitter {
                 return null;
             }
         }
-
-        // NOTE: we purposely clear the monitor's stats cache upon starting video
-        // in order to skip some calculations since upon starting video we actually
-        // stop sending packets which would result in stats to be skewed as
-        // soon as we resume sending.
-        // This is not perfect but it avoids having to constantly send
-        // empty frames when the video is off.
-        this.rtcMonitor?.clearCache();
 
         if (!this.localVideoStream) {
             logWarn('no local video stream');

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -10,14 +10,13 @@ import {Channel} from '@mattermost/types/channels';
 import {Team} from '@mattermost/types/teams';
 import {UserProfile} from '@mattermost/types/users';
 import {IDMappedObjects} from '@mattermost/types/utilities';
-import {ConnectionQuality} from 'livekit-client';
 import {Client4} from 'mattermost-redux/client';
 import React, {CSSProperties, useEffect, useState} from 'react';
 import {FormattedMessage, IntlShape} from 'react-intl';
 import {compareSemVer} from 'semver-parser';
 import {hostRemove} from 'src/actions';
 import {navigateToURL} from 'src/browser_routing';
-import {CALL_EVENT} from 'src/clients/call/constants';
+import {CALL_EVENT, CONNECTION_QUALITY} from 'src/clients/call/constants';
 import {AudioInputPermissionsError, VideoInputPermissionsError} from 'src/clients/calls';
 import Avatar from 'src/components/avatar/avatar';
 import {Badge} from 'src/components/badge';
@@ -673,10 +672,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             });
         });
 
-        window.callsClient?.on(CALL_EVENT.QUALITY_CHANGED, (quality: ConnectionQuality) => {
-            const degraded = quality === ConnectionQuality.Poor || quality === ConnectionQuality.Lost;
-            const healthy = quality === ConnectionQuality.Excellent || quality === ConnectionQuality.Good;
-            if (!this.callQualityBannerLocked && !this.state.alerts.degradedCallQuality.show && degraded) {
+        window.callsClient?.on(CALL_EVENT.QUALITY_CHANGED, (quality: CONNECTION_QUALITY) => {
+            const isCallQualityDegraded = quality === CONNECTION_QUALITY.Poor || quality === CONNECTION_QUALITY.Lost;
+            const isCallQualityHealthy = quality === CONNECTION_QUALITY.Excellent || quality === CONNECTION_QUALITY.Good;
+
+            if (!this.callQualityBannerLocked && !this.state.alerts.degradedCallQuality.show && isCallQualityDegraded) {
                 this.setState({
                     alerts: {
                         ...this.state.alerts,
@@ -687,7 +687,8 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     },
                 });
             }
-            if (!this.callQualityBannerLocked && this.state.alerts.degradedCallQuality.show && healthy) {
+
+            if (!this.callQualityBannerLocked && this.state.alerts.degradedCallQuality.show && isCallQualityHealthy) {
                 this.setState({
                     alerts: {
                         ...this.state.alerts,

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -5,12 +5,12 @@
 
 import './component.scss';
 
-import {mosThreshold} from '@mattermost/calls-common';
 import {UserSessionState} from '@mattermost/calls-common/lib/types';
 import {Channel} from '@mattermost/types/channels';
 import {Team} from '@mattermost/types/teams';
 import {UserProfile} from '@mattermost/types/users';
 import {IDMappedObjects} from '@mattermost/types/utilities';
+import {ConnectionQuality} from 'livekit-client';
 import {Client4} from 'mattermost-redux/client';
 import React, {CSSProperties, useEffect, useState} from 'react';
 import {FormattedMessage, IntlShape} from 'react-intl';
@@ -673,8 +673,10 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             });
         });
 
-        window.callsClient?.on('mos', (mos: number) => {
-            if (!this.callQualityBannerLocked && !this.state.alerts.degradedCallQuality.show && mos < mosThreshold) {
+        window.callsClient?.on(CALL_EVENT.QUALITY_CHANGED, (quality: ConnectionQuality) => {
+            const degraded = quality === ConnectionQuality.Poor || quality === ConnectionQuality.Lost;
+            const healthy = quality === ConnectionQuality.Excellent || quality === ConnectionQuality.Good;
+            if (!this.callQualityBannerLocked && !this.state.alerts.degradedCallQuality.show && degraded) {
                 this.setState({
                     alerts: {
                         ...this.state.alerts,
@@ -685,7 +687,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     },
                 });
             }
-            if (!this.callQualityBannerLocked && this.state.alerts.degradedCallQuality.show && mos >= mosThreshold) {
+            if (!this.callQualityBannerLocked && this.state.alerts.degradedCallQuality.show && healthy) {
                 this.setState({
                     alerts: {
                         ...this.state.alerts,

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -9,7 +9,6 @@ import {Post} from '@mattermost/types/posts';
 import {Team} from '@mattermost/types/teams';
 import {UserProfile} from '@mattermost/types/users';
 import {IDMappedObjects} from '@mattermost/types/utilities';
-import {ConnectionQuality} from 'livekit-client';
 import {Client4} from 'mattermost-redux/client';
 import {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {MediaControlBar, MediaController, MediaFullscreenButton} from 'media-chrome/dist/react';
@@ -18,7 +17,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {IntlShape} from 'react-intl';
 import {RouteComponentProps} from 'react-router-dom';
 import {hostMuteOthers, hostRemove} from 'src/actions';
-import {CALL_EVENT} from 'src/clients/call/constants';
+import {CALL_EVENT, CONNECTION_QUALITY} from 'src/clients/call/constants';
 import {AudioInputPermissionsError, VideoInputPermissionsError} from 'src/clients/calls';
 import Avatar from 'src/components/avatar/avatar';
 import {Badge} from 'src/components/badge';
@@ -807,10 +806,11 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             }
         }
 
-        callsClient.on(CALL_EVENT.QUALITY_CHANGED, (quality: ConnectionQuality) => {
-            const degraded = quality === ConnectionQuality.Poor || quality === ConnectionQuality.Lost;
-            const healthy = quality === ConnectionQuality.Excellent || quality === ConnectionQuality.Good;
-            if (!this.callQualityBannerLocked && !this.state.alerts.degradedCallQuality.show && degraded) {
+        callsClient.on(CALL_EVENT.QUALITY_CHANGED, (quality: CONNECTION_QUALITY) => {
+            const isCallQualityDegraded = quality === CONNECTION_QUALITY.Poor || quality === CONNECTION_QUALITY.Lost;
+            const isCallQualityHealthy = quality === CONNECTION_QUALITY.Excellent || quality === CONNECTION_QUALITY.Good;
+
+            if (!this.callQualityBannerLocked && !this.state.alerts.degradedCallQuality.show && isCallQualityDegraded) {
                 this.setState({
                     alerts: {
                         ...this.state.alerts,
@@ -821,7 +821,8 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                     },
                 });
             }
-            if (!this.callQualityBannerLocked && this.state.alerts.degradedCallQuality.show && healthy) {
+
+            if (!this.callQualityBannerLocked && this.state.alerts.degradedCallQuality.show && isCallQualityHealthy) {
                 this.setState({
                     alerts: {
                         ...this.state.alerts,

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -3,13 +3,13 @@
 
 /* eslint-disable max-lines */
 
-import {mosThreshold} from '@mattermost/calls-common';
 import {UserSessionState} from '@mattermost/calls-common/lib/types';
 import {Channel} from '@mattermost/types/channels';
 import {Post} from '@mattermost/types/posts';
 import {Team} from '@mattermost/types/teams';
 import {UserProfile} from '@mattermost/types/users';
 import {IDMappedObjects} from '@mattermost/types/utilities';
+import {ConnectionQuality} from 'livekit-client';
 import {Client4} from 'mattermost-redux/client';
 import {Theme} from 'mattermost-redux/selectors/entities/preferences';
 import {MediaControlBar, MediaController, MediaFullscreenButton} from 'media-chrome/dist/react';
@@ -807,8 +807,10 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
             }
         }
 
-        callsClient.on('mos', (mos: number) => {
-            if (!this.callQualityBannerLocked && !this.state.alerts.degradedCallQuality.show && mos < mosThreshold) {
+        callsClient.on(CALL_EVENT.QUALITY_CHANGED, (quality: ConnectionQuality) => {
+            const degraded = quality === ConnectionQuality.Poor || quality === ConnectionQuality.Lost;
+            const healthy = quality === ConnectionQuality.Excellent || quality === ConnectionQuality.Good;
+            if (!this.callQualityBannerLocked && !this.state.alerts.degradedCallQuality.show && degraded) {
                 this.setState({
                     alerts: {
                         ...this.state.alerts,
@@ -819,7 +821,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                     },
                 });
             }
-            if (!this.callQualityBannerLocked && this.state.alerts.degradedCallQuality.show && mos >= mosThreshold) {
+            if (!this.callQualityBannerLocked && this.state.alerts.degradedCallQuality.show && healthy) {
                 this.setState({
                     alerts: {
                         ...this.state.alerts,


### PR DESCRIPTION
#### Summary
CallClient now subscribes to RoomEvent.ConnectionQualityChanged and emits a new CALL_EVENT.QUALITY_CHANGED for the local participant. The widget and expanded view consume that event in place of the v1 `mos` listener: Poor/Lost shows the degradedCallQuality banner, Excellent/Good clears it, Unknown is a no-op. Dismiss + lockout behavior is unchanged.

Drops the now-dead RTCMonitor wiring from the v1 CallsClient.

#### Note for reviewers
Semantic shift: v1's MOS estimated perceived audio quality client-side, so the banner only fired once degradation became audible. LiveKit's `ConnectionQuality` grades the network path, so the banner fires earlier — sometimes while Opus FEC is still keeping audio intelligible. This is intentional as an early warning.

#### Test plan
See the ticket for the local LAN + Network Link Conditioner test setup (attached `LiveKitLocalTlsDev.md`).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68563