### PR TITLE
[MM-68855] Calls widget 'Leave call' requires two clicks after closin…

### DIFF
--- a/standalone/src/init.ts
+++ b/standalone/src/init.ts
@@ -34,7 +34,7 @@ import {
 } from '@mattermost/calls-common/lib/types';
 import {hasDCSignalingLockSupport} from '@mattermost/calls-common/lib/utils';
 import {WebSocketMessage} from '@mattermost/client/websocket';
-import type {DesktopAPI} from '@mattermost/desktop-api';
+import {type DesktopAPI} from '@mattermost/desktop-api';
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {Client4} from 'mattermost-redux/client';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';

--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -355,7 +355,6 @@
       }
     ],
     "no-undef-init": 2,
-    "no-undefined": 2,
     "no-underscore-dangle": 2,
     "no-unexpected-multiline": 2,
     "no-unmodified-loop-condition": 2,

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -38,7 +38,7 @@
         "@babel/preset-typescript": "7.16.0",
         "@formatjs/cli": "5.0.7",
         "@mattermost/client": "file:mattermost-webapp/webapp/platform/client",
-        "@mattermost/desktop-api": "5.10.0-1",
+        "@mattermost/desktop-api": "6.2.0-1",
         "@mattermost/eslint-plugin": "1.1.0-0",
         "@mattermost/types": "file:mattermost-webapp/webapp/platform/types",
         "@testing-library/jest-dom": "6.9.1",
@@ -8043,10 +8043,11 @@
       "dev": true
     },
     "node_modules/@mattermost/desktop-api": {
-      "version": "5.10.0-1",
-      "resolved": "https://registry.npmjs.org/@mattermost/desktop-api/-/desktop-api-5.10.0-1.tgz",
-      "integrity": "sha512-e6+aMmw8Wc+sKAWkKI4qDbOLYfCetKgT7ddSJaIcBWssoMg6Tlv5iOu8GLUI1KI+AOpA58PsLFDnc09FTL6xSQ==",
+      "version": "6.2.0-1",
+      "resolved": "https://registry.npmjs.org/@mattermost/desktop-api/-/desktop-api-6.2.0-1.tgz",
+      "integrity": "sha512-/C6FXZMskBtCBDqnqwc78IeCtDaf2SsC5FjhDdO6dx57gbYsGjVWi+mBfWqxkZGwjMX4nS4Eh6jb9uFGnOTxag==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"
       },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-typescript": "7.16.0",
     "@formatjs/cli": "5.0.7",
     "@mattermost/client": "file:mattermost-webapp/webapp/platform/client",
-    "@mattermost/desktop-api": "5.10.0-1",
+    "@mattermost/desktop-api": "6.2.0-1",
     "@mattermost/eslint-plugin": "1.1.0-0",
     "@mattermost/types": "file:mattermost-webapp/webapp/platform/types",
     "@testing-library/jest-dom": "6.9.1",

--- a/webapp/src/components/call_widget/component.test.tsx
+++ b/webapp/src/components/call_widget/component.test.tsx
@@ -1,0 +1,176 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Channel} from '@mattermost/types/channels';
+import type {Team} from '@mattermost/types/teams';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import {createIntl, RawIntlProvider} from 'react-intl';
+import {Provider} from 'react-redux';
+import type CallsClient from 'src/client';
+import {mockStore} from 'src/testUtils';
+
+import CallWidget from './component';
+
+type Props = React.ComponentProps<typeof CallWidget>;
+
+jest.mock('src/components/leave_call_menu', () => ({
+    LeaveCallMenu: ({leaveCall}: {leaveCall: () => void}) => (
+        // eslint-disable-next-line formatjs/no-literal-string-in-jsx
+        <button onClick={leaveCall}>{'Leave call'}</button>
+    ),
+}));
+
+jest.mock('src/components/dot_menu/dot_menu', () => {
+    return {
+        __esModule: true,
+        default: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+        DotMenuButton: 'div',
+        DropdownMenu: 'div',
+        DropdownMenuItem: ({children, onClick}: {children: React.ReactNode; onClick?: () => void}) => (
+            <button onClick={onClick}>{children}</button>
+        ),
+        DropdownMenuSeparator: () => null,
+    };
+});
+
+const intl = createIntl({locale: 'en', messages: {}});
+
+const stubChannel = {
+    id: 'channel-id',
+    team_id: 'team-id',
+    name: 'town-square',
+    display_name: 'Town Square',
+    type: 'O',
+} as Channel;
+
+const stubTeam = {id: 'team-id', name: 'team', display_name: 'Team'} as Team;
+
+const props: Props = {
+    intl,
+    currentUserID: 'user-id',
+    channel: stubChannel,
+    team: stubTeam,
+    channelURL: '/town-square',
+    channelDisplayName: 'Town Square',
+    sessions: [],
+    otherSessions: [],
+    sessionsMap: {},
+    profiles: {},
+    callStartAt: Date.now() - 30_000,
+    callHostID: 'user-id',
+    callHostChangeAt: 0,
+    isRecording: false,
+    show: true,
+    showExpandedView: jest.fn(),
+    showScreenSourceModal: jest.fn(),
+    recordingPromptDismissedAt: jest.fn(),
+    allowScreenSharing: true,
+    recentlyJoinedUsers: [],
+    hostNotices: [],
+    wider: false,
+    callsIncoming: [],
+    transcriptionsEnabled: false,
+    clientConnecting: false,
+    selectRHSPost: jest.fn(),
+    startCallRecording: jest.fn(),
+    stopCallRecording: jest.fn(),
+    recordingsEnabled: false,
+    openModal: jest.fn(),
+    openCallsUserSettings: jest.fn(),
+    enableVideo: false,
+    connectedDMUser: undefined,
+};
+
+describe('CallWidget', () => {
+    let originalCallsClient: typeof window.callsClient;
+    let disconnect: jest.Mock;
+    let openSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        originalCallsClient = window.callsClient;
+        disconnect = jest.fn();
+        window.callsClient = {
+            disconnect,
+            channelID: 'channel-id',
+            getRemoteVoiceTracks: () => [],
+            getRemoteScreenStream: () => null,
+            getLocalScreenStream: () => null,
+            on: jest.fn(),
+            off: jest.fn(),
+        } as unknown as CallsClient;
+        openSpy = jest.spyOn(window, 'open');
+    });
+
+    afterEach(() => {
+        window.callsClient = originalCallsClient;
+        openSpy.mockRestore();
+    });
+
+    test('closes the popout and disconnects when the popout is still open', async () => {
+        const fakePopout = {
+            closed: false,
+            close: jest.fn(),
+            addEventListener: jest.fn(),
+        };
+        openSpy.mockReturnValue(fakePopout as unknown as Window);
+        const user = userEvent.setup();
+
+        render(
+            <Provider store={mockStore()}>
+                <RawIntlProvider value={intl}>
+                    <CallWidget {...props}/>
+                </RawIntlProvider>
+            </Provider>,
+        );
+
+        await user.click(screen.getByRole('button', {name: /open in new window/i}));
+        expect(openSpy).toHaveBeenCalled();
+
+        await user.click(screen.getByRole('button', {name: /^leave call$/i}));
+
+        expect(fakePopout.close).toHaveBeenCalledTimes(1);
+        expect(disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    test('disconnects without calling close when the popout is already closed', async () => {
+        const fakePopout = {
+            closed: true,
+            close: jest.fn(),
+            addEventListener: jest.fn(),
+        };
+        openSpy.mockReturnValue(fakePopout as unknown as Window);
+        const user = userEvent.setup();
+
+        render(
+            <Provider store={mockStore()}>
+                <RawIntlProvider value={intl}>
+                    <CallWidget {...props}/>
+                </RawIntlProvider>
+            </Provider>,
+        );
+
+        await user.click(screen.getByRole('button', {name: /open in new window/i}));
+        await user.click(screen.getByRole('button', {name: /^leave call$/i}));
+
+        expect(fakePopout.close).not.toHaveBeenCalled();
+        expect(disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    test('disconnects when no popout was ever opened', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <Provider store={mockStore()}>
+                <RawIntlProvider value={intl}>
+                    <CallWidget {...props}/>
+                </RawIntlProvider>
+            </Provider>,
+        );
+
+        await user.click(screen.getByRole('button', {name: /^leave call$/i}));
+
+        expect(disconnect).toHaveBeenCalledTimes(1);
+    });
+});

--- a/webapp/src/components/call_widget/component.test.tsx
+++ b/webapp/src/components/call_widget/component.test.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {createIntl, RawIntlProvider} from 'react-intl';
 import {Provider} from 'react-redux';
-import type CallsClient from 'src/client';
+import type CallClient from 'src/clients/call';
 import {mockStore} from 'src/testUtils';
 
 import CallWidget from './component';
@@ -99,7 +99,7 @@ describe('CallWidget', () => {
             getLocalScreenStream: () => null,
             on: jest.fn(),
             off: jest.fn(),
-        } as unknown as CallsClient;
+        } as unknown as CallClient;
         openSpy = jest.spyOn(window, 'open');
     });
 

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -170,7 +170,6 @@ interface State {
     showAudioOutputDevicesMenu?: boolean,
     showVideoInputDevicesMenu?: boolean,
     dragging: DraggingState,
-    expandedViewWindow: Window | null,
     audioEls: HTMLAudioElement[],
     alerts: CallAlertStates,
     removeConfirmation: RemoveConfirmationData | null,
@@ -188,6 +187,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
     private prevDevicePixelRatio = 0;
     private unsubscribers: (() => void)[] = [];
     private callQualityBannerLocked = false;
+    private readonly expandedViewWindowRef: React.MutableRefObject<Window | null>;
 
     private genStyle: () => Record<string, React.CSSProperties> = () => {
         return {
@@ -316,7 +316,6 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 offX: 0,
                 offY: 0,
             },
-            expandedViewWindow: null,
             audioEls: [],
             alerts: CallAlertStatesDefault,
             screenStream: null,
@@ -328,6 +327,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         };
         this.node = React.createRef();
         this.menuNode = React.createRef();
+        this.expandedViewWindowRef = React.createRef<Window>() as React.MutableRefObject<Window | null>;
     }
 
     setScreenPlayerRef = (node: HTMLVideoElement) => {
@@ -372,8 +372,8 @@ export default class CallWidget extends React.PureComponent<Props, State> {
             },
         });
 
-        if (forward && this.state.expandedViewWindow) {
-            this.state.expandedViewWindow.callActions?.setMissingScreenPermissions(missing);
+        if (forward && this.expandedViewWindowRef.current) {
+            this.expandedViewWindowRef.current.callActions?.setMissingScreenPermissions(missing);
         }
 
         if (window.currentCallData) {
@@ -811,7 +811,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         this.props.recordingPromptDismissedAt(this.props.channel.id, Date.now());
 
         // Dismiss the expanded window's prompt.
-        this.state.expandedViewWindow?.callActions?.setRecordingPromptDismissedAt(this.props.channel.id, Date.now());
+        this.expandedViewWindowRef.current?.callActions?.setRecordingPromptDismissedAt(this.props.channel.id, Date.now());
     };
 
     onRecordToggle = async () => {
@@ -968,24 +968,11 @@ export default class CallWidget extends React.PureComponent<Props, State> {
     }
 
     onDisconnectClick = () => {
-        this.setState({
-            showMenu: false,
-            showParticipantsList: false,
-            currentAudioInputDevice: null,
-            dragging: {
-                dragging: false,
-                x: 0,
-                y: 0,
-                initX: 0,
-                initY: 0,
-                offX: 0,
-                offY: 0,
-            },
-            expandedViewWindow: null,
-        });
-        if (this.state.expandedViewWindow) {
-            this.state.expandedViewWindow.close();
+        if (this.expandedViewWindowRef.current && this.expandedViewWindowRef.current.closed === false) {
+            this.expandedViewWindowRef.current.close();
+            this.expandedViewWindowRef.current = null;
         }
+
         if (window.callsClient) {
             window.callsClient.disconnect();
         }
@@ -2147,7 +2134,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
     };
 
     onExpandClick = () => {
-        if (this.state.expandedViewWindow && !this.state.expandedViewWindow.closed) {
+        if (this.expandedViewWindowRef.current && !this.expandedViewWindowRef.current.closed) {
             if (this.props.global) {
                 if (window.desktopAPI?.focusPopout) {
                     logDebug('desktopAPI.focusPopout');
@@ -2157,7 +2144,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                     sendDesktopEvent('calls-popout-focus');
                 }
             } else {
-                this.state.expandedViewWindow.focus();
+                this.expandedViewWindowRef.current.focus();
             }
             return;
         }
@@ -2172,23 +2159,19 @@ export default class CallWidget extends React.PureComponent<Props, State> {
                 return;
             }
 
-            const expandedViewWindow = window.open(
+            this.expandedViewWindowRef.current = window.open(
                 getPopOutURL(this.props.team, this.props.channel),
                 'ExpandedView',
                 'resizable=yes',
             );
 
-            this.setState({
-                expandedViewWindow,
-            });
-
-            expandedViewWindow?.addEventListener('beforeunload', () => {
+            this.expandedViewWindowRef.current?.addEventListener('beforeunload', () => {
                 if (!window.callsClient) {
                     return;
                 }
 
                 const localScreenStream = window.callsClient.getLocalScreenStream();
-                if (localScreenStream && localScreenStream.getVideoTracks()[0].id === expandedViewWindow.screenSharingTrackId) {
+                if (localScreenStream && localScreenStream.getVideoTracks()[0].id === this.expandedViewWindowRef.current?.screenSharingTrackId) {
                     window.callsClient.unshareScreen();
                 }
             });

--- a/webapp/src/components/screen_source_modal/component.tsx
+++ b/webapp/src/components/screen_source_modal/component.tsx
@@ -3,7 +3,7 @@
 
 import './component.scss';
 
-import {DesktopCaptureSource} from '@mattermost/desktop-api';
+import {type DesktopCaptureSource} from '@mattermost/desktop-api';
 import React, {CSSProperties} from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {IntlShape} from 'react-intl';


### PR DESCRIPTION
#### Summary
cherry pick of https://github.com/mattermost/mattermost-plugin-calls/pull/1183

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the Schema Migration Template as a starting point to capture these details as release notes.
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.

Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.

NONE
-->
```release-note

```
