### PR TITLE
Diagnostic: warn when Calls runs in a container with only RFC1918 IPs and no ICEHostOverride (#1143)

### DIFF
--- a/FIX_ISSUE_1143_README.md
+++ b/FIX_ISSUE_1143_README.md
@@ -1,0 +1,129 @@
+# Fix for mattermost-plugin-calls issue #1143 — Docker IP 172.x leaking as ICE candidate
+
+**Author:** Francesco Pernice Botta (`999purple999`)
+**Branch:** `fix/1143-warn-rfc1918-docker-ice`
+**Issue:** [mattermost/mattermost-plugin-calls#1143](https://github.com/mattermost/mattermost-plugin-calls/issues/1143)
+**Touched files:**
+- `server/ice_diagnostics.go` (new, 110 lines)
+- `server/ice_diagnostics_test.go` (new, 3 tests)
+- `server/activate.go` (4-line wire-up)
+
+---
+
+## Scope and honest framing
+
+The actual ICE candidate gathering happens in [`mattermost/rtcd/service/rtc`](https://github.com/mattermost/rtcd) (`rtc.NewServer`), which is a different upstream repo. A proper fix that *suppresses* RFC1918 candidates by default belongs there.
+
+This PR addresses the part that is visible from the plugin layer: a **loud, actionable startup diagnostic** that tells the operator their setup is the misconfiguration shape that produces #1143, **before** the first call drops. It is intentionally non-behaviour-changing — a legitimate LAN-only Docker setup still works exactly as before.
+
+The proper rtcd-side fix is a follow-up I'm happy to send as a second PR.
+
+---
+
+## The bug shape (from #1143)
+
+> When using Mattermost Calls with a self-hosted TURN server, calls initially
+> connect successfully but drop after some time. The TURN server logs show
+> internal Docker network IPs (172.21.0.3) being used as peers, leading to
+> 403 Forbidden IP errors and allocation timeout.
+
+User configuration excerpt:
+```json
+"icehostoverride": "",
+"serversideturn": true,
+"iceserversconfigs": "[{\"urls\":[\"turn:{Public IP}:3478\"...]"
+```
+
+The plugin runs inside Docker on `172.21.0.0/16`. With `ICEHostOverride` empty, the embedded RTC server enumerates local interfaces, finds `172.21.0.3`, and advertises it as an ICE host candidate. coturn rejects that peer with 403 because it's not in its allowed-peer set, and the call eventually dies on allocation timeout.
+
+The operator currently has zero feedback that this is what's happening: the call connects, media flows for a while, and only later silently drops. They are left grepping coturn logs to diagnose a configuration setting they didn't know about.
+
+---
+
+## The fix
+
+A new file `server/ice_diagnostics.go` adds three small pieces:
+
+1. **`isPrivateIP(ip)`** — returns true for RFC1918 (10/8, 172.16/12, 192.168/16), RFC6598 carrier-grade NAT (100.64/10), IPv6 ULA (fc00::/7), loopback, and link-local. The exact set of address families that are *unreachable from the public internet* and therefore not safe to advertise to a remote ICE peer.
+
+2. **`listRoutableHostIPs()`** — enumerates non-loopback unicast addresses on the host's interfaces and splits them into routable vs private. No external deps; pure `net.Interfaces()`.
+
+3. **`detectInsideContainer()`** — checks `/.dockerenv` AND `/proc/1/cgroup` for `docker` / `containerd` / `kubepods`. Covers Docker, containerd, and Kubernetes pod environments. Returns false on host installations.
+
+`(*Plugin).checkICEDockerMisconfiguration(iceHostOverride)` composes these. It logs **one** `LogError` line, only if **all** of these are true:
+
+- `ICEHostOverride` is empty
+- Process is inside a container
+- No routable (public) IPs are bound to any interface
+- At least one private IP is bound
+
+In every other case the function returns silently. The message names the offending IPs and tells the operator exactly which setting to change:
+
+> Calls is running inside a container with only private (RFC1918/RFC6598) IP addresses available and ICEHostOverride is empty. ICE host candidates advertised to clients will be unreachable from outside the container, which typically manifests as the call dropping after connecting (issue #1143). Set the ICEHostOverride plugin setting to the public IP (or DNS name) that clients use to reach this host.
+
+The wire-up in `activate.go` is one line, placed before either the RTCD-client or embedded-RTC branch is chosen, so it covers both deployment modes:
+
+```go
+// One-shot diagnostic: warn the operator if we're about to advertise only
+// private ICE host candidates from inside a container with no override
+// configured. Pre-flight check, no behavioural change. See issue #1143.
+p.checkICEDockerMisconfiguration(cfg.ICEHostOverride)
+```
+
+---
+
+## Why a diagnostic rather than a behaviour change
+
+- A LAN-only deployment where every participant is on the same Docker network is a legitimate setup (HALCYON ships this exact topology). Silently dropping RFC1918 candidates would break that.
+- The plugin alone cannot fix what `rtcd` advertises — it only passes config through. A real candidate filter belongs in `rtcd`.
+- A loud LogError costs nothing and saves the operator hours of log-grepping when they hit the misconfiguration shape this issue describes.
+- I'm happy to send the rtcd-side patch as a follow-up if you want to discuss the design first (a `ICEDisableHostRFC1918` knob, or auto-detect on by default with an opt-out).
+
+---
+
+## Tests
+
+```
+go test ./server -run 'TestIsPrivateIP|TestIsPrivateIPNil|TestRFC1918NetworksParsed' -v
+```
+
+`TestIsPrivateIP` exercises the predicate against 13 representative addresses — the four major Docker / RFC1918 ranges, RFC6598 (100.64/10) which is also commonly leaked, IPv6 ULA, loopback, link-local, and several public examples just outside the boundaries (172.15/8 must NOT be flagged; 172.16/12 must). `TestIsPrivateIPNil` documents that `nil` is treated as private (a refuse-to-advertise default). `TestRFC1918NetworksParsed` is a sanity check that the package-level CIDR slice parsed correctly.
+
+I have NOT exercised `detectInsideContainer` or `checkICEDockerMisconfiguration` end-to-end because both reach out to the filesystem / live network interfaces and resist clean unit tests without a fake-filesystem indirection. I can add an interface-and-fake test if you want it for merge — let me know.
+
+---
+
+## How to verify locally
+
+```bash
+git clone -b fix/1143-warn-rfc1918-docker-ice <your-fork>
+cd mattermost-plugin-calls
+make deploy   # standard plugin build
+# In a Docker-deployed Mattermost with calls plugin: start the server, watch
+# the plugin logs. With ICEHostOverride empty and the host only on 172.x,
+# you'll see the new LogError line once at activate.
+```
+
+---
+
+## Push instructions (run when ready)
+
+```bash
+cd workrepo/mattermost-plugin-calls
+gh repo fork mattermost/mattermost-plugin-calls --clone=false --remote=true
+git push -u origin fix/1143-warn-rfc1918-docker-ice
+gh pr create \
+  --base main \
+  --repo mattermost/mattermost-plugin-calls \
+  --title "Diagnostic: warn when Calls runs in a container with only RFC1918 IPs and no ICEHostOverride (#1143)" \
+  --body "$(cat FIX_ISSUE_1143_README.md)"
+```
+
+---
+
+## Trade-offs and open questions
+
+- **Why not a refusal-to-start?** Would break legitimate LAN-only deployments.
+- **Why log once, not on every call?** Activation-time is sufficient: configuration is static; one loud line at startup is the right cadence.
+- **Should we surface this in `/diagnostics`?** Probably yes — happy to add it as a second commit on this branch if you'd like.
+- **Should we PR `mattermost/rtcd` too?** Yes — the candidate-filter knob belongs there. Separate PR, separate review.

--- a/server/activate.go
+++ b/server/activate.go
@@ -148,6 +148,11 @@ func (p *Plugin) OnActivate() (retErr error) {
 		}()
 	}
 
+	// One-shot diagnostic: warn the operator if we're about to advertise only
+	// private ICE host candidates from inside a container with no override
+	// configured. Pre-flight check, no behavioural change. See issue #1143.
+	p.checkICEDockerMisconfiguration(cfg.ICEHostOverride)
+
 	// rtcServer and rtcdManager are mutually exclusive throughout the entire lifetime of the plugin.
 	// Which one is used is decided here, during activation.
 	// We first check if RTCD is configured and allowed by the license. If so

--- a/server/ice_diagnostics.go
+++ b/server/ice_diagnostics.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"net"
+	"os"
+	"strings"
+)
+
+// rfc1918Networks is the set of address ranges that hosts running inside a
+// container or behind a NAT typically bind to. If the plugin advertises one of
+// these as an ICE host candidate while running inside a container and with no
+// `ICEHostOverride` set, clients outside the container cannot route media to
+// it — see issue #1143.
+var rfc1918Networks = func() []*net.IPNet {
+	cidrs := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"100.64.0.0/10", // RFC 6598 CGNAT — also unreachable from the public side
+		"fc00::/7",       // IPv6 ULA
+	}
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err == nil {
+			out = append(out, n)
+		}
+	}
+	return out
+}()
+
+// isPrivateIP reports whether ip is unreachable from the public internet.
+func isPrivateIP(ip net.IP) bool {
+	if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsMulticast() {
+		return true
+	}
+	for _, n := range rfc1918Networks {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// listRoutableHostIPs returns the unicast IPv4/IPv6 addresses bound to local
+// interfaces, excluding loopback and link-local. The slice is empty if every
+// detected address is private. (Caller decides what to do with that fact.)
+func listRoutableHostIPs() (routable []string, private []string) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, nil
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+			if isPrivateIP(ip) {
+				private = append(private, ip.String())
+			} else {
+				routable = append(routable, ip.String())
+			}
+		}
+	}
+	return routable, private
+}
+
+// detectInsideContainer returns true when the process appears to be running
+// inside a Docker / containerd / podman container. Uses both the canonical
+// `/.dockerenv` marker file and a cgroup-string check so it also catches
+// recent containerd-only setups that don't ship the Docker marker.
+func detectInsideContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+		s := string(data)
+		if strings.Contains(s, "docker") || strings.Contains(s, "containerd") || strings.Contains(s, "kubepods") {
+			return true
+		}
+	}
+	// /proc/self/mountinfo also shows overlayfs in containers, but the two
+	// checks above are sufficient for the misconfiguration we want to flag.
+	return false
+}
+
+// checkICEDockerMisconfiguration emits a loud LogError when the plugin is
+// about to advertise only private/RFC1918 ICE host candidates from inside a
+// container and the administrator has not set `ICEHostOverride`. This is the
+// shape of the failure reported in issue #1143: coturn observes peer
+// 172.21.0.3 (a Docker bridge address), rejects it with "403 Forbidden IP",
+// and the call drops.
+//
+// We intentionally do NOT refuse to start: a LAN-only deployment where every
+// participant is on the same Docker network is a legitimate setup. The check
+// is purely diagnostic and gives the operator one actionable line of guidance
+// in the logs.
+func (p *Plugin) checkICEDockerMisconfiguration(iceHostOverride string) {
+	if strings.TrimSpace(iceHostOverride) != "" {
+		return
+	}
+	inContainer := detectInsideContainer()
+	if !inContainer {
+		return
+	}
+	routable, private := listRoutableHostIPs()
+	if len(routable) > 0 {
+		// We have at least one public-routable IP; ICE gathering will pick it
+		// up by default. Nothing to warn about.
+		return
+	}
+	if len(private) == 0 {
+		return
+	}
+	p.LogError(
+		"Calls is running inside a container with only private (RFC1918/RFC6598) "+
+			"IP addresses available and ICEHostOverride is empty. ICE host "+
+			"candidates advertised to clients will be unreachable from outside "+
+			"the container, which typically manifests as the call dropping after "+
+			"connecting (issue #1143). Set the ICEHostOverride plugin setting "+
+			"to the public IP (or DNS name) that clients use to reach this host.",
+		"private_interface_ips", strings.Join(private, ","),
+	)
+}

--- a/server/ice_diagnostics_test.go
+++ b/server/ice_diagnostics_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		// Docker bridge / standard RFC1918 — must be flagged.
+		{"172.21.0.3", true},
+		{"172.17.0.1", true},
+		{"10.0.0.5", true},
+		{"192.168.1.1", true},
+		// RFC6598 carrier-grade NAT — also unreachable from public.
+		{"100.64.1.2", true},
+		// IPv6 ULA.
+		{"fd00::1", true},
+		// Loopback / link-local — always treated as private.
+		{"127.0.0.1", true},
+		{"169.254.1.1", true},
+		{"::1", true},
+		// Public IPs — must not be flagged.
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"172.15.0.1", false}, // just outside 172.16/12
+		{"192.167.255.1", false},
+		{"2606:4700:4700::1111", false},
+	}
+	for _, c := range cases {
+		ip := net.ParseIP(c.ip)
+		if got := isPrivateIP(ip); got != c.want {
+			t.Errorf("isPrivateIP(%q) = %v, want %v", c.ip, got, c.want)
+		}
+	}
+}
+
+func TestIsPrivateIPNil(t *testing.T) {
+	if !isPrivateIP(nil) {
+		t.Errorf("isPrivateIP(nil) should be treated as private (refuse to advertise)")
+	}
+}
+
+func TestRFC1918NetworksParsed(t *testing.T) {
+	// Sanity: every CIDR in the package-level slice parsed.
+	if len(rfc1918Networks) == 0 {
+		t.Fatal("rfc1918Networks is empty — CIDR parse must have failed")
+	}
+	wantCount := 5 // 10/8, 172.16/12, 192.168/16, 100.64/10, fc00::/7
+	if len(rfc1918Networks) != wantCount {
+		t.Errorf("rfc1918Networks len = %d, want %d", len(rfc1918Networks), wantCount)
+	}
+}


### PR DESCRIPTION
Hi @M-ZubairAhmed — putting this in front of you because you've been merging the recent server-side PRs on the Calls plugin (incl. the LiveKit migration work from @bgardner8008). Issue #1143 (Docker 172.x leaking as ICE candidate, coturn 403, calls drop minutes after connect) is still open and the `ICEHostOverride` config + the embedded `rtc.NewServer` fallback in `activate.go` are still alive in HEAD, so the diagnostic still applies during the migration window. Once embedded RTC is fully removed, this can come out too — happy to handle the cleanup PR at that point.

Full design rationale, safety invariants, and verification commands below.

---

# Fix for mattermost-plugin-calls issue #1143 — Docker IP 172.x leaking as ICE candidate

**Author:** Francesco Pernice Botta (`999purple999`)
**Branch:** `fix/1143-warn-rfc1918-docker-ice`
**Issue:** [mattermost/mattermost-plugin-calls#1143](https://github.com/mattermost/mattermost-plugin-calls/issues/1143)
**Touched files:**
- `server/ice_diagnostics.go` (new, 110 lines)
- `server/ice_diagnostics_test.go` (new, 3 tests)
- `server/activate.go` (4-line wire-up)

---

## Scope and honest framing

The actual ICE candidate gathering happens in [`mattermost/rtcd/service/rtc`](https://github.com/mattermost/rtcd) (`rtc.NewServer`), which is a different upstream repo. A proper fix that *suppresses* RFC1918 candidates by default belongs there.

This PR addresses the part that is visible from the plugin layer: a **loud, actionable startup diagnostic** that tells the operator their setup is the misconfiguration shape that produces #1143, **before** the first call drops. It is intentionally non-behaviour-changing — a legitimate LAN-only Docker setup still works exactly as before.

The proper rtcd-side fix is a follow-up I'm happy to send as a second PR.

---

## The bug shape (from #1143)

> When using Mattermost Calls with a self-hosted TURN server, calls initially
> connect successfully but drop after some time. The TURN server logs show
> internal Docker network IPs (172.21.0.3) being used as peers, leading to
> 403 Forbidden IP errors and allocation timeout.

User configuration excerpt:
```json
"icehostoverride": "",
"serversideturn": true,
"iceserversconfigs": "[{\"urls\":[\"turn:{Public IP}:3478\"...]"
```

The plugin runs inside Docker on `172.21.0.0/16`. With `ICEHostOverride` empty, the embedded RTC server enumerates local interfaces, finds `172.21.0.3`, and advertises it as an ICE host candidate. coturn rejects that peer with 403 because it's not in its allowed-peer set, and the call eventually dies on allocation timeout.

The operator currently has zero feedback that this is what's happening: the call connects, media flows for a while, and only later silently drops. They are left grepping coturn logs to diagnose a configuration setting they didn't know about.

---

## The fix

A new file `server/ice_diagnostics.go` adds three small pieces:

1. **`isPrivateIP(ip)`** — returns true for RFC1918 (10/8, 172.16/12, 192.168/16), RFC6598 carrier-grade NAT (100.64/10), IPv6 ULA (fc00::/7), loopback, and link-local. The exact set of address families that are *unreachable from the public internet* and therefore not safe to advertise to a remote ICE peer.

2. **`listRoutableHostIPs()`** — enumerates non-loopback unicast addresses on the host's interfaces and splits them into routable vs private. No external deps; pure `net.Interfaces()`.

3. **`detectInsideContainer()`** — checks `/.dockerenv` AND `/proc/1/cgroup` for `docker` / `containerd` / `kubepods`. Covers Docker, containerd, and Kubernetes pod environments. Returns false on host installations.

`(*Plugin).checkICEDockerMisconfiguration(iceHostOverride)` composes these. It logs **one** `LogError` line, only if **all** of these are true:

- `ICEHostOverride` is empty
- Process is inside a container
- No routable (public) IPs are bound to any interface
- At least one private IP is bound

In every other case the function returns silently. The message names the offending IPs and tells the operator exactly which setting to change:

> Calls is running inside a container with only private (RFC1918/RFC6598) IP addresses available and ICEHostOverride is empty. ICE host candidates advertised to clients will be unreachable from outside the container, which typically manifests as the call dropping after connecting (issue #1143). Set the ICEHostOverride plugin setting to the public IP (or DNS name) that clients use to reach this host.

The wire-up in `activate.go` is one line, placed before either the RTCD-client or embedded-RTC branch is chosen, so it covers both deployment modes:

```go
// One-shot diagnostic: warn the operator if we're about to advertise only
// private ICE host candidates from inside a container with no override
// configured. Pre-flight check, no behavioural change. See issue #1143.
p.checkICEDockerMisconfiguration(cfg.ICEHostOverride)
```

---

## Why a diagnostic rather than a behaviour change

- A LAN-only deployment where every participant is on the same Docker network is a legitimate setup (HALCYON ships this exact topology). Silently dropping RFC1918 candidates would break that.
- The plugin alone cannot fix what `rtcd` advertises — it only passes config through. A real candidate filter belongs in `rtcd`.
- A loud LogError costs nothing and saves the operator hours of log-grepping when they hit the misconfiguration shape this issue describes.
- I'm happy to send the rtcd-side patch as a follow-up if you want to discuss the design first (a `ICEDisableHostRFC1918` knob, or auto-detect on by default with an opt-out).

---

## Tests

```
go test ./server -run 'TestIsPrivateIP|TestIsPrivateIPNil|TestRFC1918NetworksParsed' -v
```

`TestIsPrivateIP` exercises the predicate against 13 representative addresses — the four major Docker / RFC1918 ranges, RFC6598 (100.64/10) which is also commonly leaked, IPv6 ULA, loopback, link-local, and several public examples just outside the boundaries (172.15/8 must NOT be flagged; 172.16/12 must). `TestIsPrivateIPNil` documents that `nil` is treated as private (a refuse-to-advertise default). `TestRFC1918NetworksParsed` is a sanity check that the package-level CIDR slice parsed correctly.

I have NOT exercised `detectInsideContainer` or `checkICEDockerMisconfiguration` end-to-end because both reach out to the filesystem / live network interfaces and resist clean unit tests without a fake-filesystem indirection. I can add an interface-and-fake test if you want it for merge — let me know.

---

## How to verify locally

```bash
git clone -b fix/1143-warn-rfc1918-docker-ice <your-fork>
cd mattermost-plugin-calls
make deploy   # standard plugin build
# In a Docker-deployed Mattermost with calls plugin: start the server, watch
# the plugin logs. With ICEHostOverride empty and the host only on 172.x,
# you'll see the new LogError line once at activate.
```

---

## Push instructions (run when ready)

```bash
cd workrepo/mattermost-plugin-calls
gh repo fork mattermost/mattermost-plugin-calls --clone=false --remote=true
git push -u origin fix/1143-warn-rfc1918-docker-ice
gh pr create \
  --base main \
  --repo mattermost/mattermost-plugin-calls \
  --title "Diagnostic: warn when Calls runs in a container with only RFC1918 IPs and no ICEHostOverride (#1143)" \
  --body "$(cat FIX_ISSUE_1143_README.md)"
```

---

## Trade-offs and open questions

- **Why not a refusal-to-start?** Would break legitimate LAN-only deployments.
- **Why log once, not on every call?** Activation-time is sufficient: configuration is static; one loud line at startup is the right cadence.
- **Should we surface this in `/diagnostics`?** Probably yes — happy to add it as a second commit on this branch if you'd like.
- **Should we PR `mattermost/rtcd` too?** Yes — the candidate-filter knob belongs there. Separate PR, separate review.
