### PR TITLE
[MM-621] Ring on incoming calls in CM

### DIFF
--- a/server/push_notifications.go
+++ b/server/push_notifications.go
@@ -47,6 +47,9 @@ func (p *Plugin) NotificationWillBePushed(notification *model.PushNotification, 
 		return nil, ""
 	}
 
+	// Mark as a calls notification so mobile clients ring for channel calls.
+	notification.SubType = model.PushSubTypeCalls
+
 	// If it's a regular channel, then the user must have notifications set to all.
 	// In that case, make the notification nicer.
 	if notification.IsIdLoaded {

--- a/server/push_notifications_test.go
+++ b/server/push_notifications_test.go
@@ -176,6 +176,7 @@ func TestNotificationWillBePushed(t *testing.T) {
 				PostType:    callStartPostType,
 				ChannelType: model.ChannelTypeOpen,
 				SenderId:    "senderID",
+				SubType:     model.PushSubTypeCalls,
 				Message:     "\u200bapp.push_notification.inviting_message",
 			}, res)
 			require.Empty(t, msg)
@@ -191,6 +192,7 @@ func TestNotificationWillBePushed(t *testing.T) {
 					PostType:    callStartPostType,
 					ChannelType: model.ChannelTypeOpen,
 					SenderId:    "senderID",
+					SubType:     model.PushSubTypeCalls,
 					IsIdLoaded:  true,
 					Message:     "app.push_notification.generic_message",
 				}, res)

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -361,7 +361,7 @@ export function incomingCallOnChannel(channelID: string, callID: string, callerI
             channel = res.data;
         }
 
-        if (!channel || !(isDMChannel(channel) || isGMChannel(channel))) {
+        if (!channel) {
             return;
         }
 
@@ -392,7 +392,7 @@ export function incomingCallOnChannel(channelID: string, callID: string, callerI
                 channelID,
                 callerID,
                 startAt,
-                type: isDMChannel(channel) ? ChannelType.DM : ChannelType.GM,
+                type: isDMChannel(channel) ? ChannelType.DM : isGMChannel(channel) ? ChannelType.GM : ChannelType.CM,
             },
         });
     };

--- a/webapp/src/components/incoming_calls/call_incoming.tsx
+++ b/webapp/src/components/incoming_calls/call_incoming.tsx
@@ -57,6 +57,16 @@ export const CallIncoming = ({call}: Props) => {
                 }}
             />
         );
+    } else if (call.type === ChannelType.CM) {
+        message = (
+            <FormattedMessage
+                defaultMessage={'<b>{callerName}</b> is inviting you to a call'}
+                values={{
+                    b: (text: React.ReactNode) => <b>{text}</b>,
+                    callerName,
+                }}
+            />
+        );
     }
 
     return (

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -171,7 +171,8 @@ export type CallActions = {
 
 export enum ChannelType {
     DM,
-    GM
+    GM,
+    CM
 }
 
 export type IncomingCallNotification = {


### PR DESCRIPTION
## Summary
- Incoming call rings for channels

## Behavior
- Channel ringing uses existing push notification delivery.
- Only users with push notifications enabled for that channel will ring.
- Fixes #621 

## Test plan
- [X] Call in DM -> ringing still works
- [X] Call in GM - ringing still works
- [X] Call in CM -> rings
