### PR TITLE
[MM-69148] Wire LiveKit-owned mute/speaking/raised-hand state into standalone bundles

### DIFF
--- a/standalone/src/index.ts
+++ b/standalone/src/index.ts
@@ -14,6 +14,7 @@ import {
     CallJobStateData,
     CallStartData,
     CallStateData,
+    EmojiData,
     EmptyData,
     HelloData,
     HostControlLowerHand,
@@ -22,13 +23,9 @@ import {
     UserDismissedNotification,
     UserJoinedData,
     UserLeftData,
-    UserMutedUnmutedData,
-    UserRaiseUnraiseHandData,
-    UserReactionData,
     UserRemovedData,
     UserScreenOnOffData,
     UserVideoOnOffData,
-    UserVoiceOnOffData,
     WebsocketEventData,
 } from '@mattermost/calls-common/lib/types';
 import {WebSocketMessage} from '@mattermost/client/websocket';
@@ -47,12 +44,14 @@ import {
 } from 'plugin/log';
 import {pluginId} from 'plugin/manifest';
 import reducer from 'plugin/reducers';
+import {userLoweredHand, userMuted, userRaisedHand, usersVoiceActivityChanged, userUnmuted} from 'plugin/state/session/actions';
 import {Store} from 'plugin/types/mattermost-webapp';
 import {
     getWSConnectionURL,
     setCallsGlobalCSSVars,
 } from 'plugin/utils';
 import {
+    dispatchReaction,
     handleCallEnd,
     handleCallHostChanged,
     handleCallJobState,
@@ -65,18 +64,11 @@ import {
     handleUserDismissedNotification,
     handleUserJoined,
     handleUserLeft,
-    handleUserMuted,
-    handleUserRaisedHand,
-    handleUserReaction,
     handleUserRemovedFromChannel,
     handleUserScreenOff,
     handleUserScreenOn,
-    handleUserUnmuted,
-    handleUserUnraisedHand,
     handleUserVideoOff,
     handleUserVideoOn,
-    handleUserVoiceOff,
-    handleUserVoiceOn,
 } from 'plugin/websocket_handlers';
 import {Reducer} from 'redux';
 import {CurrentCallDataDefault} from 'src/types/types';
@@ -120,6 +112,60 @@ function connectCall(
         // Subscribe to raw plugin-WS events BEFORE connect() so 'hello' isn't missed.
         callClient.on(CALL_EVENT.WEBSOCKET_EVENT, wsEventHandler);
 
+        // Bridge LiveKit-owned per-participant state into the store. After the
+        // LiveKit migration mute/speaking/raised-hand/reactions no longer travel
+        // over the plugin WebSocket; CallClient re-emits them as CALL_EVENTs. The
+        // main webapp wires these in its own index.tsx and the popout reuses the
+        // opener's client — the standalone bundles (widget + recording) need the
+        // same bridge here so their indicators reflect real, live state.
+        callClient.on(CALL_EVENT.MUTE, (sessionID: string, userID: string) => {
+            store.dispatch(userMuted(callClient.channelID, sessionID, userID));
+        });
+        callClient.on(CALL_EVENT.UNMUTE, (sessionID: string, userID: string) => {
+            store.dispatch(userUnmuted(callClient.channelID, sessionID, userID));
+        });
+        callClient.on(CALL_EVENT.USERS_VOICE_ACTIVITY_CHANGED, (sessionIDs: string[], userIDs: string[]) => {
+            store.dispatch(usersVoiceActivityChanged(callClient.channelID, sessionIDs, userIDs));
+        });
+        callClient.on(CALL_EVENT.RAISE_HAND, (sessionID: string, userID: string, raisedHandTimestamp: number) => {
+            store.dispatch(userRaisedHand(callClient.channelID, sessionID, userID, raisedHandTimestamp));
+        });
+        callClient.on(CALL_EVENT.LOWER_HAND, (sessionID: string, userID: string) => {
+            store.dispatch(userLoweredHand(callClient.channelID, sessionID, userID));
+        });
+        callClient.on(CALL_EVENT.REACTION, (sessionID: string, userID: string, emoji: EmojiData, timestamp: number) => {
+            dispatchReaction(store, callClient.channelID, {
+                user_id: userID,
+                session_id: sessionID,
+                emoji,
+                timestamp,
+            });
+        });
+
+        // The WS call_state seed carries the server's stale unmuted/voice/raised_hand
+        // (those fields moved to LiveKit). reSyncMuteAndHandState() replays the live
+        // state for every current participant, but only works once (a) the LiveKit
+        // room is connected and (b) the seed has populated the session list — the
+        // session reducers drop events for sessions they don't yet know about. The
+        // two can arrive in either order (notably the recording bot joining mid-call),
+        // so trigger the replay once both conditions hold.
+        let liveKitStateSynced = false;
+        let roomConnected = false;
+        let seedReceived = false;
+        const maybeReSyncLiveKitState = () => {
+            if (liveKitStateSynced || !roomConnected || !seedReceived) {
+                return;
+            }
+            liveKitStateSynced = true;
+            callClient.reSyncMuteAndHandState();
+        };
+        callClient.on(CALL_EVENT.WEBSOCKET_EVENT, (ev: WebSocketMessage<WebsocketEventData>) => {
+            if (ev.event === `custom_${pluginId}_call_state`) {
+                seedReceived = true;
+                maybeReSyncLiveKitState();
+            }
+        });
+
         let lastError: Error | undefined;
 
         callClient.on(CALL_EVENT.ERROR, (e: unknown) => {
@@ -127,7 +173,11 @@ function connectCall(
                 lastError = e;
             }
         });
-        callClient.on(CALL_EVENT.CONNECTED, () => store.dispatch(setClientConnecting(false)));
+        callClient.on(CALL_EVENT.CONNECTED, () => {
+            store.dispatch(setClientConnecting(false));
+            roomConnected = true;
+            maybeReSyncLiveKitState();
+        });
         callClient.on(CALL_EVENT.DISCONNECTED, (reason?: DisconnectReason) => {
             store.dispatch(setClientConnecting(false));
             if (window.callsClient) {
@@ -241,35 +291,14 @@ export default async function initialiseEmbedApp(cfg: InitConfig) {
         case `custom_${pluginId}_user_left`:
             handleUserLeft(store, ev as WebSocketMessage<UserLeftData>);
             break;
-        case `custom_${pluginId}_user_voice_on`:
-            handleUserVoiceOn(store, ev as WebSocketMessage<UserVoiceOnOffData>);
-            break;
-        case `custom_${pluginId}_user_voice_off`:
-            handleUserVoiceOff(store, ev as WebSocketMessage<UserVoiceOnOffData>);
-            break;
         case `custom_${pluginId}_user_screen_on`:
             handleUserScreenOn(store, ev as WebSocketMessage<UserScreenOnOffData>);
             break;
         case `custom_${pluginId}_user_screen_off`:
             handleUserScreenOff(store, ev as WebSocketMessage<UserScreenOnOffData>);
             break;
-        case `custom_${pluginId}_user_muted`:
-            handleUserMuted(store, ev as WebSocketMessage<UserMutedUnmutedData>);
-            break;
-        case `custom_${pluginId}_user_unmuted`:
-            handleUserUnmuted(store, ev as WebSocketMessage<UserMutedUnmutedData>);
-            break;
-        case `custom_${pluginId}_user_raise_hand`:
-            handleUserRaisedHand(store, ev as WebSocketMessage<UserRaiseUnraiseHandData>);
-            break;
-        case `custom_${pluginId}_user_unraise_hand`:
-            handleUserUnraisedHand(store, ev as WebSocketMessage<UserRaiseUnraiseHandData>);
-            break;
         case `custom_${pluginId}_call_host_changed`:
             handleCallHostChanged(store, ev as WebSocketMessage<CallHostChangedData>);
-            break;
-        case `custom_${pluginId}_user_reacted`:
-            handleUserReaction(store, ev as WebSocketMessage<UserReactionData>);
             break;
         case `custom_${pluginId}_call_job_state`:
             handleCallJobState(store, ev as WebSocketMessage<CallJobStateData>);

--- a/standalone/src/widget/index.tsx
+++ b/standalone/src/widget/index.tsx
@@ -22,7 +22,6 @@ import React from 'react';
 import {createRoot, Root} from 'react-dom/client';
 import {IntlProvider} from 'react-intl';
 import {Provider} from 'react-redux';
-import {userMuted, userUnmuted} from 'src/state/session/actions';
 
 import initialiseEmbedApp, {InitCbProps} from '../index';
 
@@ -58,14 +57,10 @@ async function initWidget({store, startingCall}: InitCbProps) {
 
     const locale = getCurrentUserLocale(store.getState()) || 'en';
 
-    window.callsClient?.on('mute', () => {
-        store.dispatch(userMuted(window.callsClient?.channelID ?? '', window.callsClient?.getSessionID() ?? '', getCurrentUserId(store.getState())));
-    });
-
-    window.callsClient?.on('unmute', () => {
-        store.dispatch(userUnmuted(window.callsClient?.channelID ?? '', window.callsClient?.getSessionID() ?? '', getCurrentUserId(store.getState())));
-    });
-
+    // Mute/unmute (and speaking, raised-hand, reactions) are bridged centrally in
+    // connectCall() from the LiveKit-owned CALL_EVENTs, with the event's real
+    // session/userID — so remote participants update correctly, not just the local
+    // user. Only the local-only video state is wired here.
     window.callsClient?.on('video_on', () => {
         store.dispatch({
             type: 'USER_VIDEO_ON',


### PR DESCRIPTION
## Summary

After the LiveKit migration, per-participant call state (mute, speaking/voice activity, raised hand, reactions) is owned by LiveKit and re-emitted by `CallClient` as `CALL_EVENT.*` rather than traveling over the plugin WebSocket. The standalone bundles (`standalone/src/index.ts`, shared by the **widget** and the **recording** page) never got the bridge that feeds this state into the UI, so the indicators were wrong:

- **Recording:** every participant stuck "muted", speaking outline never drew, hands/reactions never showed.
- **Widget (Desktop):** remote participants' mute/speaking indicators stale (local user was fine).

The main webapp (`webapp/src/index.tsx`) and popout (`expanded_view/component.tsx`) were already wired correctly; only the standalone surfaces were missing.

## Changes

- **`standalone/src/index.ts` — central bridge in `connectCall()`:** subscribe to `CALL_EVENT.MUTE`/`UNMUTE` → `userMuted`/`userUnmuted`, `USERS_VOICE_ACTIVITY_CHANGED` → `usersVoiceActivityChanged`, `RAISE_HAND`/`LOWER_HAND` → `userRaisedHand`/`userLoweredHand`, and `REACTION` → `dispatchReaction`, all using the event's real session/userID. Both widget and recording inherit this.
- **Replay-once seed overlay:** call `reSyncMuteAndHandState()` exactly when *both* the LiveKit room is connected *and* the WS `call_state` seed has populated the session list. The session reducers drop events for sessions they don't yet know about, so the at-connect emits race ahead of the seed and are lost — this covers the recording bot joining mid-call. Handles either arrival order.
- **`standalone/src/widget/index.tsx`:** removed the `on('mute')`/`on('unmute')` handlers that ignored the event args and hardcoded the local user (superseded by the shared bridge). Video handlers left untouched (out of scope).
- Removed the now-dead plugin-WS switch cases (`user_voice_on/off`, `user_muted/unmuted`, `user_raise_hand/unraise_hand`, `user_reacted`) and their unused imports — these events no longer travel over the plugin WS in v2.

## Testing

- Verified live: in a recording, mute + speaking (green outline) + raised hands update correctly; in the Desktop widget, remote participants' mute/speaking are correct.
- `npm run check-types` and `npm run lint` pass in `standalone/`.
- Main webapp and popout behavior unchanged.

## Notes

- Discovered while verifying MM-69144 (enable recording for Calls v2). The two changes are independent at the file level; this branch is based directly on `v2`.
- Reactions ride the LiveKit data-message path from MM-68566.
- The dead-WS-case removal overlaps the vestigial-v2-state cleanup tracked in MM-69116.

https://mattermost.atlassian.net/browse/MM-69148