### PR TITLE
[MM-69079] Port improved call logging to v2 (bot-DM upload + accumulation buffer)

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -29,6 +29,12 @@ import (
 
 const requestBodyMaxSizeBytes = 1024 * 1024 // 1MB
 
+// logsUploadMaxSizeBytes is larger than the client's MAX_ACCUMULATED_LOG_SIZE
+// (1MB) to leave margin for JSON-escaping overhead: newlines, quotes and
+// control chars in the log text inflate the encoded body beyond the raw log
+// size, and the JSON wrapper fields add a little more on top.
+const logsUploadMaxSizeBytes = 2 * 1024 * 1024 // 2MB
+
 func (p *Plugin) handleGetVersion(w http.ResponseWriter, _ *http.Request) {
 	p.mut.RLock()
 	defer p.mut.RUnlock()
@@ -837,4 +843,80 @@ func (p *Plugin) handleLiveKitSIPParticipantLeft(event *livekit.WebhookEvent) {
 		"user_id":    identity,
 		"session_id": sid,
 	}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
+}
+
+func (p *Plugin) handleUploadLogsToBot(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-Id")
+	if userID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req struct {
+		Logs      string `json:"logs"`
+		ChannelID string `json:"channel_id"`
+		TeamID    string `json:"team_id"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, logsUploadMaxSizeBytes)).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if !model.IsValidId(req.ChannelID) || !model.IsValidId(req.TeamID) {
+		http.Error(w, "Invalid channel_id or team_id", http.StatusBadRequest)
+		return
+	}
+
+	if p.botSession == nil {
+		http.Error(w, "Bot user not available", http.StatusInternalServerError)
+		return
+	}
+	botID := p.botSession.UserId
+
+	dmChannel, appErr := p.API.GetDirectChannel(userID, botID)
+	if appErr != nil {
+		http.Error(w, fmt.Sprintf("Failed to get DM channel: %s", appErr.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	filename := fmt.Sprintf("call_logs_%s.txt", time.Now().UTC().Format("2006-01-02T15-04-05Z"))
+
+	fileInfo, appErr := p.API.UploadFile([]byte(req.Logs), dmChannel.Id, filename)
+	if appErr != nil {
+		http.Error(w, fmt.Sprintf("Failed to upload file: %s", appErr.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	post, appErr := p.API.CreatePost(&model.Post{
+		UserId:    botID,
+		ChannelId: dmChannel.Id,
+		FileIds:   []string{fileInfo.Id},
+	})
+	if appErr != nil {
+		http.Error(w, fmt.Sprintf("Failed to create post: %s", appErr.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	team, appErr := p.API.GetTeam(req.TeamID)
+	if appErr != nil {
+		http.Error(w, fmt.Sprintf("Failed to get team: %s", appErr.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	siteURL := p.API.GetConfig().ServiceSettings.SiteURL
+	if siteURL == nil || *siteURL == "" {
+		http.Error(w, "Site URL not configured", http.StatusInternalServerError)
+		return
+	}
+
+	permalink := fmt.Sprintf("%s/%s/pl/%s", *siteURL, team.Name, post.Id)
+	p.API.SendEphemeralPost(userID, &model.Post{
+		ChannelId: req.ChannelID,
+		Message:   fmt.Sprintf("Call logs uploaded — [view in your @calls DM](%s)", permalink),
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write([]byte("{}")); err != nil {
+		p.LogError("failed to write logs upload response", "error", err.Error())
+	}
 }

--- a/server/api.go
+++ b/server/api.go
@@ -855,16 +855,45 @@ func (p *Plugin) handleUploadLogsToBot(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Logs      string `json:"logs"`
 		ChannelID string `json:"channel_id"`
-		TeamID    string `json:"team_id"`
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, logsUploadMaxSizeBytes)).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 
-	if !model.IsValidId(req.ChannelID) || !model.IsValidId(req.TeamID) {
-		http.Error(w, "Invalid channel_id or team_id", http.StatusBadRequest)
+	if !model.IsValidId(req.ChannelID) {
+		http.Error(w, "Invalid channel_id", http.StatusBadRequest)
 		return
+	}
+
+	// Confirm the requester is a member of the channel they want the
+	// confirmation posted to, then resolve the team server-side. The client is
+	// not trusted to supply a team: a regular channel carries its own TeamId,
+	// and DM/GM channels (which have none) fall back to any team the user
+	// belongs to, since the permalink only needs a team the user can access.
+	if _, appErr := p.API.GetChannelMember(req.ChannelID, userID); appErr != nil {
+		http.Error(w, "Not a member of the channel", http.StatusForbidden)
+		return
+	}
+
+	channel, appErr := p.API.GetChannel(req.ChannelID)
+	if appErr != nil {
+		http.Error(w, fmt.Sprintf("Failed to get channel: %s", appErr.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	teamID := channel.TeamId
+	if teamID == "" {
+		teams, appErr := p.API.GetTeamsForUser(userID)
+		if appErr != nil {
+			http.Error(w, fmt.Sprintf("Failed to get teams: %s", appErr.Error()), http.StatusInternalServerError)
+			return
+		}
+		if len(teams) == 0 {
+			http.Error(w, "User is not a member of any team", http.StatusForbidden)
+			return
+		}
+		teamID = teams[0].Id
 	}
 
 	if p.botSession == nil {
@@ -897,7 +926,7 @@ func (p *Plugin) handleUploadLogsToBot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	team, appErr := p.API.GetTeam(req.TeamID)
+	team, appErr := p.API.GetTeam(teamID)
 	if appErr != nil {
 		http.Error(w, fmt.Sprintf("Failed to get team: %s", appErr.Error()), http.StatusInternalServerError)
 		return

--- a/server/api_router.go
+++ b/server/api_router.go
@@ -116,6 +116,9 @@ func (p *Plugin) newAPIRouter() *mux.Router {
 	// Deprecated for hostCtrlRounder /end, but needed for mobile backward compatibility (pre 2.18)
 	router.HandleFunc("/calls/{call_id:[a-z0-9]{26}}/end", p.handleEnd).Methods("POST")
 
+	// Logs
+	router.HandleFunc("/logs/upload", p.handleUploadLogsToBot).Methods("POST")
+
 	// Host Controls
 	hostCtrlRouter := router.PathPrefix("/calls/{call_id:[a-z0-9]{26}}/host").Subrouter()
 	hostCtrlRouter.HandleFunc("/make", p.handleMakeHost).Methods("POST")

--- a/server/logs_test.go
+++ b/server/logs_test.go
@@ -51,7 +51,6 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
 			"logs":       "test",
 			"channel_id": originChannelID,
-			"team_id":    teamID,
 		})))
 		p.handleUploadLogsToBot(w, r)
 		require.Equal(t, http.StatusUnauthorized, w.Code)
@@ -72,24 +71,26 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
 			"logs":       "test",
 			"channel_id": "too-short",
-			"team_id":    teamID,
 		})))
 		r.Header.Set("Mattermost-User-Id", userID)
 		p.handleUploadLogsToBot(w, r)
 		require.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
-	t.Run("rejects invalid team_id", func(t *testing.T) {
-		p, _ := newPlugin()
+	t.Run("rejects requester not a member of the channel", func(t *testing.T) {
+		p, mockAPI := newPlugin()
+		defer mockAPI.AssertExpectations(t)
+
+		mockAPI.On("GetChannelMember", originChannelID, userID).Return(nil, model.NewAppError("GetChannelMember", "not_found", nil, "", http.StatusNotFound)).Once()
+
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
 			"logs":       "test",
 			"channel_id": originChannelID,
-			"team_id":    "",
 		})))
 		r.Header.Set("Mattermost-User-Id", userID)
 		p.handleUploadLogsToBot(w, r)
-		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, http.StatusForbidden, w.Code)
 	})
 
 	t.Run("happy path uploads, posts, and emits ephemeral with permalink", func(t *testing.T) {
@@ -100,6 +101,8 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		fileID := model.NewId()
 		filenameRE := regexp.MustCompile(`^call_logs_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.txt$`)
 
+		mockAPI.On("GetChannelMember", originChannelID, userID).Return(&model.ChannelMember{ChannelId: originChannelID, UserId: userID}, nil).Once()
+		mockAPI.On("GetChannel", originChannelID).Return(&model.Channel{Id: originChannelID, TeamId: teamID}, nil).Once()
 		mockAPI.On("GetDirectChannel", userID, botID).Return(&model.Channel{Id: dmChannelID}, nil).Once()
 		mockAPI.On("UploadFile", mock.Anything, dmChannelID, mock.MatchedBy(func(name string) bool {
 			return filenameRE.MatchString(name)
@@ -121,7 +124,6 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
 			"logs":       "test content",
 			"channel_id": originChannelID,
-			"team_id":    teamID,
 		})))
 		r.Header.Set("Mattermost-User-Id", userID)
 		p.handleUploadLogsToBot(w, r)
@@ -129,6 +131,60 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code)
 		require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 		require.JSONEq(t, "{}", w.Body.String())
+	})
+
+	t.Run("DM/GM channel falls back to one of the user's teams", func(t *testing.T) {
+		p, mockAPI := newPlugin()
+		defer mockAPI.AssertExpectations(t)
+
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		// A DM/GM channel has no TeamId, so the team is resolved from the
+		// requester's own memberships rather than from the channel.
+		mockAPI.On("GetChannelMember", originChannelID, userID).Return(&model.ChannelMember{ChannelId: originChannelID, UserId: userID}, nil).Once()
+		mockAPI.On("GetChannel", originChannelID).Return(&model.Channel{Id: originChannelID, TeamId: ""}, nil).Once()
+		mockAPI.On("GetTeamsForUser", userID).Return([]*model.Team{{Id: teamID, Name: teamName}}, nil).Once()
+		mockAPI.On("GetDirectChannel", userID, botID).Return(&model.Channel{Id: dmChannelID}, nil).Once()
+		mockAPI.On("UploadFile", mock.Anything, dmChannelID, mock.Anything).Return(&model.FileInfo{Id: fileID}, nil).Once()
+		mockAPI.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID, ChannelId: dmChannelID, FileIds: []string{fileID}}, nil).Once()
+		mockAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: teamName}, nil).Once()
+		mockAPI.On("GetConfig").Return(&model.Config{
+			ServiceSettings: model.ServiceSettings{SiteURL: model.NewPointer(siteURL)},
+		}).Once()
+
+		expectedPermalink := fmt.Sprintf("%s/%s/pl/%s", siteURL, teamName, postID)
+		mockAPI.On("SendEphemeralPost", userID, mock.MatchedBy(func(post *model.Post) bool {
+			return post.ChannelId == originChannelID && strings.Contains(post.Message, expectedPermalink)
+		})).Return(&model.Post{}).Once()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       "test content",
+			"channel_id": originChannelID,
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("DM/GM channel with no team membership is rejected", func(t *testing.T) {
+		p, mockAPI := newPlugin()
+		defer mockAPI.AssertExpectations(t)
+
+		mockAPI.On("GetChannelMember", originChannelID, userID).Return(&model.ChannelMember{ChannelId: originChannelID, UserId: userID}, nil).Once()
+		mockAPI.On("GetChannel", originChannelID).Return(&model.Channel{Id: originChannelID, TeamId: ""}, nil).Once()
+		mockAPI.On("GetTeamsForUser", userID).Return([]*model.Team{}, nil).Once()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       "test",
+			"channel_id": originChannelID,
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+		require.Equal(t, http.StatusForbidden, w.Code)
 	})
 
 	t.Run("accepts logs above the old 1MB body limit, leaving margin for JSON escaping", func(t *testing.T) {
@@ -143,6 +199,8 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		// used to trip the old 1MB server body limit and 400.
 		logs := strings.Repeat("a", 1536*1024)
 
+		mockAPI.On("GetChannelMember", originChannelID, userID).Return(&model.ChannelMember{ChannelId: originChannelID, UserId: userID}, nil).Once()
+		mockAPI.On("GetChannel", originChannelID).Return(&model.Channel{Id: originChannelID, TeamId: teamID}, nil).Once()
 		mockAPI.On("GetDirectChannel", userID, botID).Return(&model.Channel{Id: dmChannelID}, nil).Once()
 		mockAPI.On("UploadFile", mock.Anything, dmChannelID, mock.Anything).Return(&model.FileInfo{Id: fileID}, nil).Once()
 		mockAPI.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID, ChannelId: dmChannelID, FileIds: []string{fileID}}, nil).Once()
@@ -156,7 +214,6 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
 			"logs":       logs,
 			"channel_id": originChannelID,
-			"team_id":    teamID,
 		})))
 		r.Header.Set("Mattermost-User-Id", userID)
 		p.handleUploadLogsToBot(w, r)
@@ -171,7 +228,6 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
 			"logs":       strings.Repeat("a", 3*1024*1024),
 			"channel_id": originChannelID,
-			"team_id":    teamID,
 		})))
 		r.Header.Set("Mattermost-User-Id", userID)
 		p.handleUploadLogsToBot(w, r)

--- a/server/logs_test.go
+++ b/server/logs_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+
+	pluginMocks "github.com/mattermost/mattermost-plugin-calls/server/mocks/github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleUploadLogsToBot(t *testing.T) {
+	botID := model.NewId()
+	userID := model.NewId()
+	dmChannelID := model.NewId()
+	originChannelID := model.NewId()
+	teamID := model.NewId()
+	teamName := "myteam"
+	siteURL := "https://example.test"
+
+	newPlugin := func() (*Plugin, *pluginMocks.MockAPI) {
+		mockAPI := &pluginMocks.MockAPI{}
+		p := &Plugin{
+			MattermostPlugin: plugin.MattermostPlugin{API: mockAPI},
+			botSession:       &model.Session{UserId: botID},
+		}
+		return p, mockAPI
+	}
+
+	body := func(payload any) string {
+		raw, err := json.Marshal(payload)
+		require.NoError(t, err)
+		return string(raw)
+	}
+
+	t.Run("unauthorized without user id header", func(t *testing.T) {
+		p, _ := newPlugin()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       "test",
+			"channel_id": originChannelID,
+			"team_id":    teamID,
+		})))
+		p.handleUploadLogsToBot(w, r)
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("invalid request body", func(t *testing.T) {
+		p, _ := newPlugin()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader("not json"))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("rejects invalid channel_id", func(t *testing.T) {
+		p, _ := newPlugin()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       "test",
+			"channel_id": "too-short",
+			"team_id":    teamID,
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("rejects invalid team_id", func(t *testing.T) {
+		p, _ := newPlugin()
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       "test",
+			"channel_id": originChannelID,
+			"team_id":    "",
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("happy path uploads, posts, and emits ephemeral with permalink", func(t *testing.T) {
+		p, mockAPI := newPlugin()
+		defer mockAPI.AssertExpectations(t)
+
+		postID := model.NewId()
+		fileID := model.NewId()
+		filenameRE := regexp.MustCompile(`^call_logs_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.txt$`)
+
+		mockAPI.On("GetDirectChannel", userID, botID).Return(&model.Channel{Id: dmChannelID}, nil).Once()
+		mockAPI.On("UploadFile", mock.Anything, dmChannelID, mock.MatchedBy(func(name string) bool {
+			return filenameRE.MatchString(name)
+		})).Return(&model.FileInfo{Id: fileID}, nil).Once()
+		mockAPI.On("CreatePost", mock.MatchedBy(func(p *model.Post) bool {
+			return p.UserId == botID && p.ChannelId == dmChannelID && len(p.FileIds) == 1 && p.FileIds[0] == fileID
+		})).Return(&model.Post{Id: postID, ChannelId: dmChannelID, FileIds: []string{fileID}}, nil).Once()
+		mockAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: teamName}, nil).Once()
+		mockAPI.On("GetConfig").Return(&model.Config{
+			ServiceSettings: model.ServiceSettings{SiteURL: model.NewPointer(siteURL)},
+		}).Once()
+
+		expectedPermalink := fmt.Sprintf("%s/%s/pl/%s", siteURL, teamName, postID)
+		mockAPI.On("SendEphemeralPost", userID, mock.MatchedBy(func(post *model.Post) bool {
+			return post.ChannelId == originChannelID && strings.Contains(post.Message, expectedPermalink)
+		})).Return(&model.Post{}).Once()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       "test content",
+			"channel_id": originChannelID,
+			"team_id":    teamID,
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+		require.JSONEq(t, "{}", w.Body.String())
+	})
+
+	t.Run("accepts logs above the old 1MB body limit, leaving margin for JSON escaping", func(t *testing.T) {
+		p, mockAPI := newPlugin()
+		defer mockAPI.AssertExpectations(t)
+
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		// 1.5MB of log text: comfortably over the client's 1MB cap once
+		// JSON-escaping overhead is added, yet under the upload limit. This
+		// used to trip the old 1MB server body limit and 400.
+		logs := strings.Repeat("a", 1536*1024)
+
+		mockAPI.On("GetDirectChannel", userID, botID).Return(&model.Channel{Id: dmChannelID}, nil).Once()
+		mockAPI.On("UploadFile", mock.Anything, dmChannelID, mock.Anything).Return(&model.FileInfo{Id: fileID}, nil).Once()
+		mockAPI.On("CreatePost", mock.Anything).Return(&model.Post{Id: postID, ChannelId: dmChannelID, FileIds: []string{fileID}}, nil).Once()
+		mockAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: teamName}, nil).Once()
+		mockAPI.On("GetConfig").Return(&model.Config{
+			ServiceSettings: model.ServiceSettings{SiteURL: model.NewPointer(siteURL)},
+		}).Once()
+		mockAPI.On("SendEphemeralPost", userID, mock.Anything).Return(&model.Post{}).Once()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       logs,
+			"channel_id": originChannelID,
+			"team_id":    teamID,
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("rejects bodies beyond the upload size limit", func(t *testing.T) {
+		p, _ := newPlugin()
+		w := httptest.NewRecorder()
+		// A logs string larger than logsUploadMaxSizeBytes (2MB) on its own.
+		r := httptest.NewRequest(http.MethodPost, "/logs/upload", strings.NewReader(body(map[string]string{
+			"logs":       strings.Repeat("a", 3*1024*1024),
+			"channel_id": originChannelID,
+			"team_id":    teamID,
+		})))
+		r.Header.Set("Mattermost-User-Id", userID)
+		p.handleUploadLogsToBot(w, r)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -135,22 +135,6 @@ func handleStatsCommand(fields []string) (*model.CommandResponse, error) {
 	}, nil
 }
 
-func handleLogsCommand(fields []string) (*model.CommandResponse, error) {
-	if len(fields) < 3 {
-		return nil, fmt.Errorf("empty logs")
-	}
-
-	logs, err := base64.StdEncoding.DecodeString(fields[2])
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode payload: %w", err)
-	}
-
-	return &model.CommandResponse{
-		ResponseType: model.CommandResponseTypeEphemeral,
-		Text:         fmt.Sprintf("```\n%s\n```", logs),
-	}, nil
-}
-
 func (p *Plugin) handleEndCallCommand() (*model.CommandResponse, error) {
 	return &model.CommandResponse{}, nil
 }
@@ -222,10 +206,6 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 
 	if subCmd == statsCommandTrigger {
 		return buildCommandResponse(handleStatsCommand(fields))
-	}
-
-	if subCmd == logsCommandTrigger {
-		return buildCommandResponse(handleLogsCommand(fields))
 	}
 
 	if subCmd == endCommandTrigger {

--- a/server/utils.go
+++ b/server/utils.go
@@ -29,7 +29,9 @@ const (
 	channelNameMaxLength = 24
 )
 
-var filenameSanitizationRE = regexp.MustCompile(`[\\:*?\"<>|\n\s/]`)
+// filenameSanitizationRE matches any character NOT in the allowlist.
+// This prevents Markdown/HTML injection when filenames are embedded in Markdown.
+var filenameSanitizationRE = regexp.MustCompile(`[^a-zA-Z0-9._\-]`)
 
 func (p *Plugin) getNotificationNameFormat(userID string) string {
 	config := p.API.GetConfig()

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -48,38 +48,6 @@ import {
 } from './constants';
 import {ConnectPayload, ReactionPayload, RtcTokenResponse} from './types';
 
-// trackPubSummary returns a compact, log-friendly view of a track publication.
-// We deliberately avoid logging the raw LiveKit publication object: it serializes
-// to several KB (EventEmitter internals, logger config, full trackInfo/options),
-// which floods the client log buffer. Media-performance fields (bitrate, bytes,
-// jitter) are intentionally omitted — those belong to the RTC stats report.
-// Remote publications also carry subscription/permission state, which has no
-// local equivalent and is not surfaced by getStats().
-function trackPubSummary(pub: TrackPublication) {
-    const summary: Record<string, unknown> = {
-        sid: pub.trackSid,
-        source: pub.source,
-        kind: pub.kind,
-        muted: pub.isMuted,
-        mimeType: pub.mimeType,
-    };
-    if (pub instanceof RemoteTrackPublication) {
-        summary.subscribed = pub.isSubscribed;
-        summary.permission = pub.permissionStatus;
-    }
-    return summary;
-}
-
-// trackSummary is the equivalent compact view for a subscribed remote track.
-function trackSummary(track: RemoteTrack) {
-    return {
-        sid: track.sid,
-        source: track.source,
-        kind: track.kind,
-        streamState: track.streamState,
-    };
-}
-
 export default class CallClient extends EventEmitter {
     public channelID = '';
     public initTime = 0;
@@ -150,6 +118,38 @@ export default class CallClient extends EventEmitter {
         room.on(RoomEvent.MediaDevicesError, this.handleMediaDevicesError.bind(this));
         room.on(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged.bind(this));
         room.on(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged.bind(this));
+    }
+
+    // trackPubSummary returns a compact, log-friendly view of a track publication.
+    // We deliberately avoid logging the raw LiveKit publication object: it serializes
+    // to several KB (EventEmitter internals, logger config, full trackInfo/options),
+    // which floods the client log buffer. Media-performance fields (bitrate, bytes,
+    // jitter) are intentionally omitted — those belong to the RTC stats report.
+    // Remote publications also carry subscription/permission state, which has no
+    // local equivalent and is not surfaced by getStats().
+    private trackPubSummary(pub: TrackPublication) {
+        const summary: Record<string, unknown> = {
+            sid: pub.trackSid,
+            source: pub.source,
+            kind: pub.kind,
+            muted: pub.isMuted,
+            mimeType: pub.mimeType,
+        };
+        if (pub instanceof RemoteTrackPublication) {
+            summary.subscribed = pub.isSubscribed;
+            summary.permission = pub.permissionStatus;
+        }
+        return summary;
+    }
+
+    // trackSummary is the equivalent compact view for a subscribed remote track.
+    private trackSummary(track: RemoteTrack) {
+        return {
+            sid: track.sid,
+            source: track.source,
+            kind: track.kind,
+            streamState: track.streamState,
+        };
     }
 
     // True while the LiveKit room is connected and we haven't torn down. Note this
@@ -853,7 +853,7 @@ export default class CallClient extends EventEmitter {
             const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(localParticipant);
             this.emit(localTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, sessionID, userID);
 
-            logDebug(`CallClient: local voice stream published for user ${userID}`, trackPubSummary(localTrackPublication));
+            logDebug(`CallClient: local voice stream published for user ${userID}`, this.trackPubSummary(localTrackPublication));
         }
 
         // Browser renders a native "Stop sharing" bar when sharing screen which has dismiss/stop button.
@@ -886,7 +886,7 @@ export default class CallClient extends EventEmitter {
             if (screenShareStream) {
                 const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(localParticipant);
                 this.emit(CALL_EVENT.LOCAL_SCREEN_STREAM, screenShareStream, sessionID, userID);
-                logDebug(`CallClient: local screen share stream published for user ${userID}`, trackPubSummary(localTrackPublication));
+                logDebug(`CallClient: local screen share stream published for user ${userID}`, this.trackPubSummary(localTrackPublication));
             }
         }
     }
@@ -901,12 +901,12 @@ export default class CallClient extends EventEmitter {
 
         if (localTrackPublication.source === Track.Source.Microphone) {
             this.emit(CALL_EVENT.MUTE, sessionID, userID);
-            logDebug(`CallClient: local voice stream unpublished for user ${userID}`, trackPubSummary(localTrackPublication));
+            logDebug(`CallClient: local voice stream unpublished for user ${userID}`, this.trackPubSummary(localTrackPublication));
         }
 
         if (localTrackPublication.source === Track.Source.ScreenShare) {
             this.emit(CALL_EVENT.LOCAL_SCREEN_STREAM_OFF, sessionID, userID);
-            logDebug(`CallClient: local screen share stream unpublished for user ${userID}`, trackPubSummary(localTrackPublication));
+            logDebug(`CallClient: local screen share stream unpublished for user ${userID}`, this.trackPubSummary(localTrackPublication));
         }
     }
 
@@ -920,14 +920,14 @@ export default class CallClient extends EventEmitter {
 
         if (remoteTrackPublication.source === Track.Source.Microphone) {
             this.emit(remoteTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, sessionID, userID);
-            logDebug(`CallClient: remote voice stream published for user ${userID}`, trackPubSummary(remoteTrackPublication));
+            logDebug(`CallClient: remote voice stream published for user ${userID}`, this.trackPubSummary(remoteTrackPublication));
         }
 
         if (remoteTrackPublication.source === Track.Source.ScreenShare || remoteTrackPublication.source === Track.Source.ScreenShareAudio) {
             // Screen-share publications do not carry stream state before subscription:
             // `remoteTrackPublication.track` is undefined here. The actual MediaStreamTrack arrives in
             // handleRemoteTrackSubscribed, which is where we compose and emit REMOTE_SCREEN_STREAM.
-            logDebug(`CallClient: remote screen share stream announced (awaiting subscription) for user ${userID}`, trackPubSummary(remoteTrackPublication));
+            logDebug(`CallClient: remote screen share stream announced (awaiting subscription) for user ${userID}`, this.trackPubSummary(remoteTrackPublication));
         }
     }
 
@@ -942,14 +942,14 @@ export default class CallClient extends EventEmitter {
         if (remoteTrack.source === Track.Source.Microphone) {
             const stream = new MediaStream([remoteTrack.mediaStreamTrack]);
             this.emit(CALL_EVENT.REMOTE_VOICE_STREAM, stream, sessionID, userID);
-            logDebug(`CallClient: remote voice stream subscribed for user ${userID}`, trackSummary(remoteTrack));
+            logDebug(`CallClient: remote voice stream subscribed for user ${userID}`, this.trackSummary(remoteTrack));
         }
 
         if (remoteTrack.source === Track.Source.ScreenShare || remoteTrack.source === Track.Source.ScreenShareAudio) {
             const screenShareStream = this.composeScreenShareStream(remoteParticipant);
             if (screenShareStream) {
                 this.emit(CALL_EVENT.REMOTE_SCREEN_STREAM, screenShareStream, sessionID, userID);
-                logDebug(`CallClient: remote screen share stream subscribed for user ${userID}`, trackSummary(remoteTrack));
+                logDebug(`CallClient: remote screen share stream subscribed for user ${userID}`, this.trackSummary(remoteTrack));
             }
         }
     }
@@ -964,12 +964,12 @@ export default class CallClient extends EventEmitter {
 
         if (remoteTrackPublication.source === Track.Source.Microphone) {
             this.emit(CALL_EVENT.MUTE, sessionID, userID);
-            logDebug(`CallClient: remote voice stream unpublished for user ${userID}`, trackPubSummary(remoteTrackPublication));
+            logDebug(`CallClient: remote voice stream unpublished for user ${userID}`, this.trackPubSummary(remoteTrackPublication));
         }
 
         if (remoteTrackPublication.source === Track.Source.ScreenShare) {
             this.emit(CALL_EVENT.REMOTE_SCREEN_STREAM_OFF, sessionID, userID);
-            logDebug(`CallClient: remote screen share stream unpublished for user ${userID}`, trackPubSummary(remoteTrackPublication));
+            logDebug(`CallClient: remote screen share stream unpublished for user ${userID}`, this.trackPubSummary(remoteTrackPublication));
         }
     }
 
@@ -982,7 +982,7 @@ export default class CallClient extends EventEmitter {
             const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(participant);
             this.emit(CALL_EVENT.MUTE, sessionID, userID);
 
-            logDebug(`CallClient: track muted for user ${userID}`, trackPubSummary(trackPublication));
+            logDebug(`CallClient: track muted for user ${userID}`, this.trackPubSummary(trackPublication));
         }
     }
 
@@ -995,7 +995,7 @@ export default class CallClient extends EventEmitter {
             const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(participant);
             this.emit(CALL_EVENT.UNMUTE, sessionID, userID);
 
-            logDebug(`CallClient: track unmuted for user ${userID}`, trackPubSummary(trackPublication));
+            logDebug(`CallClient: track unmuted for user ${userID}`, this.trackPubSummary(trackPublication));
         }
     }
 

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -48,6 +48,38 @@ import {
 } from './constants';
 import {ConnectPayload, ReactionPayload, RtcTokenResponse} from './types';
 
+// trackPubSummary returns a compact, log-friendly view of a track publication.
+// We deliberately avoid logging the raw LiveKit publication object: it serializes
+// to several KB (EventEmitter internals, logger config, full trackInfo/options),
+// which floods the client log buffer. Media-performance fields (bitrate, bytes,
+// jitter) are intentionally omitted — those belong to the RTC stats report.
+// Remote publications also carry subscription/permission state, which has no
+// local equivalent and is not surfaced by getStats().
+function trackPubSummary(pub: TrackPublication) {
+    const summary: Record<string, unknown> = {
+        sid: pub.trackSid,
+        source: pub.source,
+        kind: pub.kind,
+        muted: pub.isMuted,
+        mimeType: pub.mimeType,
+    };
+    if (pub instanceof RemoteTrackPublication) {
+        summary.subscribed = pub.isSubscribed;
+        summary.permission = pub.permissionStatus;
+    }
+    return summary;
+}
+
+// trackSummary is the equivalent compact view for a subscribed remote track.
+function trackSummary(track: RemoteTrack) {
+    return {
+        sid: track.sid,
+        source: track.source,
+        kind: track.kind,
+        streamState: track.streamState,
+    };
+}
+
 export default class CallClient extends EventEmitter {
     public channelID = '';
     public initTime = 0;
@@ -821,7 +853,7 @@ export default class CallClient extends EventEmitter {
             const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(localParticipant);
             this.emit(localTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, sessionID, userID);
 
-            logDebug(`CallClient: local voice stream published for user ${userID}`, localTrackPublication);
+            logDebug(`CallClient: local voice stream published for user ${userID}`, trackPubSummary(localTrackPublication));
         }
 
         // Browser renders a native "Stop sharing" bar when sharing screen which has dismiss/stop button.
@@ -854,7 +886,7 @@ export default class CallClient extends EventEmitter {
             if (screenShareStream) {
                 const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(localParticipant);
                 this.emit(CALL_EVENT.LOCAL_SCREEN_STREAM, screenShareStream, sessionID, userID);
-                logDebug(`CallClient: local screen share stream published for user ${userID}`, localTrackPublication);
+                logDebug(`CallClient: local screen share stream published for user ${userID}`, trackPubSummary(localTrackPublication));
             }
         }
     }
@@ -869,12 +901,12 @@ export default class CallClient extends EventEmitter {
 
         if (localTrackPublication.source === Track.Source.Microphone) {
             this.emit(CALL_EVENT.MUTE, sessionID, userID);
-            logDebug(`CallClient: local voice stream unpublished for user ${userID}`, localTrackPublication);
+            logDebug(`CallClient: local voice stream unpublished for user ${userID}`, trackPubSummary(localTrackPublication));
         }
 
         if (localTrackPublication.source === Track.Source.ScreenShare) {
             this.emit(CALL_EVENT.LOCAL_SCREEN_STREAM_OFF, sessionID, userID);
-            logDebug(`CallClient: local screen share stream unpublished for user ${userID}`, localTrackPublication);
+            logDebug(`CallClient: local screen share stream unpublished for user ${userID}`, trackPubSummary(localTrackPublication));
         }
     }
 
@@ -888,14 +920,14 @@ export default class CallClient extends EventEmitter {
 
         if (remoteTrackPublication.source === Track.Source.Microphone) {
             this.emit(remoteTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, sessionID, userID);
-            logDebug(`CallClient: remote voice stream published for user ${userID}`, remoteTrackPublication);
+            logDebug(`CallClient: remote voice stream published for user ${userID}`, trackPubSummary(remoteTrackPublication));
         }
 
         if (remoteTrackPublication.source === Track.Source.ScreenShare || remoteTrackPublication.source === Track.Source.ScreenShareAudio) {
             // Screen-share publications do not carry stream state before subscription:
             // `remoteTrackPublication.track` is undefined here. The actual MediaStreamTrack arrives in
             // handleRemoteTrackSubscribed, which is where we compose and emit REMOTE_SCREEN_STREAM.
-            logDebug(`CallClient: remote screen share stream announced (awaiting subscription) for user ${userID}`, remoteTrackPublication);
+            logDebug(`CallClient: remote screen share stream announced (awaiting subscription) for user ${userID}`, trackPubSummary(remoteTrackPublication));
         }
     }
 
@@ -910,14 +942,14 @@ export default class CallClient extends EventEmitter {
         if (remoteTrack.source === Track.Source.Microphone) {
             const stream = new MediaStream([remoteTrack.mediaStreamTrack]);
             this.emit(CALL_EVENT.REMOTE_VOICE_STREAM, stream, sessionID, userID);
-            logDebug(`CallClient: remote voice stream subscribed for user ${userID}`, remoteTrack);
+            logDebug(`CallClient: remote voice stream subscribed for user ${userID}`, trackSummary(remoteTrack));
         }
 
         if (remoteTrack.source === Track.Source.ScreenShare || remoteTrack.source === Track.Source.ScreenShareAudio) {
             const screenShareStream = this.composeScreenShareStream(remoteParticipant);
             if (screenShareStream) {
                 this.emit(CALL_EVENT.REMOTE_SCREEN_STREAM, screenShareStream, sessionID, userID);
-                logDebug(`CallClient: remote screen share stream subscribed for user ${userID}`, remoteTrack);
+                logDebug(`CallClient: remote screen share stream subscribed for user ${userID}`, trackSummary(remoteTrack));
             }
         }
     }
@@ -932,12 +964,12 @@ export default class CallClient extends EventEmitter {
 
         if (remoteTrackPublication.source === Track.Source.Microphone) {
             this.emit(CALL_EVENT.MUTE, sessionID, userID);
-            logDebug(`CallClient: remote voice stream unpublished for user ${userID}`, remoteTrackPublication);
+            logDebug(`CallClient: remote voice stream unpublished for user ${userID}`, trackPubSummary(remoteTrackPublication));
         }
 
         if (remoteTrackPublication.source === Track.Source.ScreenShare) {
             this.emit(CALL_EVENT.REMOTE_SCREEN_STREAM_OFF, sessionID, userID);
-            logDebug(`CallClient: remote screen share stream unpublished for user ${userID}`, remoteTrackPublication);
+            logDebug(`CallClient: remote screen share stream unpublished for user ${userID}`, trackPubSummary(remoteTrackPublication));
         }
     }
 
@@ -950,7 +982,7 @@ export default class CallClient extends EventEmitter {
             const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(participant);
             this.emit(CALL_EVENT.MUTE, sessionID, userID);
 
-            logDebug(`CallClient: track muted for user ${userID}`, trackPublication);
+            logDebug(`CallClient: track muted for user ${userID}`, trackPubSummary(trackPublication));
         }
     }
 
@@ -963,7 +995,7 @@ export default class CallClient extends EventEmitter {
             const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(participant);
             this.emit(CALL_EVENT.UNMUTE, sessionID, userID);
 
-            logDebug(`CallClient: track unmuted for user ${userID}`, trackPublication);
+            logDebug(`CallClient: track unmuted for user ${userID}`, trackPubSummary(trackPublication));
         }
     }
 

--- a/webapp/src/components/call_widget/component.tsx
+++ b/webapp/src/components/call_widget/component.tsx
@@ -940,6 +940,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         }
 
         if (window.callsClient) {
+            logDebug('CallWidget.onDisconnectClick: user left call');
             window.callsClient.disconnect();
         }
     };
@@ -965,6 +966,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
     onAudioInputDeviceClick = (device: MediaDeviceInfo) => {
         if (device.deviceId !== this.state.currentAudioInputDevice?.deviceId) {
+            logDebug(`CallWidget.onAudioInputDeviceClick: switching audio input to '${device.label}'`);
             window.callsClient?.setAudioInputDevice(device);
         }
         this.setState({showAudioInputDevicesMenu: false, currentAudioInputDevice: device});
@@ -972,6 +974,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
 
     onAudioOutputDeviceClick = (device: MediaDeviceInfo) => {
         if (device.deviceId !== this.state.currentAudioOutputDevice?.deviceId) {
+            logDebug(`CallWidget.onAudioOutputDeviceClick: switching audio output to '${device.label}'`);
             window.callsClient?.setAudioOutputDevice(device);
             const ps = [];
             for (const audioEl of this.state.audioEls) {
@@ -995,6 +998,7 @@ export default class CallWidget extends React.PureComponent<Props, State> {
     };
 
     onRemoveConfirm = () => {
+        logDebug(`CallWidget.onRemoveConfirm: host removing session ${this.state.removeConfirmation?.sessionID}`);
         hostRemove(this.props.channel?.id, this.state.removeConfirmation?.sessionID);
         this.setState({
             removeConfirmation: null,
@@ -2118,8 +2122,10 @@ export default class CallWidget extends React.PureComponent<Props, State> {
         }
 
         if (this.isHandRaised()) {
+            logDebug('CallWidget.onRaiseHandToggle: lowering hand');
             window.callsClient.unraiseHand();
         } else {
+            logDebug('CallWidget.onRaiseHandToggle: raising hand');
             window.callsClient.raiseHand();
         }
     };

--- a/webapp/src/components/call_widget/end_call_confirmation.tsx
+++ b/webapp/src/components/call_widget/end_call_confirmation.tsx
@@ -5,6 +5,7 @@ import React, {ComponentProps} from 'react';
 import {useIntl} from 'react-intl';
 import {endCall} from 'src/actions';
 import GenericModal from 'src/components/generic_modal';
+import {logDebug} from 'src/log';
 import styled from 'styled-components';
 
 export const IDEndCallConfirmation = 'end_call_confirmation';
@@ -29,7 +30,10 @@ export const EndCallConfirmation = ({channelID, ...modalProps}: Props) => {
             confirmButtonText={confirmText}
             cancelButtonText={cancelText}
             isConfirmDestructive={true}
-            handleConfirm={() => endCall(channelID)}
+            handleConfirm={() => {
+                logDebug('EndCallConfirmation: host ending call for everyone');
+                endCall(channelID);
+            }}
             showCancel={true}
             onHide={() => null}
             components={{FooterContainer}}

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -1541,8 +1541,12 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                                 {showMuteOthers &&
                                     <MuteOthersButton
                                         onClick={() => {
+                                            if (!this.props.channel) {
+                                                logErr('channel should be defined');
+                                                return;
+                                            }
                                             logDebug('ExpandedView: host muting all other participants');
-                                            hostMuteOthers(this.props.channel?.id);
+                                            hostMuteOthers(this.props.channel.id);
                                         }}
                                     >
                                         <MutedIcon

--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -451,6 +451,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
         this.props.hideExpandedView();
         const callsClient = getCallsClient();
         if (callsClient) {
+            logDebug('ExpandedView.onDisconnectClick: user left call');
             callsClient.disconnect();
             if (window.opener) {
                 window.close();
@@ -499,6 +500,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                 },
             });
         } else {
+            logDebug('ExpandedView.onRecordToggle: starting recording');
             await this.props.startCallRecording(this.props.channel.id);
         }
     };
@@ -534,8 +536,10 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
     onRaiseHandToggle = () => {
         const callsClient = getCallsClient();
         if (this.isHandRaised()) {
+            logDebug('ExpandedView.onRaiseHandToggle: lowering hand');
             callsClient?.unraiseHand();
         } else {
+            logDebug('ExpandedView.onRaiseHandToggle: raising hand');
             callsClient?.raiseHand();
         }
     };
@@ -885,6 +889,7 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
     };
 
     onRemoveConfirm = () => {
+        logDebug(`ExpandedView.onRemoveConfirm: host removing session ${this.state.removeConfirmation?.sessionID}`);
         hostRemove(this.props.channel?.id, this.state.removeConfirmation?.sessionID);
         this.setState({
             removeConfirmation: null,
@@ -1534,7 +1539,12 @@ export default class ExpandedView extends React.PureComponent<Props, State> {
                                 <span>{formatMessage({defaultMessage: 'Participants'})}</span>
                                 <ToTheRight/>
                                 {showMuteOthers &&
-                                    <MuteOthersButton onClick={() => hostMuteOthers(this.props.channel?.id)}>
+                                    <MuteOthersButton
+                                        onClick={() => {
+                                            logDebug('ExpandedView: host muting all other participants');
+                                            hostMuteOthers(this.props.channel?.id);
+                                        }}
+                                    >
                                         <MutedIcon
                                             fill='var(--button-bg)'
                                             style={{width: '12px', height: '12px'}}

--- a/webapp/src/components/expanded_view/reaction_button.tsx
+++ b/webapp/src/components/expanded_view/reaction_button.tsx
@@ -20,6 +20,7 @@ import UnraisedHandIcon from 'src/components/icons/unraised_hand';
 import {StyledTooltip} from 'src/components/shared';
 import Shortcut from 'src/components/shortcut';
 import {EmojiIndicesByAlias} from 'src/emojis/emoji';
+import {logDebug} from 'src/log';
 import {MAKE_REACTION, RAISE_LOWER_HAND, reverseKeyMappings} from 'src/shortcuts';
 import {getCallsClient} from 'src/utils';
 import styled, {css} from 'styled-components';
@@ -79,8 +80,10 @@ export const ReactionButton = forwardRef(({isHandRaised}: Props, ref) => {
 
     const onRaiseHandToggle = () => {
         if (isHandRaised) {
+            logDebug('ReactionButton.onRaiseHandToggle: lowering hand');
             callsClient?.unraiseHand();
         } else {
+            logDebug('ReactionButton.onRaiseHandToggle: raising hand');
             callsClient?.raiseHand();
         }
     };
@@ -109,6 +112,7 @@ export const ReactionButton = forwardRef(({isHandRaised}: Props, ref) => {
             unified: ecd.unified.toLowerCase(),
             literal: ecd.emoji || '',
         };
+        logDebug(`ReactionButton.handleUserPicksEmoji: sending reaction '${emojiData.name}'`);
         callsClient?.sendReaction(emojiData);
 
         // hide everything

--- a/webapp/src/components/expanded_view/stop_recording_confirmation.tsx
+++ b/webapp/src/components/expanded_view/stop_recording_confirmation.tsx
@@ -6,6 +6,7 @@ import {useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
 import {stopCallRecording} from 'src/actions';
 import GenericModal from 'src/components/generic_modal';
+import {logDebug} from 'src/log';
 import {transcriptionsEnabled} from 'src/selectors';
 import styled from 'styled-components';
 
@@ -37,7 +38,10 @@ export const StopRecordingConfirmation = ({channelID, ...modalProps}: Props) => 
             confirmButtonText={confirmText}
             cancelButtonText={cancelText}
             isConfirmDestructive={true}
-            handleConfirm={() => stopCallRecording(channelID)}
+            handleConfirm={() => {
+                logDebug('StopRecordingConfirmation: stopping recording');
+                stopCallRecording(channelID);
+            }}
             showCancel={true}
             onHide={() => null}
             components={{FooterContainer}}

--- a/webapp/src/components/host_controls_menu.tsx
+++ b/webapp/src/components/host_controls_menu.tsx
@@ -10,6 +10,7 @@ import MonitorAccount from 'src/components/icons/monitor_account';
 import MutedIcon from 'src/components/icons/muted_icon';
 import UnraisedHandIcon from 'src/components/icons/unraised_hand';
 import UnshareScreenIcon from 'src/components/icons/unshare_screen';
+import {logDebug} from 'src/log';
 import styled from 'styled-components';
 
 type Props = {
@@ -40,7 +41,12 @@ export const HostControlsMenu = ({
     }
 
     const muteUnmute = isMuted ? null : (
-        <DropdownMenuItem onClick={() => hostMute(callID, sessionID)}>
+        <DropdownMenuItem
+            onClick={() => {
+                logDebug(`HostControlsMenu: mute participant ${sessionID}`);
+                hostMute(callID, sessionID);
+            }}
+        >
             <MutedIcon
                 data-testid={'host-mute'}
                 fill='var(--center-channel-color-56)'
@@ -56,7 +62,12 @@ export const HostControlsMenu = ({
         <>
             {muteUnmute}
             {isSharingScreen &&
-                <DropdownMenuItem onClick={() => hostScreenOff(callID, sessionID)}>
+                <DropdownMenuItem
+                    onClick={() => {
+                        logDebug(`HostControlsMenu: stop screen share for ${sessionID}`);
+                        hostScreenOff(callID, sessionID);
+                    }}
+                >
                     <UnshareScreenIcon
                         fill='var(--center-channel-color-56)'
                         style={{width: '16px', height: '16px'}}
@@ -65,7 +76,12 @@ export const HostControlsMenu = ({
                 </DropdownMenuItem>
             }
             {isHandRaised &&
-                <DropdownMenuItem onClick={() => hostLowerHand(callID, sessionID)}>
+                <DropdownMenuItem
+                    onClick={() => {
+                        logDebug(`HostControlsMenu: lower hand for ${sessionID}`);
+                        hostLowerHand(callID, sessionID);
+                    }}
+                >
                     <UnraisedHandIcon
                         fill='var(--center-channel-color-56)'
                         style={{width: '16px', height: '16px'}}
@@ -74,7 +90,12 @@ export const HostControlsMenu = ({
                 </DropdownMenuItem>
             }
             {!isHost &&
-                <DropdownMenuItem onClick={() => hostMake(callID, userID)}>
+                <DropdownMenuItem
+                    onClick={() => {
+                        logDebug(`HostControlsMenu: make host ${userID}`);
+                        hostMake(callID, userID);
+                    }}
+                >
                     <MonitorAccount
                         fill='var(--center-channel-color-56)'
                         style={{width: '16px', height: '16px'}}

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -124,3 +124,6 @@ export const STORAGE_CALLS_DEFAULT_VIDEO_INPUT_KEY = 'calls_default_video_input'
 export const STORAGE_CALLS_EXPERIMENTAL_FEATURES_KEY = 'calls_experimental_features';
 export const STORAGE_CALLS_MIRROR_VIDEO_KEY = 'calls_mirror_video';
 export const STORAGE_CALLS_BLUR_BACKGROUND_KEY = 'calls_blur_background';
+
+// Log buffer size limit
+export const MAX_ACCUMULATED_LOG_SIZE = 1024 * 1024; // 1 MB

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -129,7 +129,7 @@ import SwitchCallModal from './components/switch_call_modal';
 import {
     handleDesktopJoinedCall,
 } from './desktop';
-import {logDebug, logErr, logWarn} from './log';
+import {flushLogsToAccumulated, logDebug, logErr, logInfo, logWarn} from './log';
 import {pluginId} from './manifest';
 import reducer from './reducers';
 import {
@@ -632,6 +632,16 @@ export default class Plugin {
 
         const connectCall = async (channelID: string, title?: string, rootId?: string) => {
             const channel = getChannel(store.getState(), channelID);
+
+            // Flush any pending logs from previous call
+            flushLogsToAccumulated();
+
+            // Log separator for new call
+            const isStarting = !channelHasCall(store.getState(), channelID);
+            logInfo(`=== ${isStarting ? 'starting' : 'joining'} call at ${new Date().toISOString()}`);
+
+            // Flush separator immediately (ensures desktop clients capture it)
+            flushLogsToAccumulated();
 
             // Desktop handler
             const payload = {

--- a/webapp/src/log.test.ts
+++ b/webapp/src/log.test.ts
@@ -190,6 +190,37 @@ describe('log', () => {
             expect(accumulated.length).toBeLessThanOrEqual(MAX_ACCUMULATED_LOG_SIZE);
         });
 
+        test('should keep UTF-8 byte size within the limit for multi-byte logs', () => {
+            // Emoji are 4 UTF-8 bytes but 2 UTF-16 code units each, so a buffer
+            // under the char limit can still exceed the byte limit.
+            const multibyte = '🎉'.repeat(MAX_ACCUMULATED_LOG_SIZE);
+            mockStorage.set(STORAGE_CALLS_CLIENT_LOGS_KEY, multibyte);
+
+            logDebug('new message');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            const byteSize = new TextEncoder().encode(accumulated).length;
+            expect(byteSize).toBeLessThanOrEqual(MAX_ACCUMULATED_LOG_SIZE);
+            expect(accumulated).toContain('[... older logs truncated ...]');
+        });
+
+        test('should not throw when storage fails, and still clear the in-memory buffer', () => {
+            const setSpy = jest.spyOn(mockStorage, 'set').mockImplementationOnce(() => {
+                throw new Error('QuotaExceededError');
+            });
+
+            logDebug('message that cannot be persisted');
+            expect(() => flushLogsToAccumulated()).not.toThrow();
+
+            setSpy.mockRestore();
+
+            // The in-memory buffer must be cleared even when the write failed,
+            // so a subsequent successful flush does not re-include it.
+            flushLogsToAccumulated();
+            expect(getClientLogs()).not.toContain('message that cannot be persisted');
+        });
+
         test('should handle truncation with stats', () => {
             // Fill storage near the limit
             const largeLogs = 'log line\n'.repeat(MAX_ACCUMULATED_LOG_SIZE / 10);

--- a/webapp/src/log.test.ts
+++ b/webapp/src/log.test.ts
@@ -1,0 +1,332 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {MAX_ACCUMULATED_LOG_SIZE, STORAGE_CALLS_CLIENT_LOGS_KEY} from 'src/constants';
+import type {CallsClientStats} from 'src/types/types';
+
+import {flushLogsToAccumulated, getClientLogs, logDebug, logErr, logInfo, logWarn} from './log';
+
+// Mock the manifest
+jest.mock('./manifest', () => ({
+    pluginId: 'com.mattermost.calls',
+}));
+
+// Mock getPersistentStorage
+const mockStorage = new Map<string, string>();
+jest.mock('./utils', () => ({
+    getPersistentStorage: () => ({
+        getItem: (key: string) => mockStorage.get(key) || null,
+        setItem: (key: string, value: string) => mockStorage.set(key, value),
+        removeItem: (key: string) => mockStorage.delete(key),
+    }),
+}));
+
+describe('log', () => {
+    /* eslint-disable no-console */
+    const originalConsole = {
+        error: console.error,
+        warn: console.warn,
+        info: console.info,
+        debug: console.debug,
+    };
+
+    beforeAll(() => {
+        console.error = jest.fn();
+        console.warn = jest.fn();
+        console.info = jest.fn();
+        console.debug = jest.fn();
+    });
+
+    afterAll(() => {
+        console.error = originalConsole.error;
+        console.warn = originalConsole.warn;
+        console.info = originalConsole.info;
+        console.debug = originalConsole.debug;
+    });
+    /* eslint-enable no-console */
+
+    beforeEach(() => {
+        flushLogsToAccumulated();
+        mockStorage.clear();
+        jest.clearAllMocks();
+    });
+
+    describe('flushLogsToAccumulated', () => {
+        test('should append in-memory logs to accumulated buffer', () => {
+            logDebug('test message 1');
+            logInfo('test message 2');
+
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain('test message 1');
+            expect(accumulated).toContain('test message 2');
+            expect(accumulated).toContain('debug');
+            expect(accumulated).toContain('info');
+        });
+
+        test('should include timestamp in log entries', () => {
+            const beforeTime = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+            logDebug('test message');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain(beforeTime);
+        });
+
+        test('should append stats when provided', () => {
+            const stats: CallsClientStats = {
+                initTime: 123456,
+                callID: 'test-channel',
+                tracksInfo: [],
+                rtcStats: {
+                    ssrcStats: {},
+                    iceStats: {
+                        'in-progress': [],
+                        succeeded: [],
+                        waiting: [],
+                    },
+                },
+            };
+
+            flushLogsToAccumulated(stats);
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain('--- Call Stats ---');
+            expect(accumulated).toContain(JSON.stringify(stats));
+            expect(accumulated).toContain('---');
+        });
+
+        test('should handle empty logs gracefully', () => {
+            // Don't log anything, just flush
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toBe('');
+        });
+
+        test('should clear in-memory logs after flush', () => {
+            logDebug('test message');
+            flushLogsToAccumulated();
+
+            const firstAccumulated = getClientLogs();
+            expect(firstAccumulated).toContain('test message');
+
+            // Flush again without logging - should not duplicate
+            flushLogsToAccumulated();
+
+            const secondAccumulated = getClientLogs();
+            expect(secondAccumulated).toBe(firstAccumulated);
+        });
+
+        test('should accumulate logs across multiple flushes', () => {
+            logDebug('message 1');
+            flushLogsToAccumulated();
+
+            logDebug('message 2');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain('message 1');
+            expect(accumulated).toContain('message 2');
+        });
+
+        test('should truncate when exceeding MAX_ACCUMULATED_LOG_SIZE', () => {
+            // Create a large log that definitely exceeds the 1MB limit
+            // Use a clearly identifiable pattern at start and end
+            const oldLogsStart = 'START_MARKER_SHOULD_BE_REMOVED\n';
+            const oldLogsMiddle = 'x'.repeat(MAX_ACCUMULATED_LOG_SIZE);
+            const oldLogsEnd = '\nEND_MARKER_SHOULD_BE_KEPT\n';
+            const largeMessage = oldLogsStart + oldLogsMiddle + oldLogsEnd;
+
+            mockStorage.set(STORAGE_CALLS_CLIENT_LOGS_KEY, largeMessage);
+
+            logDebug('newest message');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+
+            // Should be at or under the limit
+            expect(accumulated.length).toBeLessThanOrEqual(MAX_ACCUMULATED_LOG_SIZE);
+
+            // Should contain truncation marker
+            expect(accumulated).toContain('[... older logs truncated ...]');
+
+            // Should contain new message (most recent)
+            expect(accumulated).toContain('newest message');
+
+            // Should NOT contain the start marker (old logs were truncated from the beginning)
+            expect(accumulated).not.toContain('START_MARKER_SHOULD_BE_REMOVED');
+
+            // Should contain the end marker (keeps most recent logs)
+            expect(accumulated).toContain('END_MARKER_SHOULD_BE_KEPT');
+        });
+
+        test('should keep most recent logs when truncating', () => {
+            // Fill storage with old logs
+            const oldLogs = 'old log line\n'.repeat(100000); // Very large
+            mockStorage.set(STORAGE_CALLS_CLIENT_LOGS_KEY, oldLogs);
+
+            logDebug('newest message');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+
+            // Should contain the newest message
+            expect(accumulated).toContain('newest message');
+
+            // Should be properly sized
+            expect(accumulated.length).toBeLessThanOrEqual(MAX_ACCUMULATED_LOG_SIZE);
+        });
+
+        test('should handle truncation edge case: exactly at limit', () => {
+            const exactSizeLog = 'y'.repeat(MAX_ACCUMULATED_LOG_SIZE - 100);
+            mockStorage.set(STORAGE_CALLS_CLIENT_LOGS_KEY, exactSizeLog);
+
+            logDebug('new message');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated.length).toBeLessThanOrEqual(MAX_ACCUMULATED_LOG_SIZE);
+        });
+
+        test('should handle truncation with stats', () => {
+            // Fill storage near the limit
+            const largeLogs = 'log line\n'.repeat(MAX_ACCUMULATED_LOG_SIZE / 10);
+            mockStorage.set(STORAGE_CALLS_CLIENT_LOGS_KEY, largeLogs);
+
+            const stats: CallsClientStats = {
+                initTime: 123456,
+                callID: 'test-channel',
+                tracksInfo: [],
+                rtcStats: {
+                    ssrcStats: {},
+                    iceStats: {
+                        'in-progress': [],
+                        succeeded: [],
+                        waiting: [],
+                    },
+                },
+            };
+
+            flushLogsToAccumulated(stats);
+
+            const accumulated = getClientLogs();
+
+            // Stats should be present
+            expect(accumulated).toContain('--- Call Stats ---');
+
+            // Should not exceed limit
+            expect(accumulated.length).toBeLessThanOrEqual(MAX_ACCUMULATED_LOG_SIZE);
+        });
+    });
+
+    describe('logging functions', () => {
+        test('logErr should append error logs', () => {
+            logErr('error message', 'additional', 'args');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain('error');
+            expect(accumulated).toContain('error message');
+            expect(accumulated).toContain('additional');
+            expect(accumulated).toContain('args');
+        });
+
+        test('logWarn should append warning logs', () => {
+            logWarn('warning message');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain('warn');
+            expect(accumulated).toContain('warning message');
+        });
+
+        test('logInfo should append info logs', () => {
+            logInfo('info message');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain('info');
+            expect(accumulated).toContain('info message');
+        });
+
+        test('logDebug should append debug logs', () => {
+            logDebug('debug message');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain('debug');
+            expect(accumulated).toContain('debug message');
+        });
+
+        test('should handle multiple log levels in order', () => {
+            logErr('first');
+            logWarn('second');
+            logInfo('third');
+            logDebug('fourth');
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            const firstPos = accumulated.indexOf('first');
+            const secondPos = accumulated.indexOf('second');
+            const thirdPos = accumulated.indexOf('third');
+            const fourthPos = accumulated.indexOf('fourth');
+
+            expect(firstPos).toBeLessThan(secondPos);
+            expect(secondPos).toBeLessThan(thirdPos);
+            expect(thirdPos).toBeLessThan(fourthPos);
+        });
+
+        test('should handle objects in log messages', () => {
+            const obj = {foo: 'bar', nested: {value: 123}};
+            logDebug('object:', obj);
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+            expect(accumulated).toContain('object:');
+            expect(accumulated).toContain('{"foo":"bar","nested":{"value":123}}');
+        });
+
+        test('should cap large object args at 256 chars with an ellipsis', () => {
+            const big = {blob: 'z'.repeat(1000)};
+            logDebug('big:', big);
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+
+            // The serialized object portion is truncated to 256 chars ending in '...'.
+            const serialized = JSON.stringify(big);
+            expect(accumulated).not.toContain(serialized);
+            expect(accumulated).toContain(serialized.slice(0, 253) + '...');
+        });
+
+        test('should not cap string or Error args', () => {
+            const longMessage = 'm'.repeat(1000);
+            const err = new Error('boom');
+            logErr(longMessage, err);
+            flushLogsToAccumulated();
+
+            const accumulated = getClientLogs();
+
+            // Strings pass through uncapped...
+            expect(accumulated).toContain(longMessage);
+
+            // ...and Errors serialize to their stack (or name: message), uncapped.
+            expect(accumulated).toContain(err.stack || 'Error: boom');
+        });
+    });
+
+    describe('getClientLogs', () => {
+        test('should return empty string when no logs', () => {
+            const logs = getClientLogs();
+            expect(logs).toBe('');
+        });
+
+        test('should return accumulated logs', () => {
+            mockStorage.set(STORAGE_CALLS_CLIENT_LOGS_KEY, 'test logs');
+            const logs = getClientLogs();
+            expect(logs).toBe('test logs');
+        });
+    });
+});

--- a/webapp/src/log.ts
+++ b/webapp/src/log.ts
@@ -49,26 +49,45 @@ export function flushLogsToAccumulated(stats?: CallsClientStats | null) {
         return; // Nothing to flush
     }
 
-    const storage = getPersistentStorage();
+    // Logging is best-effort: a storage failure (e.g. quota exceeded) must
+    // never block callers such as connectCall, so swallow any error here. The
+    // in-memory buffer is always cleared so it can't grow unbounded.
+    try {
+        const storage = getPersistentStorage();
 
-    // Get accumulated buffer
-    let accumulated = storage.getItem(STORAGE_CALLS_CLIENT_LOGS_KEY) || '';
+        // Get accumulated buffer
+        let accumulated = storage.getItem(STORAGE_CALLS_CLIENT_LOGS_KEY) || '';
 
-    // Append in-memory logs to end
-    accumulated += clientLogs;
+        // Append in-memory logs to end
+        accumulated += clientLogs;
 
-    // Truncate from start if exceeds max
-    if (accumulated.length > MAX_ACCUMULATED_LOG_SIZE) {
-        const keepSize = MAX_ACCUMULATED_LOG_SIZE - 50;
-        const truncated = accumulated.slice(-keepSize);
-        accumulated = '[... older logs truncated ...]\n\n' + truncated;
+        // Truncate from start if exceeds max. We measure UTF-8 byte size rather
+        // than string length (UTF-16 code units) so the buffer stays within the
+        // server's byte limit even when logs contain multi-byte characters.
+        const bytes = new TextEncoder().encode(accumulated);
+        if (bytes.length > MAX_ACCUMULATED_LOG_SIZE) {
+            const marker = '[... older logs truncated ...]\n\n';
+            const keepSize = MAX_ACCUMULATED_LOG_SIZE - marker.length;
+
+            // Advance the cut point past any partial multi-byte sequence (leading
+            // UTF-8 continuation bytes, 0b10xxxxxx) so decoding starts on a
+            // character boundary and produces no replacement characters.
+            let start = bytes.length - keepSize;
+            while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) {
+                start++;
+            }
+            const truncated = new TextDecoder().decode(bytes.slice(start));
+            accumulated = marker + truncated;
+        }
+
+        // Save back
+        storage.setItem(STORAGE_CALLS_CLIENT_LOGS_KEY, accumulated);
+    } catch (err) {
+        console.error(`${pluginId}: failed to flush logs to storage`, err);
+    } finally {
+        // Clear memory
+        clientLogs = '';
     }
-
-    // Save back
-    storage.setItem(STORAGE_CALLS_CLIENT_LOGS_KEY, accumulated);
-
-    // Clear memory
-    clientLogs = '';
 }
 
 export function persistClientLogs() {

--- a/webapp/src/log.ts
+++ b/webapp/src/log.ts
@@ -3,12 +3,19 @@
 
 /* eslint-disable no-console */
 
-import {STORAGE_CALLS_CLIENT_LOGS_KEY} from 'src/constants';
+import {MAX_ACCUMULATED_LOG_SIZE, STORAGE_CALLS_CLIENT_LOGS_KEY} from 'src/constants';
+import type {CallsClientStats} from 'src/types/types';
 import {getPersistentStorage} from 'src/utils';
 
 import {pluginId} from './manifest';
 
 let clientLogs = '';
+
+// Cap on the serialized length of a single non-string log argument. Objects
+// (notably LiveKit SDK objects) can serialize to several KB each, which would
+// quickly fill the accumulated log buffer and truncate away the earlier,
+// usually more useful, entries. Strings and Error stacks are not capped.
+const maxObjectLogLength = 256;
 
 function stringifyLogArg(arg: unknown): string {
     if (typeof arg === 'string') {
@@ -18,7 +25,8 @@ function stringifyLogArg(arg: unknown): string {
         return arg.stack || `${arg.name}: ${arg.message}`;
     }
     try {
-        return JSON.stringify(arg) ?? String(arg);
+        const serialized = JSON.stringify(arg) ?? String(arg);
+        return serialized.length > maxObjectLogLength ? serialized.slice(0, maxObjectLogLength - 3) + '...' : serialized;
     } catch {
         return String(arg);
     }
@@ -29,9 +37,42 @@ function appendClientLog(level: string, ...args: unknown[]) {
     clientLogs += `${level} [${new Date().toISOString()}] ${serialized}\n`;
 }
 
-export function persistClientLogs() {
-    getPersistentStorage().setItem(STORAGE_CALLS_CLIENT_LOGS_KEY, clientLogs);
+export function flushLogsToAccumulated(stats?: CallsClientStats | null) {
+    // Append stats if provided
+    if (stats) {
+        clientLogs += '--- Call Stats ---\n';
+        clientLogs += JSON.stringify(stats) + '\n';
+        clientLogs += '---\n\n';
+    }
+
+    if (!clientLogs.trim()) {
+        return; // Nothing to flush
+    }
+
+    const storage = getPersistentStorage();
+
+    // Get accumulated buffer
+    let accumulated = storage.getItem(STORAGE_CALLS_CLIENT_LOGS_KEY) || '';
+
+    // Append in-memory logs to end
+    accumulated += clientLogs;
+
+    // Truncate from start if exceeds max
+    if (accumulated.length > MAX_ACCUMULATED_LOG_SIZE) {
+        const keepSize = MAX_ACCUMULATED_LOG_SIZE - 50;
+        const truncated = accumulated.slice(-keepSize);
+        accumulated = '[... older logs truncated ...]\n\n' + truncated;
+    }
+
+    // Save back
+    storage.setItem(STORAGE_CALLS_CLIENT_LOGS_KEY, accumulated);
+
+    // Clear memory
     clientLogs = '';
+}
+
+export function persistClientLogs() {
+    flushLogsToAccumulated();
 }
 
 export function getClientLogs() {
@@ -41,9 +82,7 @@ export function getClientLogs() {
 export function logErr(...args: unknown[]) {
     console.error(`${pluginId}:`, ...args);
     try {
-        if (window.callsClient) {
-            appendClientLog('error', ...args);
-        }
+        appendClientLog('error', ...args);
     } catch (err) {
         console.error(err);
     }
@@ -51,21 +90,15 @@ export function logErr(...args: unknown[]) {
 
 export function logWarn(...args: unknown[]) {
     console.warn(`${pluginId}:`, ...args);
-    if (window.callsClient) {
-        appendClientLog('warn', ...args);
-    }
+    appendClientLog('warn', ...args);
 }
 
 export function logInfo(...args: unknown[]) {
     console.info(`${pluginId}:`, ...args);
-    if (window.callsClient) {
-        appendClientLog('info', ...args);
-    }
+    appendClientLog('info', ...args);
 }
 
 export function logDebug(...args: unknown[]) {
     console.debug(`${pluginId}:`, ...args);
-    if (window.callsClient) {
-        appendClientLog('debug', ...args);
-    }
+    appendClientLog('debug', ...args);
 }

--- a/webapp/src/slash_commands.tsx
+++ b/webapp/src/slash_commands.tsx
@@ -4,7 +4,6 @@
 import {CommandArgs} from '@mattermost/types/integrations';
 import {getChannel as getChannelAction} from 'mattermost-redux/actions/channels';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {ActionResult} from 'mattermost-redux/types/actions';
 import {defineMessage} from 'react-intl';
@@ -184,12 +183,6 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
             return {error: {message: 'No call logs available'}};
         }
 
-        // In DM/GM channels args.team_id is empty (there is no team), so fall
-        // back to the current team. The server needs a valid team to build the
-        // permalink to the @calls bot DM; the permalink resolves regardless of
-        // the team name in the URL as long as the user is a member of it.
-        const teamID = args.team_id || getCurrentTeamId(store.getState());
-
         try {
             await RestClient.fetch(
                 `${getPluginPath()}/logs/upload`,
@@ -198,7 +191,6 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
                     body: JSON.stringify({
                         logs: allLogs,
                         channel_id: args.channel_id,
-                        team_id: teamID,
                     }),
                     headers: {'Content-Type': 'application/json'},
                 },

--- a/webapp/src/slash_commands.tsx
+++ b/webapp/src/slash_commands.tsx
@@ -4,6 +4,7 @@
 import {CommandArgs} from '@mattermost/types/integrations';
 import {getChannel as getChannelAction} from 'mattermost-redux/actions/channels';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {ActionResult} from 'mattermost-redux/types/actions';
 import {defineMessage} from 'react-intl';
@@ -12,6 +13,7 @@ import {
     startCallRecording,
     stopCallRecording,
 } from 'src/actions';
+import RestClient from 'src/clients/rest';
 import {
     EndCallConfirmation,
     IDEndCallConfirmation,
@@ -22,7 +24,7 @@ import {
 } from 'src/constants';
 import {modals} from 'src/webapp_globals';
 
-import {getClientLogs, logDebug} from './log';
+import {flushLogsToAccumulated, getClientLogs, logDebug} from './log';
 import {
     areGroupCallsAllowed,
     channelHasCall,
@@ -32,7 +34,7 @@ import {
     isRecordingInCurrentCall,
 } from './selectors';
 import {Store} from './types/mattermost-webapp';
-import {getCallsClient, getCallsWindow, getPersistentStorage, isDMChannel, sendDesktopEvent, shouldRenderDesktopWidget} from './utils';
+import {getCallsClient, getCallsWindow, getPersistentStorage, getPluginPath, isDMChannel, sendDesktopEvent, shouldRenderDesktopWidget} from './utils';
 
 type joinCallFn = (channelId: string, teamId?: string, title?: string, rootId?: string) => void;
 
@@ -175,7 +177,36 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
         return {message: `/call stats ${btoa(data)}`, args};
     }
     case 'logs': {
-        return {message: `/call logs ${btoa(getClientLogs())}`, args};
+        flushLogsToAccumulated();
+        const allLogs = getClientLogs();
+
+        if (!allLogs || allLogs.trim().length === 0) {
+            return {error: {message: 'No call logs available'}};
+        }
+
+        // In DM/GM channels args.team_id is empty (there is no team), so fall
+        // back to the current team. The server needs a valid team to build the
+        // permalink to the @calls bot DM; the permalink resolves regardless of
+        // the team name in the URL as long as the user is a member of it.
+        const teamID = args.team_id || getCurrentTeamId(store.getState());
+
+        try {
+            await RestClient.fetch(
+                `${getPluginPath()}/logs/upload`,
+                {
+                    method: 'POST',
+                    body: JSON.stringify({
+                        logs: allLogs,
+                        channel_id: args.channel_id,
+                        team_id: teamID,
+                    }),
+                    headers: {'Content-Type': 'application/json'},
+                },
+            );
+            return {};
+        } catch (err) {
+            return {error: {message: `Failed to upload logs: ${(err as Error).message}`}};
+        }
     }
     case 'recording': {
         if (fields.length < 3 || (fields[2] !== 'start' && fields[2] !== 'stop')) {


### PR DESCRIPTION
## Summary

Ports the improved `/call logs` implementation (PRs #1126 and #1203 from `main`) to the `v2` (LiveKit) branch — the client-agnostic logging infrastructure. LiveKit `getStats()` / SDK-internal-log capture is tracked separately in the follow-up ticket.

### Infrastructure port (#1126 + #1203)
- **Server:** new `handleUploadLogsToBot` + `POST /logs/upload` route — uploads the log file to the user↔@calls bot DM, posts it from the bot, and replies with an ephemeral permalink in the origin channel. Adds `logsUploadMaxSizeBytes` (2MB) for JSON-escaping margin over the client's 1MB buffer, tightens `filenameSanitizationRE` to an allowlist, and removes the dead `handleLogsCommand` base64 echo path.
- **Webapp:** `log.ts` reworked into a 1MB start-truncating accumulation buffer (`flushLogsToAccumulated`), dropping the `window.callsClient` guards so init-time and post-call logs are captured. `/call logs` now flushes and POSTs the buffer (with `getCurrentTeamId()` fallback for DM/GM); `connectCall` writes a `=== starting/joining call` separator.

### Buffer hygiene (v2-specific)
- 256-char cap on non-string log args in `stringifyLogArg` (strings and Error stacks uncapped); the `--- Call Stats ---` block is appended directly and stays full.
- Curated the LiveKit publication/track log call sites in `call_client.ts` to compact summaries (`trackPubSummary`/`trackSummary`) instead of dumping multi-KB SDK objects per event. Media-performance fields are intentionally omitted — those belong to the RTC stats follow-up; remote subscription/permission state (which `getStats()` won't surface) is kept.

### Gesture logging
Added gesture-level logs for the remaining user actions that weren't covered: leave, end-call (host), host controls (mute, mute-all, lower hand, make host, remove), record start/stop, device change, raise/lower hand, and reactions. Destructive actions are logged at the confirm step.

## Test plan
- Server: `go test ./server/...` — `TestHandleUploadLogsToBot` (channel/DM/GM, ~1.5MB regression guard, oversize rejection) and `TestSanitizeFilename` pass.
- Webapp: `jest src/log.test.ts` (20 tests incl. truncation/cap), `call_client.test.ts` (81), `call_widget/component.test.tsx` (3) pass.
- `tsc --noEmit` clean, `eslint` clean.
- Manually verified in a LiveKit DM call: separator on join, curated publication summaries, gesture logs (mute/hand/reaction/host/device/leave), and successful `/call logs` upload with resolving permalink.

## Out of scope
- LiveKit `getStats()` implementation and SDK-internal-log capture (follow-up ticket).
- Wiring the legacy pion `CallsClient` disconnect path.

References: #1126, #1203