### PR TITLE
[MM-69110] Fix low-res screen share by disabling adaptiveStream/dynacast

### DIFF
--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -75,8 +75,18 @@ export default class CallClient extends EventEmitter {
 
         const room = new Room({
             audioCaptureDefaults: AUDIO_CAPTURE_DEFAULTS,
-            dynacast: true,
-            adaptiveStream: true,
+
+            // adaptiveStream/dynacast are disabled so screen shares always send
+            // full resolution (MM-69110). adaptiveStream picks a subscriber's
+            // layer from the rendered element size, but it observes via
+            // ResizeObserver in the window that owns the track — it cannot
+            // measure the popout's <video> (separate window) and only ever sees
+            // the tiny widget preview, so it pinned everyone to the lowest
+            // simulcast layer (540p). Screen share wants sharp text regardless
+            // of pane size, so element-driven adaptation is the wrong tradeoff
+            // here. dynacast is off too so the high layer is always encoded.
+            dynacast: false,
+            adaptiveStream: false,
             disconnectOnPageLeave: true,
             publishDefaults: {
                 dtx: true,


### PR DESCRIPTION
## Summary

Screen shares in Calls v2 (LiveKit) rendered at a downscaled resolution (960×540) on remote clients and never ramped up to full quality, even in a fullscreen popout. This was a regression from v1 (RTCD), which sent a fixed full-resolution stream.

**Root cause:** `adaptiveStream` sizes each subscriber's simulcast layer from the rendered `<video>` element, observed via a `ResizeObserver`. But Calls renders the expanded/popout view in a **separate browser window** while the LiveKit `Room`/track live in the opener window. The observer runs in the opener's document and **cannot measure the popout's `<video>` across the window boundary** — it only ever sees the small main-window widget preview (~243×139), so it demanded the lowest simulcast layer (540p) and `dynacast` parked the high layer. For screen share, matching resolution to display size is also the wrong tradeoff: you want sharp text regardless of pane size.

**Fix:** Disable `adaptiveStream` and `dynacast` in the `Room` constructor so screen shares always send full resolution, matching v1 behavior.

## Diagnosis

Confirmed via WebRTC stats and element probes:
- Sender: capture `1920×1080@30`, but only the low layer (`rid: q`, `960×540`) encoded; high layer paused; `qualityLimitationReason: none` (not CPU/bandwidth limited — purely a demand cap).
- Popout receiver: `{client: 1280×720, intrinsic: 960×540}` — element box larger than the served stream.
- Main-window widget: `{client: 243×139, intrinsic: 960×540}` — the only element adaptiveStream could observe, dragging everyone to the floor layer.

`track.attach()`-based rendering was trialled to feed adaptiveStream the element size, but it cannot work across the popout's separate window (rendering worked; size observation did not).

## Tradeoff

Camera-tile video also loses adaptive downscaling (more upstream bandwidth in large video calls). Accepted short-term — screen share is the reported bug and this matches v1. A future option is rendering the popout in-window so adaptiveStream can observe it, or a screen-share-exempt adaptiveStream (no clean per-track LiveKit support today).

## Testing

- Manually verified full-resolution screen share in the popout at fullscreen.
- Widget preview, screen-share audio, stop/restart, and sharer-switch all behave normally.
- `eslint` clean on the changed file.