### PR TITLE
[MM-69107] Drive host lower-hand and mute through the LiveKit admin API

### DIFF
--- a/server/host_controls.go
+++ b/server/host_controls.go
@@ -94,10 +94,11 @@ func (p *Plugin) hostMuteParticipant(requesterID, channelID, sessionID string) e
 		return ErrNotInCall
 	}
 
-	if !ust.Unmuted {
-		return nil
-	}
-
+	// NB: we deliberately do not gate on server-side mute state. Under LiveKit
+	// (v2) mute lives in the track state; the server's session.Unmuted is
+	// vestigial (never updated post-migration, see MM-69116) and would always
+	// read false here. livekitMuteParticipant is idempotent — it no-ops if the
+	// participant has no unmuted mic track.
 	if err := p.livekitMuteParticipant(channelID, composeLivekitIdentity(ust.UserID, sessionID)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
 		p.LogError("hostMuteParticipant: failed to mute participant via LiveKit",
 			"channelID", channelID, "sessionID", sessionID, "err", err.Error())
@@ -127,20 +128,26 @@ func (p *Plugin) hostMuteAllParticipants(requesterID, channelID string) error {
 		}
 	}
 
-	// Unmute anyone muted (who is not the host/requester).
-	// If there are no unmuted sessions, return without doing anything.
+	// Mute every participant except the host/requester. We deliberately do not
+	// gate on server-side mute state: under LiveKit (v2) mute lives in the track
+	// state and the server's session.Unmuted is vestigial (never updated
+	// post-migration, see MM-69116) — it would read false for everyone and skip
+	// the whole loop. livekitMuteParticipant is idempotent, so muting an
+	// already-muted participant is a harmless no-op.
 	for id, s := range state.sessions {
-		if s.Unmuted && s.UserID != requesterID {
-			if err := p.livekitMuteParticipant(channelID, composeLivekitIdentity(s.UserID, id)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
-				p.LogError("hostMuteAllParticipants: failed to mute participant via LiveKit",
-					"channelID", channelID, "sessionID", id, "err", err.Error())
-			}
-
-			p.publishWebSocketEvent(wsEventHostMute, map[string]interface{}{
-				"channel_id": channelID,
-				"session_id": id,
-			}, &WebSocketBroadcast{UserID: s.UserID, ReliableClusterSend: true})
+		if s.UserID == requesterID {
+			continue
 		}
+
+		if err := p.livekitMuteParticipant(channelID, composeLivekitIdentity(s.UserID, id)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
+			p.LogError("hostMuteAllParticipants: failed to mute participant via LiveKit",
+				"channelID", channelID, "sessionID", id, "err", err.Error())
+		}
+
+		p.publishWebSocketEvent(wsEventHostMute, map[string]interface{}{
+			"channel_id": channelID,
+			"session_id": id,
+		}, &WebSocketBroadcast{UserID: s.UserID, ReliableClusterSend: true})
 	}
 
 	return nil
@@ -200,8 +207,20 @@ func (p *Plugin) hostLowerParticipantHand(requesterID, channelID, sessionID stri
 		return ErrNotInCall
 	}
 
-	if ust.RaisedHand == 0 {
-		return nil
+	// NB: we deliberately do not gate on server-side raised-hand state. Under
+	// LiveKit (v2) the hand is a participant attribute the client owns; the
+	// server's session.RaisedHand is vestigial (never updated post-migration,
+	// see MM-69116) and would always read 0 here. Clearing an already-empty
+	// attribute is a harmless no-op.
+	//
+	// Clear the raised-hand attribute directly on the LiveKit server. This is the
+	// authoritative path: it propagates to every participant via
+	// ParticipantAttributesChanged. The WS event below still goes to the target
+	// client to surface the "host lowered your hand" notice (and acts as a fallback
+	// when LiveKit is not configured).
+	if err := p.livekitLowerParticipantHand(channelID, composeLivekitIdentity(ust.UserID, sessionID)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
+		p.LogError("hostLowerParticipantHand: failed to lower hand via LiveKit",
+			"channelID", channelID, "sessionID", sessionID, "err", err.Error())
 	}
 
 	p.publishWebSocketEvent(wsEventHostLowerHand, map[string]interface{}{

--- a/server/livekit_admin.go
+++ b/server/livekit_admin.go
@@ -16,6 +16,13 @@ import (
 const userIDSessionIDSeparator = "___"
 const livekitAPITimeout = 5 * time.Second
 
+// livekitAttributeRaisedHand is the LiveKit participant attribute key that
+// carries raised-hand state. It mirrors CALL_ATTRIBUTES.RAISED_HAND on the
+// webapp; hand state is derived purely from this attribute, so server-side
+// host controls must mutate it directly rather than relying on a client
+// round-trip.
+const livekitAttributeRaisedHand = "raised_hand"
+
 var errLiveKitNotConfigured = errors.New("LiveKit is not configured")
 
 func composeLivekitIdentity(userID, sessionID string) string {
@@ -64,6 +71,31 @@ func (p *Plugin) livekitMuteParticipant(room, identity string) error {
 		}); err != nil {
 			return fmt.Errorf("livekit MutePublishedTrack: %w", err)
 		}
+	}
+	return nil
+}
+
+// livekitLowerParticipantHand clears the participant's raised-hand attribute on
+// the server. Setting the attribute to an empty string deletes it, which fires
+// RoomEvent.ParticipantAttributesChanged on every connected client, driving the
+// hand-lowered UI for all participants — the same propagation path as the user
+// lowering their own hand, but server-authoritative and not dependent on a WS
+// round-trip to the target client.
+func (p *Plugin) livekitLowerParticipantHand(room, identity string) error {
+	client, err := p.getLiveKitRoomClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), livekitAPITimeout)
+	defer cancel()
+
+	if _, err := client.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
+		Room:       room,
+		Identity:   identity,
+		Attributes: map[string]string{livekitAttributeRaisedHand: ""},
+	}); err != nil {
+		return fmt.Errorf("livekit UpdateParticipant: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes the host **lower-hand** and **mute / mute-others** controls under LiveKit (v2), which were wired end-to-end but silently did nothing.

**Root cause:** all three gated on the server-side `session.RaisedHand` / `session.Unmuted` fields. The v2 `CallClient` moved hand state onto a LiveKit participant attribute and mute onto the track state, and it no longer sends the raise-hand / mute WS messages. So those server fields stay frozen at their join defaults (`RaisedHand=0`, `Unmuted=false`) and the guards always short-circuited:

- `hostLowerParticipantHand` — `if ust.RaisedHand == 0 { return nil }` always true
- `hostMuteParticipant` — `if !ust.Unmuted { return nil }` always true (so individual mute was also fully broken, not just "unverified")
- `hostMuteAllParticipants` — `if s.Unmuted && …` never true, so the whole loop was skipped

**Fix:** drop the vestigial guards and act unconditionally through the LiveKit admin API, which is idempotent:

- Lower-hand: new `livekitLowerParticipantHand` clears the `raised_hand` attribute via `UpdateParticipant` (empty string deletes it), mirroring the client's own `unraiseHand()`.
- Mute / mute-others: force-mute the mic track via the existing `livekitMuteParticipant` (no-ops if there is no unmuted mic track).

LiveKit then propagates the change to **every** participant — including observers — via `ParticipantAttributesChanged` / `TrackMuted`, which is the reliable observer-sync path. The targeted host-control WS events (`host_lower_hand`, `host_mute`) are retained as client-side UX notices and as a fallback when LiveKit is not configured.

## Relationship to other tickets

- **Depends on** #1204 (MM-68565/MM-68566) for the client-side LiveKit hand attribute — already on `v2`.
- The broader removal of the vestigial `Unmuted`/`RaisedHand`/`Video` server plumbing (columns, `UpdateCallSession`, dead WS handlers) is tracked separately in **MM-69116**; this PR only stops *relying* on those fields.
- Full host-control UI is being wired in **MM-68567**; some controls aren't reachable from the UI until that lands.

## Other host controls (unchanged)

`remove`, `stop screen share`, `make host`, and `end call` were not affected by the vestigial-state bug and are left as-is. Stop-screen-share relies on the Calls WebSocket round-trip to the target (no LiveKit fallback) by design.

## Testing

Build / vet / gofmt clean. Manual two-user end-to-end verification pending (the acceptance signal for this ticket).