### PR TITLE
[MM-69201] Read bot auth state from writer in LiveKit token endpoint

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -481,7 +481,10 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Require the session to belong to the requesting user to prevent unauthorized token minting.
-	callSession, err := p.store.GetCallSession(requestingSessionID, db.GetCallSessionOpts{})
+	// Read from the writer: this is a security gate that immediately follows the join write
+	// (especially the recorder bot's job-gated join), and a read-replica lag under load would
+	// otherwise miss the just-written session and 403 a legitimate request.
+	callSession, err := p.store.GetCallSession(requestingSessionID, db.GetCallSessionOpts{FromWriter: true})
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
 		p.LogError("failed to get call session", "err", err.Error(), "session_id", requestingSessionID)
 		res.Err = "Internal server error"
@@ -495,7 +498,8 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Require the session to belong to the active call in the requested channel.
-	activeCall, err := p.store.GetActiveCallByChannelID(requestingChannelID, db.GetCallOpts{})
+	// Read from the writer for the same reason as the session lookup above.
+	activeCall, err := p.store.GetActiveCallByChannelID(requestingChannelID, db.GetCallOpts{FromWriter: true})
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
 		p.LogError("failed to get active call", "err", err.Error(), "channel_id", requestingChannelID)
 		res.Err = "Internal server error"


### PR DESCRIPTION
## Summary

During a large-scale test (20+ users) of Calls v2 (LiveKit) on Community, call recording failed to start. The recording bot's `GET /livekit-token` request returned `403 Forbidden`, so the recorder never connected to the LiveKit room and timed out (`failed to poll for client initialization err="timed out"`).

### Root cause

`handleGetLiveKitToken` authorizes the bot with two DB reads and 403s if either misses:
- `GetCallSession(requestingSessionID, ...)`
- `GetActiveCallByChannelID(requestingChannelID, ...)`

Both were called with empty opts, which `dbXFromGetOpts` resolves to the **read replica** (`FromWriter: false`). These reads immediately follow the bot's job-gated join, whose `calls_sessions`/`calls` rows were just written to the primary. Under load the replica lag widened and the read consistently lost the race → row not found → 403.

A single-Postgres local dev stack has no replica, so this never reproduces locally.

### Fix

Read both the call session and active call from the writer. These are a security gate that immediately follows the bot's own join write, so they must observe current state rather than a lagging replica.

## Test Done

- `go build ./server/...`, `go vet ./server/` clean
- `go test ./server/ -run TestHandleGetLiveKitToken` passes
- Will not reproduce locally (no replica); needs a concurrent-recording re-run on a replica-backed env to confirm in the wild

## Ticket

https://mattermost.atlassian.net/browse/MM-69201