### PR TITLE
[MM-69018] End call via LiveKit DeleteRoom and unify call_ended event

### DIFF
--- a/server/host_controls.go
+++ b/server/host_controls.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mattermost/mattermost-plugin-calls/server/db"
-
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/pkg/errors"
 )
@@ -295,36 +293,26 @@ func (p *Plugin) hostEnd(requesterID, channelID string) error {
 		}
 	}
 
-	// Ask clients to disconnect themselves. The last to disconnect will cause the call to end, as usual.
-	p.publishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
+	// Destroy the LiveKit room. This forcibly disconnects every connected
+	// participant; each client's LiveKit SDK fires RoomEvent.Disconnected
+	// (reason=ROOM_DELETED), driving in-call UI teardown independently of
+	// plugin-WebSocket delivery.
+	if err := p.livekitDeleteRoom(channelID); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
+		p.LogError("hostEnd: failed to delete LiveKit room",
+			"channelID", channelID, "err", err.Error())
+	}
 
-	callID := state.Call.ID
+	// Notify the whole channel that the call has ended so bystander UI
+	// (toast, sidebar icon) clears immediately. In-call clients also receive
+	// this event, but their widget teardown is driven by LiveKit.
+	p.publishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &WebSocketBroadcast{
+		ChannelID:           channelID,
+		ReliableClusterSend: true,
+	})
 
-	go func() {
-		// We wait a few seconds for the call to end cleanly. If this doesn't
-		// happen we force end it.
-		time.Sleep(5 * time.Second)
-
-		call, err := p.store.GetCall(callID, db.GetCallOpts{})
-		if err != nil {
-			p.LogError("failed to get call", "err", err.Error())
-		}
-
-		sessions, err := p.store.GetCallSessions(callID, db.GetCallSessionOpts{})
-		if err != nil {
-			p.LogError("failed to get call sessions", "err", err.Error())
-		}
-
-		for _, session := range sessions {
-			if err := p.closeRTCSession(session.UserID, session.ID, channelID); err != nil {
-				p.LogError(err.Error())
-			}
-		}
-
-		if err := p.cleanCallState(call); err != nil {
-			p.LogError(err.Error())
-		}
-	}()
+	if err := p.cleanCallState(&state.Call); err != nil {
+		return fmt.Errorf("failed to clean call state: %w", err)
+	}
 
 	return nil
 }

--- a/server/livekit_admin.go
+++ b/server/livekit_admin.go
@@ -86,3 +86,26 @@ func (p *Plugin) livekitRemoveParticipant(room, identity string) error {
 	}
 	return nil
 }
+
+// livekitDeleteRoom destroys the LiveKit room and forcibly disconnects every
+// participant. The plugin server is the authority on call lifecycle; this is
+// the atomic media-layer teardown that backs the host-end-call action and any
+// other server-driven call termination. Each connected client's LiveKit SDK
+// fires RoomEvent.Disconnected (reason=ROOM_DELETED), which drives in-call UI
+// teardown without relying on plugin-WebSocket delivery.
+func (p *Plugin) livekitDeleteRoom(room string) error {
+	client, err := p.getLiveKitRoomClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), livekitAPITimeout)
+	defer cancel()
+
+	if _, err := client.DeleteRoom(ctx, &livekit.DeleteRoomRequest{
+		Room: room,
+	}); err != nil {
+		return fmt.Errorf("livekit DeleteRoom: %w", err)
+	}
+	return nil
+}

--- a/server/session.go
+++ b/server/session.go
@@ -436,6 +436,11 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		}
 		setCallEnded(&state.Call)
 
+		p.publishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &WebSocketBroadcast{
+			ChannelID:           channelID,
+			ReliableClusterSend: true,
+		})
+
 		defer func() {
 			_, err := p.updateCallPostEnded(state.Call.PostID, mapKeys(state.Call.Props.Participants))
 			if err != nil {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -31,7 +31,7 @@ const (
 	wsEventUserVideoOff              = "user_video_off"
 	wsEventCallStart                 = "call_start"
 	wsEventCallState                 = "call_state"
-	wsEventCallEnd                   = "call_end"
+	wsEventCallEnd                   = "call_ended"
 	wsEventUserRaiseHand             = "user_raise_hand"
 	wsEventUserUnraiseHand           = "user_unraise_hand"
 	wsEventUserReacted               = "user_reacted"
@@ -446,11 +446,13 @@ func (p *Plugin) wsReader(us *session, authSessionID string) {
 					fields = append(fields, "sessionID", s.Id, "expiresAt", fmt.Sprintf("%d", s.ExpiresAt))
 				}
 
-				p.LogInfo("invalid or expired session, closing RTC session", fields...)
+				p.LogInfo("invalid or expired session, removing LiveKit participant", fields...)
 
-				// We forcefully disconnect any session that has been revoked or expired.
-				if err := p.closeRTCSession(us.userID, us.connID, us.channelID); err != nil {
-					p.LogError("failed to close RTC session", append(fields[:5], "err", err.Error()))
+				// Force the participant off the LiveKit room. Their client will see
+				// RoomEvent.Disconnected and tear down its own UI.
+				if err := p.livekitRemoveParticipant(us.channelID, composeLivekitIdentity(us.userID, us.connID)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
+					p.LogError("failed to remove LiveKit participant for revoked session",
+						append(fields, "err", err.Error())...)
 				}
 
 				return
@@ -1068,13 +1070,6 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 		p.LogError("chan is full, dropping ws msg", "type", msg.Type)
 		return
 	}
-}
-
-// closeRTCSession is a no-op in the LiveKit architecture.
-// LiveKit manages media session cleanup directly when participants disconnect.
-func (p *Plugin) closeRTCSession(userID, connID, channelID string) error {
-	p.LogDebug("closeRTCSession", "userID", userID, "connID", connID, "channelID", channelID)
-	return nil
 }
 
 func (p *Plugin) handleBotWSReconnect(connID, prevConnID, originalConnID, channelID string) error {

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -319,14 +319,10 @@ func TestWSReader(t *testing.T) {
 				ExpiresAt: expiresAt,
 			}, nil).Once()
 
-			mockAPI.On("LogInfo", "invalid or expired session, closing RTC session",
+			mockAPI.On("LogInfo", "invalid or expired session, removing LiveKit participant",
 				"origin", mock.AnythingOfType("string"),
 				"channelID", us.channelID, "userID", us.userID, "connID", us.connID,
 				"sessionID", "authSessionID", "expiresAt", fmt.Sprintf("%d", expiresAt)).Once()
-
-			mockAPI.On("LogDebug", "closeRTCSession",
-				"origin", mock.AnythingOfType("string"),
-				"userID", us.userID, "connID", us.connID, "channelID", us.channelID).Once()
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -349,14 +345,10 @@ func TestWSReader(t *testing.T) {
 			mockAPI.On("GetSession", "authSessionID").Return(nil,
 				model.NewAppError("GetSessionById", "We encountered an error finding the session.", nil, "", http.StatusUnauthorized)).Once()
 
-			mockAPI.On("LogInfo", "invalid or expired session, closing RTC session",
+			mockAPI.On("LogInfo", "invalid or expired session, removing LiveKit participant",
 				"origin", mock.AnythingOfType("string"),
 				"channelID", us.channelID, "userID", us.userID, "connID", us.connID,
 				"err", "GetSessionById: We encountered an error finding the session.").Once()
-
-			mockAPI.On("LogDebug", "closeRTCSession",
-				"origin", mock.AnythingOfType("string"),
-				"userID", us.userID, "connID", us.connID, "channelID", us.channelID).Once()
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -383,13 +375,9 @@ func TestWSReader(t *testing.T) {
 				"origin", mock.AnythingOfType("string"),
 				"channelID", us.channelID, "userID", us.userID, "connID", us.connID)
 
-			mockAPI.On("LogInfo", "invalid or expired session, closing RTC session",
+			mockAPI.On("LogInfo", "invalid or expired session, removing LiveKit participant",
 				"origin", mock.AnythingOfType("string"),
 				"channelID", us.channelID, "userID", us.userID, "connID", us.connID).Once()
-
-			mockAPI.On("LogDebug", "closeRTCSession",
-				"origin", mock.AnythingOfType("string"),
-				"userID", us.userID, "connID", us.connID, "channelID", us.channelID).Once()
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -905,6 +893,11 @@ func TestHandleJoin(t *testing.T) {
 		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, map[string]any{"session_id": connID, "user_id": userID},
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
 
+		// Last participant leaving triggers the call_ended broadcast.
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, map[string]any{},
+			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
+
 		mockAPI.On("UpdatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{Id: postID}, nil).Once()
 
 		// Call unlock
@@ -1039,6 +1032,11 @@ func TestHandleJoin(t *testing.T) {
 		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, mock.Anything,
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Times(10)
 
+		// Last participant leaving triggers the call_ended broadcast.
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, map[string]any{},
+			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
+
 		mockAPI.On("UpdatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{Id: postID}, nil).Once()
 
 		// Call unlock
@@ -1152,6 +1150,12 @@ func TestHandleJoin(t *testing.T) {
 		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, mock.Anything,
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
 		defer mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, mock.Anything,
+			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Unset()
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd)
+		defer mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Unset()
+		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, mock.Anything,
+			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
+		defer mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, mock.Anything,
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Unset()
 		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil)
 		mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -1372,6 +1376,11 @@ func TestHandleJoin(t *testing.T) {
 
 		mockMetrics.On("IncWebSocketEvent", "out", wsEventUserLeft).Once()
 		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, map[string]any{"session_id": connID, "user_id": userID},
+			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
+
+		// Last participant leaving triggers the call_ended broadcast.
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, map[string]any{},
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
 
 		// Call unlock

--- a/standalone/src/index.ts
+++ b/standalone/src/index.ts
@@ -232,7 +232,7 @@ export default async function initialiseEmbedApp(cfg: InitConfig) {
         case `custom_${pluginId}_call_start`:
             handleCallStart(store, ev as WebSocketMessage<CallStartData>);
             break;
-        case `custom_${pluginId}_call_end`:
+        case `custom_${pluginId}_call_ended`:
             handleCallEnd(store, ev as WebSocketMessage<EmptyData>);
             break;
         case `custom_${pluginId}_user_joined`:


### PR DESCRIPTION
## Summary

Fixes [MM-69018](https://mattermost.atlassian.net/browse/MM-69018) — host-initiated "End call for everyone" no longer tore down `#calls-widget` on any client under LiveKit. Root cause was a combination of the WS event name diverging between server and webapp during the LiveKit migration, plus a `closeRTCSession` stub left behind from the RTCD era that did nothing.

This PR moves the authoritative call teardown to LiveKit's `DeleteRoom` RPC, which forcibly disconnects every participant at the media layer. Each client's LiveKit SDK fires `RoomEvent.Disconnected`, and the existing webapp handler tears down the widget — no plugin-WebSocket cooperation required. The `call_ended` event is kept as a fast channel-wide notification so bystander UI (toast, sidebar icon) clears immediately, and is now also emitted on the natural last-leave path so both code paths look the same to clients.

The design rationale and follow-up cleanup are written up in https://mattermost.atlassian.net/wiki/spaces/Calls/pages/4600430595/Calls+v2+Call+Flow+Setup+and+Teardown. Follow-up ticket for the webapp-side teardown-path cleanup: [MM-69034](https://mattermost.atlassian.net/browse/MM-69034).

### Server

- `server/livekit_admin.go` — new `livekitDeleteRoom(room)` helper wrapping LiveKit's `DeleteRoom` RPC (parallels existing `livekitRemoveParticipant`).
- `server/host_controls.go` — `hostEnd` now calls `livekitDeleteRoom(channelID)` synchronously, broadcasts `call_ended`, then `cleanCallState`. Dropped the 5-second sleep + `closeRTCSession` loop + the goroutine.
- `server/session.go` — `removeUserSession` now broadcasts `call_ended` immediately after `setCallEnded` on natural last-leave. Previously only the host-end path broadcast this event.
- `server/websocket.go` — `wsEventCallEnd` value renamed `"call_end"` → `"call_ended"` to match the webapp handler. `closeRTCSession` no-op stub deleted. Expired-session path now calls `livekitRemoveParticipant` instead of the stub.
- `server/websocket_test.go` — updated mocks for the renamed log line and the new `call_ended` broadcast on last leave.

### Webapp / standalone

- `standalone/src/index.ts` — switch case updated `call_end` → `call_ended` to match server (main webapp already listened for `call_ended`).

## Test plan

- [x] Server unit tests pass (`go test ./...` in `server/`).
- [x] `go vet ./...` clean.
- [ ] Manual two-user repro: host clicks "End call for everyone" → widget disappears on both clients, channel toast clears, sidebar active-call icon clears.
- [ ] Manual repro from `/call end` slash path.
- [ ] Manual repro from post-card "Leave" → "End call for everyone".
- [ ] Manual repro: natural last-leave (single user leaves) → call ends cleanly, channel toast / sidebar icon clear.
- [ ] Individual host-kick (`Remove from call`) still works — single participant disconnected, rest of call continues.
- [ ] Four host-end E2E tests pass (`e2e/tests/slash_commands.spec.ts`, `e2e/tests/join_call.spec.ts`).

## Notes for reviewers

- LiveKit room name = channelID. The token's `VideoGrant.Room` is already set this way at token mint (`server/api.go:524`), so `DeleteRoom(channelID)` matches.
- `golangci-lint` is currently blocked locally by a Go 1.26.3 vs lint binary 1.25 mismatch (pre-existing, unrelated to this PR). CI should run it on a matched toolchain.