### PR TITLE
[MM-69076] Fix /call logs in DM channels and add margin to upload size limit

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -28,6 +28,12 @@ import (
 
 const requestBodyMaxSizeBytes = 1024 * 1024 // 1MB
 
+// logsUploadMaxSizeBytes is larger than the client's MAX_ACCUMULATED_LOG_SIZE
+// (1MB) to leave margin for JSON-escaping overhead: newlines, quotes and
+// control chars in the log text inflate the encoded body beyond the raw log
+// size, and the JSON wrapper fields add a little more on top.
+const logsUploadMaxSizeBytes = 2 * 1024 * 1024 // 2MB
+
 func (p *Plugin) handleGetVersion(w http.ResponseWriter, _ *http.Request) {
 	p.mut.RLock()
 	defer p.mut.RUnlock()
@@ -586,7 +592,7 @@ func (p *Plugin) handleUploadLogsToBot(w http.ResponseWriter, r *http.Request) {
 		ChannelID string `json:"channel_id"`
 		TeamID    string `json:"team_id"`
 	}
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, requestBodyMaxSizeBytes)).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, logsUploadMaxSizeBytes)).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}

--- a/server/logs_test.go
+++ b/server/logs_test.go
@@ -130,4 +130,51 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 		require.JSONEq(t, "{}", w.Body.String())
 	})
+
+	t.Run("accepts logs above the old 1MB body limit, leaving margin for JSON escaping", func(t *testing.T) {
+		p, mockAPI := newPlugin()
+		defer mockAPI.AssertExpectations(t)
+
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		// 1.5MB of log text: comfortably over the client's 1MB cap once
+		// JSON-escaping overhead is added, yet under the upload limit. This
+		// used to trip the old 1MB server body limit and 400.
+		logs := strings.Repeat("a", 1536*1024)
+
+		mockAPI.On("GetDirectChannel", userID, botID).Return(&model.Channel{Id: dmChannelID}, nil).Once()
+		mockAPI.On("UploadFile", mock.Anything, dmChannelID, mock.Anything).Return(&model.FileInfo{Id: fileID}, nil).Once()
+		mockAPI.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID, ChannelId: dmChannelID, FileIds: []string{fileID}}, nil).Once()
+		mockAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: teamName}, nil).Once()
+		mockAPI.On("GetConfig").Return(&model.Config{
+			ServiceSettings: model.ServiceSettings{SiteURL: model.NewPointer(siteURL)},
+		}).Once()
+		mockAPI.On("SendEphemeralPost", userID, mock.Anything).Return(&model.Post{}).Once()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       logs,
+			"channel_id": originChannelID,
+			"team_id":    teamID,
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("rejects bodies beyond the upload size limit", func(t *testing.T) {
+		p, _ := newPlugin()
+		w := httptest.NewRecorder()
+		// A logs string larger than logsUploadMaxSizeBytes (2MB) on its own.
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       strings.Repeat("a", 3*1024*1024),
+			"channel_id": originChannelID,
+			"team_id":    teamID,
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }

--- a/webapp/src/slash_commands.tsx
+++ b/webapp/src/slash_commands.tsx
@@ -4,6 +4,7 @@
 import {CommandArgs} from '@mattermost/types/integrations';
 import {getChannel as getChannelAction} from 'mattermost-redux/actions/channels';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {ActionResult} from 'mattermost-redux/types/actions';
 import {defineMessage} from 'react-intl';
@@ -183,6 +184,12 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
             return {error: {message: 'No call logs available'}};
         }
 
+        // In DM/GM channels args.team_id is empty (there is no team), so fall
+        // back to the current team. The server needs a valid team to build the
+        // permalink to the @calls bot DM; the permalink resolves regardless of
+        // the team name in the URL as long as the user is a member of it.
+        const teamID = args.team_id || getCurrentTeamId(store.getState());
+
         try {
             await RestClient.fetch(
                 `${getPluginPath()}/logs/upload`,
@@ -191,7 +198,7 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
                     body: JSON.stringify({
                         logs: allLogs,
                         channel_id: args.channel_id,
-                        team_id: args.team_id,
+                        team_id: teamID,
                     }),
                     headers: {'Content-Type': 'application/json'},
                 },


### PR DESCRIPTION
## Summary

Fixes [MM-69076](https://mattermost.atlassian.net/browse/MM-69076). Running `/call logs` in a DM (or GM) channel failed with an HTTP 400 and the logs were never uploaded. Also fixes a related latent issue where the client and server log-upload size limits collided.

## Issue 1 — `/call logs` fails in DM channels

The webapp's `logs` command handler sent `team_id: args.team_id` with no fallback. In a DM/GM there is no team, so `args.team_id` is empty and the server's `handleUploadLogsToBot` rejected the request via `model.IsValidId(req.TeamID)`.

Fall back to the current team when `args.team_id` is empty:

```ts
const teamID = args.team_id || getCurrentTeamId(store.getState());
```

`getCurrentTeamId` is used rather than `channel.team_id` because the latter is also empty for DMs. The server uses the team to build the permalink to the @calls bot DM, and Mattermost permalinks resolve regardless of the team name in the URL as long as the user is a member of that team.

## Issue 2 — log upload size limit lacks margin for JSON escaping

The client caps the accumulated log buffer at 1MB (`MAX_ACCUMULATED_LOG_SIZE`) and the server capped the entire request body at a coincidental 1MB. JSON-escaping the log text (newlines, quotes, control chars) plus the wrapper fields inflates the encoded body beyond 1MB, so a near-cap buffer tripped `MaxBytesReader`, the JSON decode failed, and the server returned `400 "Invalid request body"` — logs silently lost.

Added a dedicated 2MB limit for the upload handler (`logsUploadMaxSizeBytes`) to leave margin for escaping overhead, while leaving the general `requestBodyMaxSizeBytes` at 1MB for other handlers.

## Testing

- Added a server test confirming a payload above the old 1MB limit now succeeds, and one confirming bodies beyond the new limit are still rejected.
- Manually reproduced: `/call logs` in a DM now uploads to the @calls bot DM and the ephemeral permalink resolves.

## Steps to reproduce (Issue 1)

1. Start/join a 1:1 call in a DM channel.
2. Run `/call logs`.
3. Before: "Failed to upload logs". After: logs uploaded to the @calls bot DM.