### PR TITLE
[MM-68796] Release camera device when video is disabled

### DIFF
--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -374,4 +374,156 @@ describe('CallsClient', () => {
             expect(client.setAudioInputDevice).not.toHaveBeenCalled();
         });
     });
+
+    describe('video track management', () => {
+        const makeVideoTrack = (id: string) => ({
+            id,
+            kind: 'video',
+            enabled: false,
+            stop: jest.fn(),
+            dispatchEvent: jest.fn(),
+        });
+
+        const makeStream = (id: string, tracks: Array<ReturnType<typeof makeVideoTrack>>) => ({
+            id,
+            getVideoTracks: () => tracks,
+            getTracks: () => tracks,
+            removeTrack: jest.fn(),
+            addTrack: jest.fn(),
+        });
+
+        const setupPeer = () => {
+            const peer = {addTrack: jest.fn(), replaceTrack: jest.fn()};
+            const ws = {send: jest.fn()};
+
+            // @ts-ignore - accessing private property for testing
+            client.config.enableVideo = true;
+
+            // @ts-ignore - accessing private property for testing
+            client.peer = peer;
+
+            // @ts-ignore - accessing private property for testing
+            client.ws = ws;
+            return {peer, ws};
+        };
+
+        it('startVideo adds the track and records the sender track ID', async () => {
+            const {peer} = setupPeer();
+            const track = makeVideoTrack('cam-1');
+            const stream = makeStream('stream-1', [track]);
+
+            // @ts-ignore - accessing private property for testing
+            client.localVideoStream = stream;
+
+            await client.startVideo();
+
+            expect(peer.addTrack).toHaveBeenCalledTimes(1);
+            expect(track.enabled).toBe(true);
+
+            // @ts-ignore - accessing private property for testing
+            expect(client.videoTrackAdded).toBe(true);
+
+            // @ts-ignore - accessing private property for testing
+            expect(client.videoSenderTrackID).toBe('cam-1');
+        });
+
+        it('stopVideo stops the camera track and releases the stream so the device LED turns off', () => {
+            const {peer, ws} = setupPeer();
+            const track = makeVideoTrack('cam-1');
+            track.enabled = true;
+            const stream = makeStream('stream-1', [track]);
+
+            // @ts-ignore - accessing private property for testing
+            client.localVideoStream = stream;
+
+            // @ts-ignore - accessing private property for testing
+            client.videoSenderTrackID = 'cam-1';
+
+            client.stopVideo();
+
+            // Detaches the track from the sender without tearing it down.
+            expect(peer.replaceTrack).toHaveBeenCalledWith('cam-1', null);
+
+            // Crucially, the device is fully stopped (not just disabled) so the LED turns off.
+            expect(track.stop).toHaveBeenCalledTimes(1);
+
+            // The stream is released so the next startVideo re-initializes it.
+            // @ts-ignore - accessing private property for testing
+            expect(client.localVideoStream).toBeNull();
+            expect(ws.send).toHaveBeenCalledWith('video_off');
+        });
+
+        it('re-enables video after a stop by replacing the sender track with a freshly acquired one', async () => {
+            const {peer} = setupPeer();
+
+            const track1 = makeVideoTrack('cam-1');
+            const stream1 = makeStream('stream-1', [track1]);
+
+            // @ts-ignore - accessing private property for testing
+            client.localVideoStream = stream1;
+
+            await client.startVideo();
+            client.stopVideo();
+
+            // initVideo acquires a brand new stream/track on re-enable.
+            const track2 = makeVideoTrack('cam-2');
+            const stream2 = makeStream('stream-2', [track2]);
+
+            // @ts-ignore - accessing private method for testing
+            client.initVideo = jest.fn().mockImplementation(async () => {
+                // @ts-ignore - accessing private property for testing
+                client.localVideoStream = stream2;
+            });
+
+            await client.startVideo();
+
+            // The sender is reused (no second addTrack) and the new track replaces the
+            // previously held one, keyed by the tracked ID.
+            expect(peer.addTrack).toHaveBeenCalledTimes(1);
+            expect(peer.replaceTrack).toHaveBeenLastCalledWith('cam-1', track2);
+
+            // @ts-ignore - accessing private property for testing
+            expect(client.videoSenderTrackID).toBe('cam-2');
+        });
+
+        it('keeps the sender track ID in sync after a device switch so a later stopVideo targets the right sender (MM-68796 regression)', async () => {
+            const {peer} = setupPeer();
+
+            const oldTrack = makeVideoTrack('cam-1');
+            const oldStream = makeStream('stream-1', [oldTrack]);
+
+            // @ts-ignore - accessing private property for testing
+            client.localVideoStream = oldStream;
+
+            await client.startVideo();
+
+            // @ts-ignore - accessing private property for testing
+            expect(client.videoSenderTrackID).toBe('cam-1');
+
+            // Switching the camera replaces the sender track, which re-keys the peer's
+            // senders map. Before the fix, videoSenderTrackID kept pointing at the old ID,
+            // and the subsequent stopVideo threw "senders for track not found".
+            const newTrack = makeVideoTrack('cam-2');
+            const newStream = makeStream('stream-2', [newTrack]);
+            Object.defineProperty(navigator, 'mediaDevices', {
+                value: {getUserMedia: jest.fn().mockResolvedValue(newStream)},
+                writable: true,
+                configurable: true,
+            });
+
+            await client.setVideoInputDevice({deviceId: 'cam-2-device', label: 'Camera 2'} as MediaDeviceInfo);
+
+            expect(oldTrack.stop).toHaveBeenCalledTimes(1);
+            expect(peer.replaceTrack).toHaveBeenLastCalledWith('cam-1', newTrack);
+
+            // @ts-ignore - accessing private property for testing
+            expect(client.videoSenderTrackID).toBe('cam-2');
+
+            client.stopVideo();
+
+            // The detach now targets the current sender track, not the stale one.
+            expect(peer.replaceTrack).toHaveBeenLastCalledWith('cam-2', null);
+            expect(newTrack.stop).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -376,6 +376,18 @@ describe('CallsClient', () => {
     });
 
     describe('video track management', () => {
+        const originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices');
+
+        afterEach(() => {
+            // Restore navigator.mediaDevices in case a test replaced it, to avoid polluting other tests.
+            if (originalMediaDevices) {
+                Object.defineProperty(navigator, 'mediaDevices', originalMediaDevices);
+            } else {
+                // @ts-ignore - cleaning up a mock added by a test
+                delete navigator.mediaDevices;
+            }
+        });
+
         const makeVideoTrack = (id: string) => ({
             id,
             kind: 'video',
@@ -441,16 +453,42 @@ describe('CallsClient', () => {
 
             client.stopVideo();
 
-            // Detaches the track from the sender without tearing it down.
+            // Detaches the track from the sender (which is kept alive) before stopping it.
             expect(peer.replaceTrack).toHaveBeenCalledWith('cam-1', null);
 
-            // Crucially, the device is fully stopped (not just disabled) so the LED turns off.
+            // Crucially, the device is fully stopped (not just disabled) so the LED turns off,
+            // and an 'ended' event is dispatched so listeners can react.
             expect(track.stop).toHaveBeenCalledTimes(1);
+            expect(track.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({type: 'ended'}));
 
             // The stream is released so the next startVideo re-initializes it.
             // @ts-ignore - accessing private property for testing
             expect(client.localVideoStream).toBeNull();
             expect(ws.send).toHaveBeenCalledWith('video_off');
+        });
+
+        it('stopVideo stops and clears the background-blur segmenter when active', () => {
+            setupPeer();
+            const track = makeVideoTrack('cam-1');
+            track.enabled = true;
+            const stream = makeStream('stream-1', [track]);
+            const segmenter = {stop: jest.fn()};
+
+            // @ts-ignore - accessing private property for testing
+            client.localVideoStream = stream;
+
+            // @ts-ignore - accessing private property for testing
+            client.videoSenderTrackID = 'cam-1';
+
+            // @ts-ignore - accessing private property for testing
+            client.segmenter = segmenter;
+
+            client.stopVideo();
+
+            expect(segmenter.stop).toHaveBeenCalledTimes(1);
+
+            // @ts-ignore - accessing private property for testing
+            expect(client.segmenter).toBeNull();
         });
 
         it('re-enables video after a stop by replacing the sender track with a freshly acquired one', async () => {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -807,6 +807,7 @@ export default class CallsClient extends EventEmitter {
                 // videoTrackAdded must be true if the track is enabled.
                 logDebug('replacing track to peer', newTrack.id);
                 this.peer.replaceTrack(videoTrack.id, newTrack);
+
                 // Keep track of the new ID the sender holds so a later stopVideo
                 // can replace it (the peer re-keys its senders map by track ID).
                 this.videoSenderTrackID = newTrack.id;

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -64,6 +64,12 @@ export default class CallsClient extends EventEmitter {
     public currentVideoInputDevice: MediaDeviceInfo | null = null;
     private voiceTrackAdded: boolean;
     private videoTrackAdded: boolean;
+
+    // ID of the track currently held by the video sender. The sender is kept
+    // alive for the lifetime of the call (to avoid renegotiation), but the
+    // underlying track is stopped and recreated as video is toggled off/on, so
+    // we track the current ID to be able to replace it.
+    private videoSenderTrackID = '';
     private streams: MediaStream[];
     private stream: MediaStream | null;
     private audioDevices: MediaDevices;
@@ -92,6 +98,7 @@ export default class CallsClient extends EventEmitter {
         this.currentVideoInputDevice = null;
         this.voiceTrackAdded = false;
         this.videoTrackAdded = false;
+        this.videoSenderTrackID = '';
         this.streams = [];
         this.remoteVoiceTracks = [];
         this.remoteVideoTracks = [];
@@ -800,6 +807,9 @@ export default class CallsClient extends EventEmitter {
                 // videoTrackAdded must be true if the track is enabled.
                 logDebug('replacing track to peer', newTrack.id);
                 this.peer.replaceTrack(videoTrack.id, newTrack);
+                // Keep track of the new ID the sender holds so a later stopVideo
+                // can replace it (the peer re-keys its senders map by track ID).
+                this.videoSenderTrackID = newTrack.id;
                 this.emit('localVideoStream', newStream);
             } else {
                 this.videoTrackAdded = false;
@@ -1119,7 +1129,6 @@ export default class CallsClient extends EventEmitter {
         }
 
         let localVideoTrack = this.localVideoStream.getVideoTracks()[0];
-        const localVideoTrackID = localVideoTrack.id;
         localVideoTrack.enabled = true;
 
         const bgBlurData = getBgBlurData();
@@ -1129,7 +1138,10 @@ export default class CallsClient extends EventEmitter {
         }
 
         if (this.videoTrackAdded) {
-            await this.peer.replaceTrack(localVideoTrackID, localVideoTrack);
+            // The sender already exists from a previous startVideo. Its track may
+            // currently be null (video was stopped) or a now-stopped track, so we
+            // replace whatever it holds with the freshly initialized one.
+            await this.peer.replaceTrack(this.videoSenderTrackID, localVideoTrack);
         } else {
             await this.peer.addTrack(localVideoTrack, this.localVideoStream, {encodings: this.defaultVideoTrackEncodings});
             if (this.config.enableAV1 && this.av1Codec) {
@@ -1141,6 +1153,7 @@ export default class CallsClient extends EventEmitter {
             }
             this.videoTrackAdded = true;
         }
+        this.videoSenderTrackID = localVideoTrack.id;
 
         this.emit('localVideoStream', this.localVideoStream);
 
@@ -1159,11 +1172,26 @@ export default class CallsClient extends EventEmitter {
             return;
         }
 
-        const localVideoTrack = this.localVideoStream.getVideoTracks()[0];
-
+        // Detach the track from the sender so we stop transmitting video. We keep
+        // the sender itself around (videoTrackAdded stays true) to avoid a
+        // renegotiation when video is started again.
         // @ts-ignore: we actually mean (and need) to pass null here
-        this.peer.replaceTrack(localVideoTrack.id, null);
-        localVideoTrack.enabled = false;
+        this.peer.replaceTrack(this.videoSenderTrackID, null);
+
+        // Fully stop and release the camera device so its hardware indicator (LED)
+        // turns off. Simply disabling the track (enabled = false) keeps the device
+        // open and the LED lit (MM-68796). The stream (and its segmenter, if
+        // background blur is enabled) is released here and re-initialized on the
+        // next startVideo. When blur is active the stream holds the canvas track,
+        // whose 'ended' event stops the underlying camera track.
+        this.segmenter?.stop();
+        this.segmenter = null;
+        for (const track of this.localVideoStream.getVideoTracks()) {
+            track.stop();
+            track.dispatchEvent(new Event('ended'));
+        }
+        this.localVideoStream = null;
+
         this.emit('video_off');
         this.ws.send('video_off');
     }


### PR DESCRIPTION
## Summary

Fixes [MM-68796](https://mattermost.atlassian.net/browse/MM-68796): the camera's hardware indicator LED stays lit after a user toggles video off during a call.

`stopVideo` only disabled the local video track (`track.enabled = false`) and replaced it with null on the sender. Disabling a track stops transmission but does **not** release the underlying camera device, so the browser keeps it open and the LED stays on for the rest of the call.

## Changes

- `stopVideo` now stops the local video track (and its background-blur segmenter, when active) and releases the stream, so the camera device is freed and the LED turns off. The stream is re-initialized on the next `startVideo`.
- Because the camera track is now destroyed on stop, re-enabling acquires a fresh track with a new ID. To keep the existing no-renegotiation design (a single persistent RTP sender for the call), a `videoSenderTrackID` field tracks the ID the sender currently holds so it can be replaced across video toggles **and** input-device switches. The peer keys its `senders` map by track ID, so this ID is kept in sync everywhere the sender's track is swapped (`startVideo`, `setVideoInputDevice`, `stopVideo`).

The second point also fixes a `senders for track not found` exception that occurred when stopping video after a camera input-device change (e.g. on Safari, which fires a `devicechange` after permissions populate device labels).

## Why remote video is unaffected

`replaceTrack` reuses the same sender/SSRC and does not renegotiate, so no new `OnTrack` fires on the SFU and its existing track classification persists regardless of the (now-changing) local stream ID. This is the same mechanism `setVideoInputDevice` already relies on.

## Test Manually

1. Join a call, enable video — confirm the camera LED turns on.
2. Toggle video off — the LED should now turn off (previously stayed lit).
3. Toggle video back on — video resumes.
4. Switch camera input device, then stop video — no error, LED off.
5. Toggle background blur on, then stop video — camera released.

Verified on both Chrome and Safari.