### PR TITLE
[MM-69144] Enable call recording for Calls v2 (LiveKit)

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -469,7 +469,12 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Require the requesting user to have read permissions on the requested channel.
-	if !p.API.HasPermissionToChannel(requestingUserID, requestingChannelID, model.PermissionReadChannel) {
+	// The recording/transcribing bot is exempt: it's never a channel member, so it
+	// can't satisfy this check. Its authorization is instead established below by
+	// owning a valid call session tied to the active call, which it can only obtain
+	// through the job-gated bot join.
+	if requestingUserID != p.getBotID() &&
+		!p.API.HasPermissionToChannel(requestingUserID, requestingChannelID, model.PermissionReadChannel) {
 		res.Err = "Forbidden"
 		res.Code = http.StatusForbidden
 		return
@@ -511,6 +516,12 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bot (recorder/transcriber) jobs may reach LiveKit at a different address than
+	// browser clients do, so hand them the bot-specific signaling URL if configured.
+	if requestingUserID == p.getBotID() {
+		lkURL = cfg.getLiveKitURLForBot()
+	}
+
 	user, appErr := p.API.GetUser(requestingUserID)
 	if appErr != nil {
 		res.Err = appErr.Error()
@@ -523,7 +534,17 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 		RoomJoin: true,
 		Room:     requestingChannelID,
 	}
-	grant.SetCanUpdateOwnMetadata(true)
+	if requestingUserID == p.getBotID() {
+		// The recording/transcribing bot only consumes media — it never publishes
+		// tracks or data, and never updates its own metadata (no raised hand).
+		// Restrict its grant to subscribe-only so the bot token can't be used to
+		// inject audio, video, or data into the call.
+		grant.SetCanPublish(false)
+		grant.SetCanPublishData(false)
+		grant.SetCanSubscribe(true)
+	} else {
+		grant.SetCanUpdateOwnMetadata(true)
+	}
 	at.SetVideoGrant(grant).
 		SetIdentity(composeLivekitIdentity(requestingUserID, requestingSessionID)).
 		SetName(user.Id).

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -318,6 +318,19 @@ func (c *configuration) getLiveKitURL() string {
 	return c.LiveKitURL
 }
 
+// getLiveKitURLForBot returns the LiveKit signaling URL handed to bot
+// (recorder/transcriber) job containers. They run in an environment that may not
+// share the browser's network view of LiveKit (e.g. host.docker.internal vs
+// localhost in local dev), so MM_CALLS_RECORDER_LIVEKIT_URL can override the URL
+// returned to bot token requests. Falls back to the standard URL when unset,
+// which is the common production case where one URL is reachable by everyone.
+func (c *configuration) getLiveKitURLForBot() string {
+	if url := os.Getenv("MM_CALLS_RECORDER_LIVEKIT_URL"); url != "" {
+		return url
+	}
+	return c.getLiveKitURL()
+}
+
 func (c *configuration) getJobServiceURL() string {
 	if url := os.Getenv("MM_CALLS_JOB_SERVICE_URL"); url != "" {
 		return url

--- a/server/recording_api.go
+++ b/server/recording_api.go
@@ -73,20 +73,12 @@ func (p *Plugin) recJobTimeoutChecker(callID, jobID string) {
 	}
 }
 
-// errRecordingNotSupported and errTranscriptionNotSupported gate the
-// recording/transcription entry points while the recorder/transcriber are
-// being migrated to LiveKit. The orchestration logic below the gates is kept
-// intact so it can be re-enabled by deleting the guard.
-var (
-	errRecordingNotSupported     = fmt.Errorf("recording is not yet supported on this version")
-	errTranscriptionNotSupported = fmt.Errorf("transcription is not yet supported on this version")
-)
+// errTranscriptionNotSupported gates the transcription entry points while the
+// transcriber is being migrated to LiveKit. The orchestration logic below the
+// gate is kept intact so it can be re-enabled by deleting the guard.
+var errTranscriptionNotSupported = fmt.Errorf("transcription is not yet supported on this version")
 
 func (p *Plugin) startRecordingJob(state *callState, callID, userID string) (rst *JobStateClient, rcode int, rerr error) {
-	if true { // LiveKit migration gate; delete to restore recording
-		return nil, http.StatusNotImplemented, errRecordingNotSupported
-	}
-
 	if state.Recording != nil && state.Recording.EndAt == 0 {
 		return nil, http.StatusForbidden, fmt.Errorf("recording already in progress")
 	}
@@ -193,10 +185,6 @@ func (p *Plugin) startRecordingJob(state *callState, callID, userID string) (rst
 }
 
 func (p *Plugin) stopRecordingJob(state *callState, callID string) (rst *JobStateClient, rcode int, rerr error) {
-	if true { // LiveKit migration gate; delete to restore recording
-		return nil, http.StatusNotImplemented, errRecordingNotSupported
-	}
-
 	if state.Recording == nil || state.Recording.EndAt != 0 {
 		return nil, http.StatusForbidden, fmt.Errorf("no recording in progress")
 	}

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -131,6 +131,19 @@ export default class CallClient extends EventEmitter {
         return this.disconnected;
     }
 
+    // Back-compat aliases for the calls-recorder, which polls
+    // window.callsClient.connected and .closed to decide when to start/stop the
+    // ffmpeg capture. The recorder is media-stack-agnostic and shared across
+    // versions, so we satisfy its existing contract here rather than couple it to
+    // the v2 LiveKit naming.
+    public get connected(): boolean {
+        return this.isConnected;
+    }
+
+    public get closed(): boolean {
+        return this.isDisconnected;
+    }
+
     // _e2eForceWebsocketClose closes the plugin WebSocket without telling the
     // client to stay closed, so reconnect logic runs — used by E2E tests to
     // exercise the WS-reconnect path.


### PR DESCRIPTION
## Summary

Re-enables call recording on the Calls v2 (LiveKit) line. Jira: [MM-69144](https://mattermost.atlassian.net/browse/MM-69144).

The chromium+ffmpeg `calls-recorder` is media-stack-agnostic — it loads the standalone recording page in headless Chromium and screen-grabs it, so it works regardless of the underlying media stack as long as the page can connect to the call. Enabling v2 recording therefore came down to closing a handful of server/client gaps the LiveKit migration introduced (no recorder changes, and deliberately not LiveKit Egress — the custom recorder captures the real standalone product UI).

## Changes

- **`server/recording_api.go`** — Remove the `if true` LiveKit-migration gates in `startRecordingJob`/`stopRecordingJob` and the now-unused `errRecordingNotSupported`. (Transcription gates intentionally left in place — separate work.)
- **`server/api.go` (`handleGetLiveKitToken`)** — Exempt the recording/transcribing bot from the channel read-permission check. The bot is never a channel member, so it can't satisfy that check; its authorization instead comes from owning a valid call session tied to the active call, obtainable only via the job-gated bot join.
- **`server/api.go` + `server/configuration.go`** — Add `getLiveKitURLForBot()` reading `MM_CALLS_RECORDER_LIVEKIT_URL` (falls back to the standard URL), returned to bot token requests. The recorder container may reach LiveKit at a different address than browser clients (e.g. `host.docker.internal` vs `localhost` in local dev); in production one URL is typically reachable by everyone.
- **`server/api.go` (`handleGetLiveKitToken`)** — Restrict the bot's LiveKit grant to subscribe-only (`CanPublish=false`, `CanPublishData=false`, `CanSubscribe=true`, no `CanUpdateOwnMetadata`). The recorder only consumes media, so a leaked bot token can't inject audio/video/data into a live call. Human clients are unchanged.
- **`webapp/src/clients/call/call_client.ts`** — Restore back-compat `connected`/`closed` getters aliasing `isConnected`/`isDisconnected`. The version-agnostic recorder polls `window.callsClient.connected`/`.closed`; v2 renamed these, so its readiness poll never fired.

## Testing

Verified end-to-end locally: bot joins → LiveKit token success → connected → ready event fires → ffmpeg runs → mp4 posted with audio + screen share. Tested both before and after the subscribe-only grant restriction. Stop via the recording button for a graceful finalize/upload.

## Out of scope / follow-ups

- Mute/raised-hand/reaction indicators are wrong in the recording (and the desktop widget) because the standalone bundles never got the LiveKit-owned-state bridge — tracked separately as [MM-69148](https://mattermost.atlassian.net/browse/MM-69148).
- Confirm full-res screen share to the recorder; verify the host-ends-call (ROOM_DELETED) path finalizes gracefully.
- Transcription remains gated.