### PR TITLE
[MM-69216] Add server-side call-lifecycle logging for forensics

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -669,21 +669,32 @@ func (p *Plugin) handleLiveKitWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p.LogDebug("handleLiveKitWebhook: received event",
+	// Log every received webhook event at INFO regardless of whether the plugin
+	// acts on it, so the forensic audit trail is complete. LiveKit webhook
+	// delivery is at-least-once and not order-guaranteed (events are retried),
+	// so these logs may contain occasional duplicate or slightly out-of-order
+	// events — a retry should not be misread as a distinct event. See MM-69216.
+	fields := []any{
 		"event", event.GetEvent(),
-		"room", event.GetRoom().GetName())
+		"channelID", event.GetRoom().GetName(),
+		"nodeID", p.nodeID,
+	}
+	if participant := event.GetParticipant(); participant != nil {
+		fields = append(fields, "identity", participant.GetIdentity(), "sid", participant.GetSid())
+		// The disconnect reason (CLIENT_INITIATED, DUPLICATE_IDENTITY,
+		// ROOM_DELETED, SERVER_SHUTDOWN, ...) is the highest-value field for
+		// explaining a failed teardown.
+		if event.GetEvent() == webhook.EventParticipantLeft {
+			fields = append(fields, "disconnectReason", participant.GetDisconnectReason().String())
+		}
+	}
+	p.LogInfo("handleLiveKitWebhook: received event", fields...)
 
 	switch event.GetEvent() {
 	case webhook.EventParticipantJoined:
 		p.handleLiveKitSIPParticipantJoined(event)
 	case webhook.EventParticipantLeft:
 		p.handleLiveKitSIPParticipantLeft(event)
-	case webhook.EventRoomStarted, webhook.EventRoomFinished:
-		p.LogDebug("handleLiveKitWebhook: room lifecycle event (informational only)",
-			"event", event.GetEvent(),
-			"room", event.GetRoom().GetName())
-	default:
-		p.LogDebug("handleLiveKitWebhook: ignoring event", "event", event.GetEvent())
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/server/api_livekit_webhook_test.go
+++ b/server/api_livekit_webhook_test.go
@@ -80,7 +80,8 @@ func TestHandleLiveKitWebhook(t *testing.T) {
 		mockAPI.On("LogInfo", mock.AnythingOfType("string"),
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything).Maybe()
 		mockAPI.On("LogError", mock.AnythingOfType("string"), mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
 		return p, mockAPI
@@ -217,6 +218,11 @@ func TestHandleLiveKitSIPParticipant(t *testing.T) {
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+		mockAPI.On("LogInfo", mock.AnythingOfType("string"),
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything).Maybe()
 		mockAPI.On("LogError", mock.AnythingOfType("string"),
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()

--- a/server/api_livekit_webhook_test.go
+++ b/server/api_livekit_webhook_test.go
@@ -77,6 +77,10 @@ func TestHandleLiveKitWebhook(t *testing.T) {
 		mockAPI.On("GetLicense").Return(&model.License{SkuShortName: "enterprise"}, nil)
 		mockAPI.On("LogDebug", mock.AnythingOfType("string"), mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+		mockAPI.On("LogInfo", mock.AnythingOfType("string"),
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
 		mockAPI.On("LogError", mock.AnythingOfType("string"), mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
 		return p, mockAPI

--- a/server/db/calls_sessions_store.go
+++ b/server/db/calls_sessions_store.go
@@ -169,7 +169,9 @@ func (s *Store) GetCallSessions(callID string, opts GetCallSessionOpts) (map[str
 	return sessionsMap, nil
 }
 
-func (s *Store) DeleteCallsSessions(callID string) error {
+// DeleteCallsSessions deletes all session rows for the given call and returns
+// the number of rows deleted.
+func (s *Store) DeleteCallsSessions(callID string) (int64, error) {
 	s.metrics.IncStoreOp("DeleteCallsSessions")
 	defer func(start time.Time) {
 		s.metrics.ObserveStoreMethodsTime("DeleteCallsSessions", time.Since(start).Seconds())
@@ -181,17 +183,23 @@ func (s *Store) DeleteCallsSessions(callID string) error {
 
 	q, args, err := qb.ToSql()
 	if err != nil {
-		return fmt.Errorf("failed to prepare query: %w", err)
+		return 0, fmt.Errorf("failed to prepare query: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*s.settings.QueryTimeout)*time.Second)
 	defer cancel()
-	_, err = s.wDB.ExecContext(ctx, q, args...)
+	res, err := s.wDB.ExecContext(ctx, q, args...)
 	if err != nil {
-		return fmt.Errorf("failed to run query: %w", err)
+		return 0, fmt.Errorf("failed to run query: %w", err)
 	}
 
-	return nil
+	deleted, err := res.RowsAffected()
+	if err != nil {
+		// The rows were still deleted; we just couldn't get the count.
+		return 0, nil
+	}
+
+	return deleted, nil
 }
 
 func (s *Store) GetCallSessionsCount(callID string, opts GetCallSessionOpts) (int, error) {

--- a/server/db/calls_sessions_store_test.go
+++ b/server/db/calls_sessions_store_test.go
@@ -201,8 +201,9 @@ func testGetCallSessions(t *testing.T, store *Store) {
 
 func testDeleteCallsSessions(t *testing.T, store *Store) {
 	t.Run("no sessions", func(t *testing.T) {
-		err := store.DeleteCallsSessions(model.NewId())
+		deleted, err := store.DeleteCallsSessions(model.NewId())
 		require.NoError(t, err)
+		require.Zero(t, deleted)
 	})
 
 	t.Run("multiple sessions", func(t *testing.T) {
@@ -222,8 +223,9 @@ func testDeleteCallsSessions(t *testing.T, store *Store) {
 			require.NoError(t, err)
 		}
 
-		err := store.DeleteCallsSessions(callID)
+		deleted, err := store.DeleteCallsSessions(callID)
 		require.NoError(t, err)
+		require.EqualValues(t, 10, deleted)
 
 		sessions, err := store.GetCallSessions(callID, GetCallSessionOpts{})
 		require.NoError(t, err)

--- a/server/host_controls.go
+++ b/server/host_controls.go
@@ -312,14 +312,26 @@ func (p *Plugin) hostEnd(requesterID, channelID string) error {
 		}
 	}
 
+	sessionCount := len(state.sessions)
+
 	// Destroy the LiveKit room. This forcibly disconnects every connected
 	// participant; each client's LiveKit SDK fires RoomEvent.Disconnected
 	// (reason=ROOM_DELETED), driving in-call UI teardown independently of
 	// plugin-WebSocket delivery.
+	roomDeleted := true
 	if err := p.livekitDeleteRoom(channelID); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
+		roomDeleted = false
 		p.LogError("hostEnd: failed to delete LiveKit room",
 			"channelID", channelID, "err", err.Error())
 	}
+
+	p.LogInfo("host ended call",
+		"callID", state.Call.ID,
+		"channelID", channelID,
+		"requesterID", requesterID,
+		"nodeID", p.nodeID,
+		"sessionCount", sessionCount,
+		"roomDeleted", roomDeleted)
 
 	// Notify the whole channel that the call has ended so bystander UI
 	// (toast, sidebar icon) clears immediately. In-call clients also receive
@@ -329,7 +341,7 @@ func (p *Plugin) hostEnd(requesterID, channelID string) error {
 		ReliableClusterSend: true,
 	})
 
-	if err := p.cleanCallState(&state.Call); err != nil {
+	if err := p.cleanCallState(&state.Call, "host_end"); err != nil {
 		return fmt.Errorf("failed to clean call state: %w", err)
 	}
 

--- a/server/session.go
+++ b/server/session.go
@@ -209,6 +209,12 @@ func (p *Plugin) addUserSession(state *callState, callsEnabled *bool, userID, co
 		if err := p.store.CreateCall(&state.Call); err != nil {
 			return nil, fmt.Errorf("failed to create call: %w", err)
 		}
+
+		p.LogInfo("call created",
+			"callID", state.Call.ID,
+			"channelID", channelID,
+			"userID", userID,
+			"nodeID", p.nodeID)
 	} else {
 		if err := p.store.UpdateCall(&state.Call); err != nil {
 			return nil, fmt.Errorf("failed to update call: %w", err)
@@ -217,6 +223,14 @@ func (p *Plugin) addUserSession(state *callState, callsEnabled *bool, userID, co
 	if err := p.store.CreateCallSession(state.sessions[connID]); err != nil {
 		return nil, fmt.Errorf("failed to create call session: %w", err)
 	}
+
+	p.LogInfo("call session joined",
+		"callID", state.Call.ID,
+		"channelID", channelID,
+		"sessionID", connID,
+		"userID", userID,
+		"nodeID", p.nodeID,
+		"sessionCount", len(state.sessions))
 
 	return state, nil
 }
@@ -276,7 +290,13 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		return fmt.Errorf("failed to delete call session: %w", err)
 	}
 	delete(state.sessions, originalConnID)
-	p.LogDebug("session was removed from state", "userID", userID, "connID", connID, "originalConnID", originalConnID)
+	p.LogInfo("call session left",
+		"callID", state.Call.ID,
+		"channelID", channelID,
+		"sessionID", originalConnID,
+		"userID", userID,
+		"nodeID", p.nodeID,
+		"sessionCount", len(state.sessions))
 
 	// Check if leaving session was screen sharing.
 	if state.Call.Props.ScreenSharingSessionID == originalConnID {
@@ -435,6 +455,13 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 			state.Call.Stats.ScreenDuration += secondsSinceTimestamp(state.Call.Props.ScreenStartAt)
 		}
 		setCallEnded(&state.Call)
+
+		p.LogInfo("call ended",
+			"callID", state.Call.ID,
+			"channelID", channelID,
+			"nodeID", p.nodeID,
+			"reason", "last_left",
+			"sessionCount", 0)
 
 		p.publishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &WebSocketBroadcast{
 			ChannelID:           channelID,

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -46,6 +46,11 @@ func TestAddUserSession(t *testing.T) {
 	p.store = store
 
 	mockMetrics.On("ObserveAppHandlersTime", mock.AnythingOfType("string"), mock.AnythingOfType("float64"))
+	mockAPI.On("LogInfo", mock.AnythingOfType("string"),
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Maybe()
 
 	t.Run("not enabled", func(t *testing.T) {
 		defer mockAPI.AssertExpectations(t)

--- a/server/state.go
+++ b/server/state.go
@@ -343,7 +343,7 @@ func (p *Plugin) cleanUpState() error {
 			continue
 		}
 
-		if err := p.cleanCallState(call); err != nil {
+		if err := p.cleanCallState(call, "cleanup_on_restart"); err != nil {
 			p.unlockCall(call.ChannelID)
 			return fmt.Errorf("failed to clean up state: %w", err)
 		}
@@ -355,8 +355,9 @@ func (p *Plugin) cleanUpState() error {
 }
 
 // NOTE: cleanCallState is meant to be called under lock (on channelID) so that
-// the operation can be performed atomically.
-func (p *Plugin) cleanCallState(call *public.Call) error {
+// the operation can be performed atomically. reason identifies what triggered
+// the call to end (e.g. host_end, cleanup_on_restart) for forensic logging.
+func (p *Plugin) cleanCallState(call *public.Call, reason string) error {
 	if call == nil {
 		return nil
 	}
@@ -369,9 +370,17 @@ func (p *Plugin) cleanCallState(call *public.Call) error {
 		setCallEnded(call)
 	}
 
-	if err := p.store.DeleteCallsSessions(call.ID); err != nil {
+	deleted, err := p.store.DeleteCallsSessions(call.ID)
+	if err != nil {
 		p.LogError("failed to delete calls sessions", "err", err.Error())
 	}
+
+	p.LogInfo("call ended",
+		"callID", call.ID,
+		"channelID", call.ChannelID,
+		"nodeID", p.nodeID,
+		"reason", reason,
+		"sessionsDeleted", deleted)
 
 	jobs, err := p.store.GetActiveCallJobs(call.ID, db.GetCallJobOpts{
 		FromWriter: true,

--- a/server/state_test.go
+++ b/server/state_test.go
@@ -576,6 +576,12 @@ func TestCleanUpState(t *testing.T) {
 			mockAPI.On("LogDebug", "creating cluster mutex for call",
 				"origin", mock.AnythingOfType("string"), "channelID", channelID).Once()
 
+			mockAPI.On("LogInfo", "call ended",
+				"origin", mock.AnythingOfType("string"),
+				"callID", mock.Anything, "channelID", mock.Anything,
+				"nodeID", mock.Anything, "reason", mock.Anything,
+				"sessionsDeleted", mock.Anything).Once()
+
 			mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 
 			mockMetrics.On("ObserveClusterMutexGrabTime", "mutex_call", mock.AnythingOfType("float64"))

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -785,6 +785,12 @@ func TestHandleJoin(t *testing.T) {
 		"xForwardedFor", mock.AnythingOfType("string"),
 	)
 
+	mockAPI.On("LogInfo", mock.AnythingOfType("string"),
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Maybe()
+
 	store, tearDown := NewTestStore(t)
 	t.Cleanup(tearDown)
 	p.store = store


### PR DESCRIPTION
## Summary

Adds structured server-side call-lifecycle logging to the Calls plugin (v2/LiveKit) so a stuck or mis-torn-down call can be reconstructed from server logs after the fact. This is the server-side complement to the client-side logging work (MM-69079, MM-69080).

Motivated by the 2026-06-10 large-scale (20+ user) test: after _End call for all_, a call persisted with one participant for hours, and the existing server logs (almost entirely `LogDebug`, off in production) could not explain why.

This ticket only captures the evidence — it does **not** fix the teardown bug or wire non-SIP `participant_left` as a teardown source of truth (separate follow-up).

## Changes

All logging is at `LogInfo` (fire-once-per-event), with consistent `callID` / `channelID` / `sessionID` / `userID` / `nodeID` / `sessionCount` fields so logs can be filtered across a multi-node cluster.

- **Call created** — logged when the first session creates the call (`addUserSession`).
- **Call ended** — both end paths, with a `reason`: `host_end` and `cleanup_on_restart` (via `cleanCallState`) and `last_left` (last-participant-left in `removeUserSession`).
- **`hostEnd` success line** — `requesterID`, sessions live at end, and whether the LiveKit room delete succeeded (`roomDeleted`).
- **Session joined / left** — promoted Debug → Info, including originating `nodeID` and post-change `sessionCount`.
- **`cleanCallState`** — logs the count of sessions deleted. `DeleteCallsSessions` now returns that count.
- **LiveKit webhooks** — every received webhook event is logged at INFO in `handleLiveKitWebhook`, regardless of whether the plugin acts on it, so the audit trail is complete. Includes event type, room (channelID), participant identity where present, and — for `participant_left` — the **disconnect reason** (`CLIENT_INITIATED`, `ROOM_DELETED`, `SERVER_SHUTDOWN`, …), the single highest-value field for explaining a failed teardown. A code comment notes that LiveKit webhook delivery is at-least-once and not order-guaranteed, so retries may appear as duplicate/out-of-order events.

## Test

`go build` / `go vet` clean. Updated `testDeleteCallsSessions` for the new return value (requires Postgres to run).

Ticket: https://mattermost.atlassian.net/browse/MM-69216
