### PR TITLE
[MM-69233] Persist video stats on toggle to fix Calls video metrics

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -450,8 +450,14 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 			return fmt.Errorf("failed to update call session: %w", err)
 		}
 
-		// Note: Video stats are persisted when users leave or call ends,
-		// no need to write to DB on every toggle for performance.
+		// Stats.HasUsedVideo and Props.VideoStartAt must be persisted on every
+		// toggle: getCallState reloads from the DB on each handler invocation, so
+		// without this write the next video_on/video_off, the leave path, and the
+		// call-end finalization would all see stale state — leaving has_used_video
+		// false and the video durations at zero (MM-69233).
+		if err := p.store.UpdateCall(&state.Call); err != nil {
+			return fmt.Errorf("failed to update call: %w", err)
+		}
 
 		evType := wsEventUserVideoOn
 		if msg.Type == clientMessageTypeVideoOff {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -450,11 +450,8 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage, handlerID strin
 			return fmt.Errorf("failed to update call session: %w", err)
 		}
 
-		// Stats.HasUsedVideo and Props.VideoStartAt must be persisted on every
-		// toggle: getCallState reloads from the DB on each handler invocation, so
-		// without this write the next video_on/video_off, the leave path, and the
-		// call-end finalization would all see stale state — leaving has_used_video
-		// false and the video durations at zero (MM-69233).
+		// Persist HasUsedVideo and VideoStartAt: getCallState reloads from the DB
+		// each invocation, so without this write the stats are lost (MM-69233).
 		if err := p.store.UpdateCall(&state.Call); err != nil {
 			return fmt.Errorf("failed to update call: %w", err)
 		}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1509,13 +1509,13 @@ func TestHandleClientMsgVideoStats(t *testing.T) {
 	t.Run("video on persists HasUsedVideo and VideoStartAt", func(t *testing.T) {
 		defer ResetTestStore(t, p.store)
 
-		channelID, _, connID, userID := setupCall(t)
+		channelID, callID, connID, userID := setupCall(t)
 		us := &session{
 			userID:         userID,
 			channelID:      channelID,
 			connID:         connID,
 			originalConnID: connID,
-			callID:         channelID,
+			callID:         callID,
 		}
 
 		err := p.handleClientMsg(us, clientMessage{Type: clientMessageTypeVideoOn}, handlerID)
@@ -1535,7 +1535,7 @@ func TestHandleClientMsgVideoStats(t *testing.T) {
 	t.Run("video off accumulates and persists VideoDuration", func(t *testing.T) {
 		defer ResetTestStore(t, p.store)
 
-		channelID, _, connID, userID := setupCall(t)
+		channelID, callID, connID, userID := setupCall(t)
 
 		// Simulate a video that was turned on 10 seconds ago and persisted, as
 		// the video_on handler would have done.
@@ -1555,7 +1555,7 @@ func TestHandleClientMsgVideoStats(t *testing.T) {
 			channelID:      channelID,
 			connID:         connID,
 			originalConnID: connID,
-			callID:         channelID,
+			callID:         callID,
 		}
 
 		err = p.handleClientMsg(us, clientMessage{Type: clientMessageTypeVideoOff}, handlerID)

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-calls/server/batching"
 	"github.com/mattermost/mattermost-plugin-calls/server/cluster"
+	"github.com/mattermost/mattermost-plugin-calls/server/db"
 	"github.com/mattermost/mattermost-plugin-calls/server/enterprise"
 	"github.com/mattermost/mattermost-plugin-calls/server/public"
 
@@ -1433,5 +1434,139 @@ func TestHandleJoin(t *testing.T) {
 
 		// We need to give it some time as leaving happens in a goroutine.
 		time.Sleep(2 * time.Second)
+	})
+}
+
+// TestHandleClientMsgVideoStats guards against the MM-69233 regression: the
+// video on/off handler must persist Stats.HasUsedVideo and Props.VideoStartAt
+// via UpdateCall. Because every handler reloads call state from the DB
+// (lockCallReturnState -> getCallState), in-memory mutations that aren't
+// written back are lost on the next handler invocation, the leave path, and
+// call-end finalization — which is exactly how video metrics silently zeroed
+// out. The assertions deliberately re-read state from the store to exercise
+// that reload-from-DB boundary.
+func TestHandleClientMsgVideoStats(t *testing.T) {
+	mockAPI := &pluginMocks.MockAPI{}
+	mockMetrics := &serverMocks.MockMetrics{}
+
+	p := Plugin{
+		MattermostPlugin: plugin.MattermostPlugin{
+			API: mockAPI,
+		},
+		callsClusterLocks: map[string]*cluster.Mutex{},
+		metrics:           mockMetrics,
+		nodeID:            "nodeA",
+		sessions:          map[string]*session{},
+	}
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+	p.store = store
+
+	// The handler relays to another node (handlerID != nodeID), so it goes
+	// through the cluster message path rather than requiring a live RTC peer.
+	const handlerID = "nodeB"
+
+	mockAPI.On("LogDebug", "creating cluster mutex for call", "origin", mock.Anything, "channelID", mock.Anything)
+	mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+	mockAPI.On("KVDelete", mock.Anything).Return(nil)
+	mockAPI.On("PublishWebSocketEvent", mock.Anything, mock.Anything, mock.Anything)
+	mockAPI.On("PublishPluginClusterEvent", mock.Anything, mock.Anything).Return(nil)
+
+	mockMetrics.On("IncWebSocketEvent", mock.AnythingOfType("string"), mock.AnythingOfType("string"))
+	mockMetrics.On("IncClusterEvent", mock.AnythingOfType("string"))
+	mockMetrics.On("ObserveClusterMutexGrabTime", "mutex_call", mock.AnythingOfType("float64"))
+	mockMetrics.On("ObserveClusterMutexLockedTime", "mutex_call", mock.AnythingOfType("float64"))
+	mockMetrics.On("ObserveAppHandlersTime", mock.AnythingOfType("string"), mock.AnythingOfType("float64"))
+
+	// setupCall creates an active call with a single joined session and returns
+	// its identifiers.
+	setupCall := func(t *testing.T) (channelID, callID, connID, userID string) {
+		t.Helper()
+		channelID = model.NewId()
+		callID = model.NewId()
+		connID = model.NewId()
+		userID = model.NewId()
+
+		require.NoError(t, p.store.CreateCall(&public.Call{
+			ID:        callID,
+			CreateAt:  time.Now().UnixMilli(),
+			ChannelID: channelID,
+			StartAt:   time.Now().UnixMilli(),
+			PostID:    model.NewId(),
+			ThreadID:  model.NewId(),
+			OwnerID:   userID,
+		}))
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:     connID,
+			CallID: callID,
+			UserID: userID,
+			JoinAt: time.Now().UnixMilli(),
+		}))
+		return
+	}
+
+	t.Run("video on persists HasUsedVideo and VideoStartAt", func(t *testing.T) {
+		defer ResetTestStore(t, p.store)
+
+		channelID, _, connID, userID := setupCall(t)
+		us := &session{
+			userID:         userID,
+			channelID:      channelID,
+			connID:         connID,
+			originalConnID: connID,
+			callID:         channelID,
+		}
+
+		err := p.handleClientMsg(us, clientMessage{Type: clientMessageTypeVideoOn}, handlerID)
+		require.NoError(t, err)
+
+		// Re-read from the DB (fromWriter=false) to confirm the stats survived
+		// the reload boundary that previously discarded them.
+		state, err := p.getCallState(channelID, false)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		require.True(t, state.Call.Stats.HasUsedVideo, "HasUsedVideo must be persisted")
+		require.NotNil(t, state.Call.Props.VideoStartAt)
+		require.Greater(t, state.Call.Props.VideoStartAt[connID], int64(0), "VideoStartAt must be persisted")
+		require.True(t, state.sessions[connID].Video, "session video flag must be persisted")
+	})
+
+	t.Run("video off accumulates and persists VideoDuration", func(t *testing.T) {
+		defer ResetTestStore(t, p.store)
+
+		channelID, _, connID, userID := setupCall(t)
+
+		// Simulate a video that was turned on 10 seconds ago and persisted, as
+		// the video_on handler would have done.
+		call, err := p.store.GetActiveCallByChannelID(channelID, db.GetCallOpts{})
+		require.NoError(t, err)
+		call.Stats.HasUsedVideo = true
+		call.Props.VideoStartAt = map[string]int64{connID: time.Now().Unix() - 10}
+		require.NoError(t, p.store.UpdateCall(call))
+
+		sess, err := p.store.GetCallSession(connID, db.GetCallSessionOpts{})
+		require.NoError(t, err)
+		sess.Video = true
+		require.NoError(t, p.store.UpdateCallSession(sess))
+
+		us := &session{
+			userID:         userID,
+			channelID:      channelID,
+			connID:         connID,
+			originalConnID: connID,
+			callID:         channelID,
+		}
+
+		err = p.handleClientMsg(us, clientMessage{Type: clientMessageTypeVideoOff}, handlerID)
+		require.NoError(t, err)
+
+		state, err := p.getCallState(channelID, false)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		require.True(t, state.Call.Stats.HasUsedVideo, "HasUsedVideo must remain set")
+		require.Greater(t, state.Call.Stats.VideoDuration, int64(0), "VideoDuration must be accumulated and persisted")
+		require.NotContains(t, state.Call.Props.VideoStartAt, connID, "VideoStartAt entry must be cleared on video off")
+		require.False(t, state.sessions[connID].Video, "session video flag must be cleared")
 	})
 }


### PR DESCRIPTION
### Summary

The Grafana "Calls metrics" dashboard reported **Video Calls = 0** even when video was actively used, and **Avg/Total Video Duration** were likewise zero. Screen-share metrics were unaffected.

Root cause: the video on/off handler set `Stats.HasUsedVideo` and `Props.VideoStartAt` in memory but only persisted the session row via `UpdateCallSession` — it never called `UpdateCall`. Because every websocket handler reloads call state fresh from the DB (`lockCallReturnState` → `getCallState` → `GetActiveCallByChannelID`), those in-memory mutations were discarded before the next handler, the leave path, or call-end finalization could read them. So `has_used_video` was written back as `false`, and the duration-finalization loops found an empty `VideoStartAt` map and accumulated nothing.

The handler carried a comment claiming video stats were "persisted when users leave or call ends" — that assumption was wrong, since `state.Call` is reloaded from the DB on every invocation.

### Fix

Persist the call via `p.store.UpdateCall(&state.Call)` on every video toggle, in addition to the existing `UpdateCallSession`. This writes both `Stats.HasUsedVideo` and `Props.VideoStartAt`, fixing the call count and both duration metrics. This is the same pattern the screen-share handler already uses (restored in #1178 after the same regression was introduced for screen share by #1125). Video toggles are infrequent relative to audio mute, so the per-toggle write cost the original comment worried about is negligible.

Introduced by #1125 ("Add video statistics and metrics").

### Testing

Added `TestHandleClientMsgVideoStats`, which drives the real `handleClientMsg` handler and re-reads state from the store to exercise the reload-from-DB boundary:

- `video on` → `HasUsedVideo`, `VideoStartAt[connID]`, and the session video flag are all persisted.
- `video off` → `VideoDuration` is accumulated and persisted, the `VideoStartAt` entry is cleared, and `HasUsedVideo` remains set.

Confirmed the test fails without the fix and passes with it. Full `./server/` package suite passes.

### Acceptance criteria

- [x] After a call that used video, `stats->>'has_used_video'` is `true` in the `calls` row.
- [x] Dashboard "Video Calls" reflects the real count; "Avg/Total Video Duration" are non-zero when video was used.
- [x] Server test covering persistence of `HasUsedVideo` and `VideoDuration` across the reload-from-DB boundary.

https://mattermost.atlassian.net/browse/MM-69233