### PR TITLE
[MM-69111] Update channel call button immediately on leave

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -716,16 +716,23 @@ export default class Plugin {
                     }
 
                     if (window.callsClient) {
+                        const callChannelID = window.callsClient.channelID;
                         const currentSessionID = window.callsClient.getSessionID();
                         const currentUserID = getCurrentUserId(store.getState());
-                        if (currentSessionID) {
-                            store.dispatch(leaveUser(window.callsClient.channelID, currentUserID, currentSessionID));
-                        }
 
-                        store.dispatch(localSessionClose(window.callsClient.channelID));
+                        // Tear down the global BEFORE dispatching. channelIDForCurrentCall
+                        // reads window.callsClient (a non-Redux global), so the dispatches
+                        // below must run against the cleared client to trigger a re-render
+                        // that flips the channel "Leave" button back to "Join". Deleting it
+                        // afterwards leaves the UI stale until some later incidental dispatch.
                         void window.callsClient.disconnect();
                         delete window.callsClient;
                         delete window.currentCallData;
+
+                        if (currentSessionID) {
+                            store.dispatch(leaveUser(callChannelID, currentUserID, currentSessionID));
+                        }
+                        store.dispatch(localSessionClose(callChannelID));
                         playSound('leave_self');
                     }
                 });


### PR DESCRIPTION
## Summary

Fixes [MM-69111](https://mattermost.atlassian.net/browse/MM-69111): the channel call button stayed on "Leave" after leaving a call and only reverted to "Join" after a delay.

The button reads `channelIDForCurrentCall`, whose first input is the non-Redux `window.callsClient` global (`selectors.ts` → `utils.ts`). In the `CALL_EVENT.DISCONNECTED` handler the global was deleted *after* the `leaveUser`/`localSessionClose` dispatches, so the deletion itself triggered no re-render — the button stayed stale until the next incidental store dispatch (the `user_left` echo, a status poll, or the toast's 5s timestamp tick) happened to re-run the selector.

This reorders the teardown so `window.callsClient` is cleared **before** those dispatches (with `channelID`/`sessionID`/`userID` captured into locals first). The dispatches then re-render against the cleared global and the button flips to "Join" in the same tick.

The server-side leave path was verified correct and immediate via logs during investigation — this is a client-only re-render-timing fix; no server or webhook changes.

## Testing

Manual: start a call on one client, join from a second, leave from the second — the channel button (header, in-channel call post, and toast) flips to "Join" immediately instead of after a delay.

## Follow-up (out of scope)

- Structural cleanup: derive `channelIDForCurrentCall` from Redux rather than the `window.callsClient` global, to eliminate the whole "global mutated → no re-render" class.
- Separate latent gap for non-clean exits (crash/tab-close/network drop) where no leave message is sent; v2 has no RTC-close backstop, so the session lingers until the 10s `wsReconnectionTimeout`.