### PR TITLE
[MM-69019] Gate E2E call helpers on WS state hydration

### DIFF
--- a/e2e/page.ts
+++ b/e2e/page.ts
@@ -64,6 +64,11 @@ export default class PlaywrightDevPage {
         await expect(startCallButton).toBeVisible();
         await startCallButton.click();
         await this.page.waitForFunction(() => window.callsClient && window.callsClient.connected && !window.callsClient.closed);
+
+        // Wait for the plugin's WS-driven call state (host/sessions) to land in Redux
+        // before returning, so a following action (e.g. /call end, which reads the host)
+        // doesn't race the hydration. See MM-69019.
+        await this.page.waitForFunction(() => window.e2eCallStateLoaded?.());
         await expect(this.page.locator('#calls-widget')).toBeVisible();
     }
 
@@ -85,6 +90,9 @@ export default class PlaywrightDevPage {
         await expect(joinCallButton).toBeVisible();
         await joinCallButton.click();
         await this.page.waitForFunction(() => window.callsClient && window.callsClient.connected && !window.callsClient.closed);
+
+        // See startCall() — wait for WS hydration before returning (MM-69019).
+        await this.page.waitForFunction(() => window.e2eCallStateLoaded?.());
         await expect(this.page.locator('#calls-widget')).toBeVisible();
     }
 

--- a/e2e/types.ts
+++ b/e2e/types.ts
@@ -10,6 +10,7 @@ declare global {
         e2eNotificationsSoundedAt?: number[],
         e2eNotificationsSoundStoppedAt?: number[],
         e2eRingLength?: number,
+        e2eCallStateLoaded?: (channelID?: string) => boolean,
         plugins: any,
 
         // Desktop Mocking

--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -263,6 +263,21 @@ describe('CallClient', () => {
         });
     });
 
+    describe('connected / closed getters', () => {
+        it('connected is false before connect, true once the room is connected, and closed flips on disconnect', async () => {
+            expect(client.connected).toBe(false);
+            expect(client.closed).toBe(false);
+
+            await client.connect({channelID: 'test-channel'});
+            expect(client.connected).toBe(true);
+            expect(client.closed).toBe(false);
+
+            await client.disconnect();
+            expect(client.connected).toBe(false);
+            expect(client.closed).toBe(true);
+        });
+    });
+
     describe('Connected event', () => {
         it('treats absent mic publication as muted', async () => {
             mockRoom.localParticipant.getTrackPublication.mockReturnValue(null);

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -413,6 +413,17 @@ export default class CallClient extends EventEmitter {
         return sessionID;
     }
 
+    // True while the LiveKit room is connected and we haven't torn down. Note this
+    // reflects the media plane only; plugin call state (host/sessions) hydrates via WS
+    // separately, so callers needing that should wait on it themselves (see MM-69019).
+    public get connected(): boolean {
+        return this.isRoomConnected && !this.isDisconnected;
+    }
+
+    public get closed(): boolean {
+        return this.isDisconnected;
+    }
+
     // ------------------------------------------------------------
     // Private methods
     // ------------------------------------------------------------

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -140,6 +140,7 @@ import {
     channelIDForCurrentCall,
     defaultEnabled,
     hasPermissionsToEnableCalls,
+    hostIDForCallInChannel,
     isCloudStarter,
     isLimitRestricted,
     ringingEnabled,
@@ -298,6 +299,16 @@ export default class Plugin {
             RestClient.setUrl(window.basename);
             Client4.setUrl(window.basename);
         }
+
+        // E2E hydration probe: lets tests wait until the plugin's WS-driven call state
+        // (host/sessions) has landed in Redux before acting, rather than racing it. Reads
+        // current state on each call, so there's no setup ordering to get wrong. With no
+        // channelID it checks the call the local user is currently in. See MM-69019.
+        window.e2eCallStateLoaded = (channelID?: string) => {
+            const state = store.getState();
+            const cid = channelID || channelIDForCurrentCall(state);
+            return Boolean(cid && hostIDForCallInChannel(state, cid));
+        };
 
         const theme = getTheme(store.getState());
         setCallsGlobalCSSVars(theme.sidebarBg);

--- a/webapp/src/types/global.d.ts
+++ b/webapp/src/types/global.d.ts
@@ -32,6 +32,7 @@ declare global {
         e2eNotificationsSoundedAt?: number[],
         e2eNotificationsSoundStoppedAt?: number[],
         e2eRingLength?: number,
+        e2eCallStateLoaded?: (channelID?: string) => boolean,
 
         registerPlugin(id: string, plugin: unknown): void,
     }


### PR DESCRIPTION
## Summary

Under LiveKit, `CallClient.connect()` resolves once the LiveKit room is connected, but the plugin's WS-driven Redux state (host, active call) hydrates on a **separate** roundtrip (the main Mattermost WS → `handleCallState` → `loadCallState`). The revived E2E suite acted on that state immediately after joining and raced the hydration — e.g. `/call end` read a not-yet-populated `hostIDForCallInChannel` and hit the "you don't have permission" modal.

After investigation we concluded this is a **test-timing artifact, not a product bug**: real users act seconds after joining, long after hydration completes, and no product code reads call state synchronously on connect. So rather than change `connect()`'s semantics (and couple a shared, store-agnostic client to Redux), the fix lives in the test layer — which the ticket's acceptance criteria explicitly allow ("after `startCall()` resolves … **OR E2E helpers**").

## Changes

- **`e2eCallStateLoaded` probe** (`index.tsx`): a test-only `window` hook, in the same spirit as the existing `e2e*` hooks, that reads the **authoritative** Redux state (`hostIDForCallInChannel`, defaulting to the current call's channel). Because it reads state on each call, there's no setup-ordering race, and it observes the exact state consumers read — so it's race-free, not merely probabilistic.
- **E2E helpers** (`page.ts`): `startCall()`/`joinCall()` now wait on `window.e2eCallStateLoaded?.()` before returning, so a following action doesn't race hydration.
- **`connected`/`closed` getters** (`call_client.ts`): added to the v2 `CallClient` (they were missing; the E2E helpers already poll `window.callsClient.connected`/`.closed`). `connected` reflects the LiveKit media plane (`isRoomConnected && !isDisconnected`).

`connect()` runtime behavior is unchanged; the only production additions are the two getters and the test-only probe.

## Why the store probe rather than gating `connect()`

The webapp hydrates Redux on the **main** MM WS, while `connect()`/CallClient run on the **separate** calls plugin WS — so gating `connect()` on the calls-WS `call_state` event would only narrow the cross-connection race, not eliminate it. Observing the Redux store waits on the downstream result of hydration, so it's correct regardless of which WS fed it. Keeping it store-agnostic, `CallClient` gains no Redux dependency.

## Testing

- `call_client.test.ts`: 56 passed (added a `connected`/`closed` getter test). Full webapp suite: 339 passed / 36 suites. `tsc` + eslint clean.
- The quarantined E2E tests referenced in the ticket live in the unmerged MM-68570 PRs; this PR provides the `e2eCallStateLoaded` probe + helper waits they'll gate on. Full E2E verification needs the Docker stack.