### PR TITLE
[MM-69080] LiveKit getStats() with vendored RTC-stats + SDK error logging

### DIFF
--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -414,6 +414,20 @@ describe('CallClient', () => {
             expect(storage.getItem(STORAGE_CALLS_CLIENT_LOGS_KEY)).toContain('--- Call Stats ---');
         });
 
+        it('clears stale persisted stats when the call tears down before any sample', () => {
+            const storage = getPersistentStorage();
+
+            // Stats left over from an earlier call.
+            storage.setItem(STORAGE_CALLS_CLIENT_STATS_KEY, JSON.stringify({channelID: 'old-call'}));
+
+            // Disconnect before RoomEvent.Connected ever fired (failed/cancelled join):
+            // polling never started, so lastStats is null and there is no fresh sample.
+            mockRoom.fire(RoomEvent.Disconnected);
+
+            // The stale entry is cleared rather than served by a later `/call stats`.
+            expect(storage.getItem(STORAGE_CALLS_CLIENT_STATS_KEY)).toBeNull();
+        });
+
         it('takes an immediate stats sample with ICE candidate pairs on connect', async () => {
             await client.connect({channelID: 'ice'});
 
@@ -1781,9 +1795,7 @@ describe('CallClient', () => {
                 enabled: opts.enabled ?? true,
                 readyState: opts.readyState ?? 'live',
             },
-            getRTCStatsReport: opts.reportErr ?
-                jest.fn().mockRejectedValue(opts.reportErr) :
-                jest.fn().mockResolvedValue(opts.report),
+            getRTCStatsReport: opts.reportErr ? jest.fn().mockRejectedValue(opts.reportErr) : jest.fn().mockResolvedValue(opts.report),
         });
 
         const setPublications = (local: any[], remote: any[]) => {

--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -15,10 +15,13 @@ import RestClient from 'src/clients/rest';
 import {WEBSOCKET_EVENT, WebSocketClient} from 'src/clients/websocket';
 import {AudioInputPermissionsErr} from 'src/components/error_modal/error_messages';
 import {
+    STORAGE_CALLS_CLIENT_LOGS_KEY,
+    STORAGE_CALLS_CLIENT_STATS_KEY,
     STORAGE_CALLS_DEFAULT_AUDIO_INPUT_KEY,
     STORAGE_CALLS_DEFAULT_AUDIO_OUTPUT_KEY,
 } from 'src/constants';
-import {getScreenStream} from 'src/utils';
+import {flushLogsToAccumulated} from 'src/log';
+import {getPersistentStorage, getScreenStream} from 'src/utils';
 
 import CallClient from './call_client';
 import {CALL_EVENT} from './constants';
@@ -108,6 +111,7 @@ function createMockRoom(): MockRoom {
             setAttributes: jest.fn().mockResolvedValue(undefined),
             publishData: jest.fn().mockResolvedValue(undefined),
             audioTrackPublications: new Map(),
+            trackPublications: new Map(),
             attributes: {},
         },
         remoteParticipants: new Map(),
@@ -219,6 +223,9 @@ describe('CallClient', () => {
     });
 
     afterEach(() => {
+        // handleConnected starts a stats-polling interval; clear it so tests that
+        // fire RoomEvent.Connected without disconnecting don't leak a live timer.
+        (client as unknown as {stopStatsPolling(): void}).stopStatsPolling();
         jest.clearAllMocks();
     });
 
@@ -337,6 +344,138 @@ describe('CallClient', () => {
             expect(client.isDisconnected).toBe(true);
             expect(mockWebSocketClient.sendLeave).toHaveBeenCalled();
             expect(disconnectedListener).toHaveBeenCalled();
+        });
+
+        // Builds a publication whose track returns the given stats report, and seeds
+        // a single poll sample into lastStats — the same path the interval drives.
+        const seedStatsSample = async (channelID: string, ssrc: number, bytesSent: number) => {
+            const report = new Map<string, any>([
+                ['out-1', {id: 'out-1', type: 'outbound-rtp', ssrc, kind: 'audio', bytesSent}],
+            ]);
+            mockRoom.localParticipant.trackPublications = new Map([
+                ['pub-0', {track: {
+                    sid: 'mic',
+                    source: 'microphone',
+                    kind: 'audio',
+                    mediaStream: {id: 's'},
+                    mediaStreamTrack: {id: 'm', kind: 'audio', label: '', enabled: true, readyState: 'live'},
+                    getRTCStatsReport: jest.fn().mockResolvedValue(report),
+                }}],
+            ]);
+            client.channelID = channelID;
+            await (client as any).pollStats();
+        };
+
+        it('flushes the last sampled stats on a clean (user-initiated) disconnect', async () => {
+            await client.connect({channelID: 'clean'});
+            mockRoom.state = ConnectionState.Connected;
+            mockRoom.fire(RoomEvent.Connected);
+
+            await seedStatsSample('clean', 99, 42);
+
+            const storage = getPersistentStorage();
+            storage.removeItem(STORAGE_CALLS_CLIENT_STATS_KEY);
+            storage.removeItem(STORAGE_CALLS_CLIENT_LOGS_KEY);
+
+            client.disconnect();
+            expect(mockRoom.disconnect).toHaveBeenCalled();
+
+            // Teardown (and the stats/log flush) is driven by the resulting room event.
+            mockRoom.fire(RoomEvent.Disconnected);
+
+            const stored = JSON.parse(storage.getItem(STORAGE_CALLS_CLIENT_STATS_KEY) || '{}');
+            expect(stored.channelID).toBe('clean');
+            expect(stored.rtcStats.ssrcStats[99].local.out).toMatchObject({bytesSent: 42});
+            expect(storage.getItem(STORAGE_CALLS_CLIENT_LOGS_KEY)).toContain('--- Call Stats ---');
+        });
+
+        it('samples stats while connected and logs the last sample on remote teardown', async () => {
+            await client.connect({channelID: 'remote-end'});
+            mockRoom.fire(RoomEvent.Connected);
+
+            // Polling is active while the call is connected.
+            expect((client as any).statsPollTimer).not.toBeNull();
+
+            await seedStatsSample('remote-end', 7, 123);
+
+            const storage = getPersistentStorage();
+            storage.removeItem(STORAGE_CALLS_CLIENT_STATS_KEY);
+            storage.removeItem(STORAGE_CALLS_CLIENT_LOGS_KEY);
+
+            // Remote teardown: Disconnected arrives without disconnect() being called,
+            // so a fresh getStats() could no longer reach the (gone) peer connections.
+            mockRoom.fire(RoomEvent.Disconnected);
+
+            // Polling stopped, and the last sample was persisted + folded into the log buffer.
+            expect((client as any).statsPollTimer).toBeNull();
+            const stored = JSON.parse(storage.getItem(STORAGE_CALLS_CLIENT_STATS_KEY) || '{}');
+            expect(stored.channelID).toBe('remote-end');
+            expect(stored.rtcStats.ssrcStats[7].local.out).toMatchObject({bytesSent: 123});
+            expect(storage.getItem(STORAGE_CALLS_CLIENT_LOGS_KEY)).toContain('--- Call Stats ---');
+        });
+
+        it('takes an immediate stats sample with ICE candidate pairs on connect', async () => {
+            await client.connect({channelID: 'ice'});
+
+            // A subscribed track present at connect time, whose report carries a
+            // candidate pair — so the very first sample includes ICE stats.
+            const report = new Map<string, any>([
+                ['cp-1', {id: 'cp-1', type: 'candidate-pair', state: 'succeeded', nominated: true, localCandidateId: 'lc', remoteCandidateId: 'rc'}],
+                ['lc', {id: 'lc', type: 'local-candidate', candidateType: 'host'}],
+                ['rc', {id: 'rc', type: 'remote-candidate', candidateType: 'srflx'}],
+            ]);
+            mockRoom.localParticipant.trackPublications = new Map([
+                ['pub-0', {track: {
+                    sid: 'mic',
+                    source: 'microphone',
+                    kind: 'audio',
+                    mediaStream: {id: 's'},
+                    mediaStreamTrack: {id: 'm', kind: 'audio', label: '', enabled: true, readyState: 'live'},
+                    getRTCStatsReport: jest.fn().mockResolvedValue(report),
+                }}],
+            ]);
+
+            // handleConnected starts polling, which takes an immediate sample.
+            mockRoom.fire(RoomEvent.Connected);
+
+            // Let the immediate poll's microtasks settle — no timer advance needed.
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect((client as any).lastStats.rtcStats.iceStats.succeeded).toHaveLength(1);
+            expect((client as any).lastStats.rtcStats.iceStats.succeeded[0]).toMatchObject({
+                local: {candidateType: 'host'},
+                remote: {candidateType: 'srflx'},
+            });
+        });
+
+        it('samples stats when the local mic publishes (first track on the transport)', async () => {
+            await client.connect({channelID: 'mic-publish'});
+            client.channelID = 'mic-publish';
+
+            const report = new Map<string, any>([
+                ['out-1', {id: 'out-1', type: 'outbound-rtp', ssrc: 55, kind: 'audio', bytesSent: 9}],
+            ]);
+            mockRoom.localParticipant.trackPublications = new Map([
+                ['pub-0', {track: {
+                    sid: 'mic',
+                    source: 'microphone',
+                    kind: 'audio',
+                    mediaStream: {id: 's'},
+                    mediaStreamTrack: {id: 'm', kind: 'audio', label: '', enabled: true, readyState: 'live'},
+                    getRTCStatsReport: jest.fn().mockResolvedValue(report),
+                }}],
+            ]);
+
+            // Fire LocalTrackPublished for the mic, which should trigger an immediate sample.
+            mockRoom.fire(
+                RoomEvent.LocalTrackPublished,
+                {source: Track.Source.Microphone, isMuted: false, trackSid: 'mic', kind: 'audio', mimeType: 'audio/opus', track: {mediaStreamTrack: {id: 'm'}}},
+                mockRoom.localParticipant,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect((client as any).lastStats.rtcStats.ssrcStats[55].local.out).toMatchObject({bytesSent: 9});
         });
 
         it('before the room connects, tears down directly (livekit room.disconnect would not emit)', () => {
@@ -1588,6 +1727,169 @@ describe('CallClient', () => {
             await client.unmute();
 
             expect(mockRoom.localParticipant.setMicrophoneEnabled).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('SDK error logging', () => {
+        it('logs an error when a remote track subscription fails', () => {
+            const storage = getPersistentStorage();
+            storage.removeItem(STORAGE_CALLS_CLIENT_LOGS_KEY);
+
+            mockRoom.fire(RoomEvent.TrackSubscriptionFailed, 'TR_abc', {identity: 'user1___sess1'}, undefined);
+
+            flushLogsToAccumulated();
+            const logs = storage.getItem(STORAGE_CALLS_CLIENT_LOGS_KEY) || '';
+            expect(logs).toContain('track subscription failed for track TR_abc');
+            expect(logs).toContain('user1');
+        });
+
+        it('logs an error on an encryption error', () => {
+            const storage = getPersistentStorage();
+            storage.removeItem(STORAGE_CALLS_CLIENT_LOGS_KEY);
+
+            mockRoom.fire(RoomEvent.EncryptionError, new Error('boom'));
+
+            flushLogsToAccumulated();
+            expect(storage.getItem(STORAGE_CALLS_CLIENT_LOGS_KEY) || '').toContain('encryption error');
+        });
+    });
+
+    describe('getStats', () => {
+        // makeTrack builds a minimal stand-in for a LiveKit Local/RemoteTrack:
+        // the fields trackMetadata() reads plus a getRTCStatsReport() returning
+        // the given W3C stats map.
+        const makeTrack = (opts: {
+            sid: string;
+            source: string;
+            mstId: string;
+            kind: string;
+            streamID?: string;
+            label?: string;
+            enabled?: boolean;
+            readyState?: string;
+            report?: Map<string, any> | undefined;
+            reportErr?: Error;
+        }) => ({
+            sid: opts.sid,
+            source: opts.source,
+            kind: opts.kind,
+            mediaStream: opts.streamID ? {id: opts.streamID} : undefined,
+            mediaStreamTrack: {
+                id: opts.mstId,
+                kind: opts.kind,
+                label: opts.label ?? '',
+                enabled: opts.enabled ?? true,
+                readyState: opts.readyState ?? 'live',
+            },
+            getRTCStatsReport: opts.reportErr ?
+                jest.fn().mockRejectedValue(opts.reportErr) :
+                jest.fn().mockResolvedValue(opts.report),
+        });
+
+        const setPublications = (local: any[], remote: any[]) => {
+            mockRoom.localParticipant.trackPublications = new Map(
+                local.map((track, i) => [`local-pub-${i}`, {track}]),
+            );
+            mockRoom.remoteParticipants = new Map([
+                ['remote-1', {
+                    trackPublications: new Map(
+                        remote.map((track, i) => [`remote-pub-${i}`, {track}]),
+                    ),
+                }],
+            ]);
+        };
+
+        it('returns null when there is no room', async () => {
+            (client as any).room = null;
+
+            expect(await client.getStats()).toBeNull();
+        });
+
+        it('reports track metadata and parsed rtc stats from local and remote tracks', async () => {
+            client.initTime = 1234;
+            client.channelID = 'channel-abc';
+
+            const localReport = new Map<string, any>([
+                ['out-1', {id: 'out-1', type: 'outbound-rtp', ssrc: 111, kind: 'audio', bytesSent: 500}],
+                ['cp-1', {id: 'cp-1', type: 'candidate-pair', state: 'succeeded', nominated: true, priority: 10, localCandidateId: 'lc-1', remoteCandidateId: 'rc-1'}],
+                ['lc-1', {id: 'lc-1', type: 'local-candidate', candidateType: 'host'}],
+                ['rc-1', {id: 'rc-1', type: 'remote-candidate', candidateType: 'srflx'}],
+            ]);
+            const remoteReport = new Map<string, any>([
+                ['in-1', {id: 'in-1', type: 'inbound-rtp', ssrc: 222, kind: 'audio', bytesReceived: 700}],
+            ]);
+
+            const micTrack = makeTrack({sid: 'mic-sid', source: 'microphone', kind: 'audio', mstId: 'mic-mst', streamID: 'mic-stream', label: 'Default Mic', report: localReport});
+            const remoteTrack = makeTrack({sid: 'rem-sid', source: 'microphone', kind: 'audio', mstId: 'rem-mst', streamID: 'rem-stream', report: remoteReport});
+            setPublications([micTrack], [remoteTrack]);
+
+            const stats = await client.getStats();
+
+            expect(stats).not.toBeNull();
+            expect(stats!.initTime).toBe(1234);
+            expect(stats!.channelID).toBe('channel-abc');
+
+            expect(stats!.tracksInfo).toEqual([
+                {streamID: 'mic-stream', id: 'mic-mst', kind: 'audio', label: 'Default Mic', enabled: true, readyState: 'live'},
+                {streamID: 'rem-stream', id: 'rem-mst', kind: 'audio', label: '', enabled: true, readyState: 'live'},
+            ]);
+
+            // SSRC stats from both reports are merged.
+            expect(stats!.rtcStats!.ssrcStats[111].local.out).toMatchObject({bytesSent: 500, kind: 'audio'});
+            expect(stats!.rtcStats!.ssrcStats[222].local.in).toMatchObject({bytesReceived: 700, kind: 'audio'});
+
+            // ICE candidate-pair was parsed and its local/remote candidates resolved.
+            expect(stats!.rtcStats!.iceStats.succeeded).toHaveLength(1);
+            expect(stats!.rtcStats!.iceStats.succeeded[0]).toMatchObject({
+                id: 'cp-1',
+                nominated: true,
+                local: {id: 'lc-1', candidateType: 'host'},
+                remote: {id: 'rc-1', candidateType: 'srflx'},
+            });
+        });
+
+        it('falls back to empty streamID when a track has no mediaStream', async () => {
+            const track = makeTrack({sid: 's', source: 'microphone', kind: 'audio', mstId: 'm', report: new Map()});
+            setPublications([track], []);
+
+            const stats = await client.getStats();
+
+            expect(stats!.tracksInfo[0].streamID).toBe('');
+        });
+
+        it('skips publications without a track', async () => {
+            mockRoom.localParticipant.trackPublications = new Map([['pub-0', {track: undefined}]]);
+            mockRoom.remoteParticipants = new Map();
+
+            const stats = await client.getStats();
+
+            expect(stats!.tracksInfo).toEqual([]);
+            expect(stats!.rtcStats).toBeNull();
+        });
+
+        it('continues when a track fails to produce a stats report', async () => {
+            const goodReport = new Map<string, any>([
+                ['out-1', {id: 'out-1', type: 'outbound-rtp', ssrc: 111, kind: 'audio', bytesSent: 1}],
+            ]);
+            const good = makeTrack({sid: 'good', source: 'microphone', kind: 'audio', mstId: 'good-mst', report: goodReport});
+            const bad = makeTrack({sid: 'bad', source: 'screen_share', kind: 'video', mstId: 'bad-mst', reportErr: new Error('peer gone')});
+            setPublications([good, bad], []);
+
+            const stats = await client.getStats();
+
+            // Both tracks are still described; only the good report contributes stats.
+            expect(stats!.tracksInfo).toHaveLength(2);
+            expect(stats!.rtcStats!.ssrcStats[111].local.out).toMatchObject({bytesSent: 1});
+        });
+
+        it('returns null rtcStats when no track yields a report', async () => {
+            const track = makeTrack({sid: 's', source: 'microphone', kind: 'audio', mstId: 'm', report: undefined});
+            setPublications([track], []);
+
+            const stats = await client.getStats();
+
+            expect(stats!.tracksInfo).toHaveLength(1);
+            expect(stats!.rtcStats).toBeNull();
         });
     });
 });

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -23,6 +23,7 @@ import {
     Room,
     RoomEvent,
     ScreenShareCaptureOptions,
+    SubscriptionError,
     Track,
     TrackPublication,
 } from 'livekit-client';
@@ -30,12 +31,14 @@ import RestClient from 'src/clients/rest';
 import {WEBSOCKET_EVENT, WebSocketClient, WebSocketError, WebSocketErrorType} from 'src/clients/websocket';
 import {AudioInputPermissionsErr} from 'src/components/error_modal/error_messages';
 import {
+    STORAGE_CALLS_CLIENT_STATS_KEY,
     STORAGE_CALLS_DEFAULT_AUDIO_INPUT_KEY,
     STORAGE_CALLS_DEFAULT_AUDIO_OUTPUT_KEY,
 } from 'src/constants';
-import {logDebug, logErr, logInfo, logWarn} from 'src/log';
-import {CallsClientStats, MediaDevices} from 'src/types/types';
-import {getPluginPath, getScreenStream} from 'src/utils';
+import {flushLogsToAccumulated, logDebug, logErr, logInfo, logWarn} from 'src/log';
+import {parseRTCStats} from 'src/rtc_stats';
+import {CallsClientStats, MediaDevices, TrackMetadata} from 'src/types/types';
+import {getPersistentStorage, getPluginPath, getScreenStream} from 'src/utils';
 
 import {
     AUDIO_CAPTURE_DEFAULTS,
@@ -47,6 +50,46 @@ import {
     USER_ID_SESSION_ID_SEPARATOR,
 } from './constants';
 import {ConnectPayload, ReactionPayload, RtcTokenResponse} from './types';
+
+// trackMetadata extracts the diagnostic fields getStats() reports for a track,
+// from its underlying MediaStreamTrack. Mirrors the shape produced by the legacy
+// pion client so the --- Call Stats --- block looks the same on both paths.
+function trackMetadata(track: LocalTrack | RemoteTrack): TrackMetadata {
+    const mst = track.mediaStreamTrack;
+    return {
+        streamID: track.mediaStream?.id ?? '',
+        id: mst.id,
+        kind: mst.kind,
+        label: mst.label,
+        enabled: mst.enabled,
+        readyState: mst.readyState,
+    };
+}
+
+// mergeStatsReports flattens the per-track RTCStatsReports returned by the
+// LiveKit SDK into a single map keyed by stat id. RTCRtpSender/Receiver.getStats()
+// each return the full chain for their RTP stream — including the shared
+// transport and candidate-pair entries — so the same candidate-pair id appears
+// in every report on a given PeerConnection; keying by id dedupes those while
+// preserving the distinct publisher/subscriber transports. The result is a
+// Map, which satisfies RTCStatsReport (a ReadonlyMap) for parseRTCStats().
+function mergeStatsReports(reports: RTCStatsReport[]): RTCStatsReport {
+    // RTCStatsReport is a ReadonlyMap<string, any>; the per-stat value type is
+    // inherently any (it varies by stat type), matching the DOM lib definition.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const merged = new Map<string, any>();
+    for (const report of reports) {
+        report.forEach((stat, id) => {
+            merged.set(id, stat);
+        });
+    }
+    return merged;
+}
+
+// How often we sample RTC stats during a live call, so a last-known-good sample
+// is available to log if the call is torn down remotely. Matches the v1 client's
+// RTCMonitor cadence.
+const statsPollIntervalMs = 10000;
 
 export default class CallClient extends EventEmitter {
     public channelID = '';
@@ -60,6 +103,13 @@ export default class CallClient extends EventEmitter {
     private disconnecting = false;
     private disconnected = false;
     private connectPayload: ConnectPayload | null = null;
+
+    // Most recent periodic stats sample, captured while the call is live. On a
+    // remote-initiated teardown (host ends the call, network drop) the peer
+    // connections are already gone by the time we learn about it, so this is the
+    // best stats we can log for forensics. See startStatsPolling().
+    private lastStats: CallsClientStats | null = null;
+    private statsPollTimer: ReturnType<typeof setInterval> | null = null;
 
     // Cached enumerated audio devices so we can call getAudioDevices() synchronously
     private audioDevices: MediaDevices = {inputs: [], outputs: []};
@@ -118,6 +168,8 @@ export default class CallClient extends EventEmitter {
         room.on(RoomEvent.MediaDevicesError, this.handleMediaDevicesError.bind(this));
         room.on(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged.bind(this));
         room.on(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged.bind(this));
+        room.on(RoomEvent.TrackSubscriptionFailed, this.handleTrackSubscriptionFailed.bind(this));
+        room.on(RoomEvent.EncryptionError, this.handleEncryptionError.bind(this));
     }
 
     // trackPubSummary returns a compact, log-friendly view of a track publication.
@@ -299,8 +351,9 @@ export default class CallClient extends EventEmitter {
     }
 
     // The single public entry point to end a call. In the normal case it ONLY
-    // initiates a LiveKit disconnect and does no teardown itself; all teardown is
-    // driven by the resulting RoomEvent.Disconnected -> handleDisconnected().
+    // initiates a LiveKit disconnect and does no teardown itself; all teardown —
+    // including the final stats/log flush — is driven by the resulting
+    // RoomEvent.Disconnected -> handleDisconnected().
     public disconnect(): Promise<void> {
         // Already torn down — nothing to wait for.
         if (this.disconnected) {
@@ -313,13 +366,49 @@ export default class CallClient extends EventEmitter {
         if (this.room && this.room.state !== ConnectionState.Disconnected) {
             this.room.disconnect();
         } else {
-            // But! If room is already disconnected, run handleDisconnected directly since room.disconnect()
-            //  will not emit the event. This ensures teardown still occurs.
+            // room.disconnect() will not emit the event in this state, so run
+            // handleDisconnected directly to ensure teardown still occurs.
             this.handleDisconnected(DisconnectReason.CLIENT_INITIATED);
         }
 
         return isDisconnectCompleted;
     }
+
+    // startStatsPolling samples RTC stats on an interval while the call is live,
+    // keeping the latest in lastStats. This is the sole stats source flushed at
+    // teardown: by the time we learn a call ended (especially a remote teardown)
+    // the peer connections are gone, so a fresh read is not possible.
+    private startStatsPolling(): void {
+        this.stopStatsPolling();
+
+        // Take an immediate sample rather than waiting a full interval, so a call
+        // that fails early still has stats — in particular the ICE candidate pairs,
+        // which are the key diagnostic for a connection that never stabilized.
+        void this.pollStats();
+
+        this.statsPollTimer = setInterval(this.pollStats, statsPollIntervalMs);
+    }
+
+    private stopStatsPolling(): void {
+        if (this.statsPollTimer) {
+            clearInterval(this.statsPollTimer);
+            this.statsPollTimer = null;
+        }
+    }
+
+    // pollStats captures one stats sample into lastStats. Arrow-bound so it can be
+    // handed directly to setInterval. Failures are logged at debug and swallowed —
+    // a transient read failure just means we keep the previous sample.
+    private pollStats = async (): Promise<void> => {
+        try {
+            const stats = await this.getStats();
+            if (stats) {
+                this.lastStats = stats;
+            }
+        } catch (err) {
+            logDebug('CallClient: periodic stats capture failed', err);
+        }
+    };
 
     public async mute(): Promise<void> {
         if (!this.room || !this.roomConnected) {
@@ -601,7 +690,50 @@ export default class CallClient extends EventEmitter {
     }
 
     public async getStats(): Promise<CallsClientStats | null> {
-        return null;
+        if (!this.room) {
+            return null;
+        }
+
+        const tracksInfo: TrackMetadata[] = [];
+        const reports: RTCStatsReport[] = [];
+
+        const collect = async (track: LocalTrack | RemoteTrack) => {
+            tracksInfo.push(trackMetadata(track));
+            try {
+                const report = await track.getRTCStatsReport();
+                if (report) {
+                    reports.push(report);
+                }
+            } catch (err) {
+                logWarn(`CallClient: failed to get RTC stats for track ${track.sid} (${track.source})`, err);
+            }
+        };
+
+        // Our published tracks (microphone, screen video/audio).
+        const collecting: Promise<void>[] = [];
+        for (const pub of this.room.localParticipant.trackPublications.values()) {
+            if (pub.track) {
+                collecting.push(collect(pub.track));
+            }
+        }
+
+        // Tracks we're subscribed to from remote participants.
+        for (const participant of this.room.remoteParticipants.values()) {
+            for (const pub of participant.trackPublications.values()) {
+                if (pub.track) {
+                    collecting.push(collect(pub.track));
+                }
+            }
+        }
+
+        await Promise.all(collecting);
+
+        return {
+            initTime: this.initTime,
+            channelID: this.channelID,
+            tracksInfo,
+            rtcStats: reports.length ? parseRTCStats(mergeStatsReports(reports)) : null,
+        };
     }
 
     public getSessionID() {
@@ -693,6 +825,10 @@ export default class CallClient extends EventEmitter {
 
         this.roomConnected = true;
         this.initTime = Date.now();
+
+        // Start sampling RTC stats so we have a last-known-good snapshot to log if
+        // the call is torn down remotely (see lastStats / startStatsPolling).
+        this.startStatsPolling();
 
         // Request microphone permission in the background so connection
         // handling is not blocked by the user's interaction.
@@ -826,6 +962,7 @@ export default class CallClient extends EventEmitter {
         this.roomConnected = false;
         this.connectPayload = null;
         this.room = null;
+        this.stopStatsPolling();
 
         this.emit(CALL_EVENT.DISCONNECTED, reason);
 
@@ -839,6 +976,15 @@ export default class CallClient extends EventEmitter {
                 this.websocketClient = null;
                 logDebug('CallClient: pluginWS disconnected');
             }
+        }
+
+        // Persist final diagnostics: the last periodic stats sample (lastStats is
+        // null for a call torn down within the first poll interval) folded into the
+        // log buffer that `/call logs` uploads, plus a copy under
+        // STORAGE_CALLS_CLIENT_STATS_KEY for `/call stats`, mirroring the v1 client.
+        flushLogsToAccumulated(this.lastStats);
+        if (this.lastStats) {
+            getPersistentStorage().setItem(STORAGE_CALLS_CLIENT_STATS_KEY, JSON.stringify(this.lastStats));
         }
     }
 
@@ -854,6 +1000,10 @@ export default class CallClient extends EventEmitter {
             this.emit(localTrackPublication.isMuted ? CALL_EVENT.MUTE : CALL_EVENT.UNMUTE, sessionID, userID);
 
             logDebug(`CallClient: local voice stream published for user ${userID}`, this.trackPubSummary(localTrackPublication));
+
+            // The mic is usually the first track on the transport, so sample now to
+            // capture ICE candidate pairs as soon as they exist (see startStatsPolling).
+            void this.pollStats();
         }
 
         // Browser renders a native "Stop sharing" bar when sharing screen which has dismiss/stop button.
@@ -1076,6 +1226,22 @@ export default class CallClient extends EventEmitter {
 
         logErr('CallClient: media device error occurred', err);
         this.emit(CALL_EVENT.ERROR, err);
+    }
+
+    // Fires when the SDK fails to subscribe to a remote track — the media-layer
+    // cause behind "I can't hear/see someone". Logged for forensics; LiveKit
+    // retries subscription on its own, so we don't surface it to the user.
+    private handleTrackSubscriptionFailed(trackSid: string, participant: RemoteParticipant, reason?: SubscriptionError) {
+        const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(participant);
+        const reasonName = reason === undefined ? 'unknown' : SubscriptionError[reason];
+        logErr(`CallClient: track subscription failed for track ${trackSid} from user ${userID} (session ${sessionID}), reason: ${reasonName}`);
+    }
+
+    // Fires on an E2EE failure. Calls does not enable end-to-end encryption today,
+    // so this should not occur — logged defensively in case it ever does.
+    private handleEncryptionError(err: Error, participant?: Participant) {
+        const who = participant ? ` for user ${this.parseUserIdAndSessionIdFromIdentity(participant).userID}` : '';
+        logErr(`CallClient: encryption error${who}`, err);
     }
 
     /**

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -982,9 +982,13 @@ export default class CallClient extends EventEmitter {
         // null for a call torn down within the first poll interval) folded into the
         // log buffer that `/call logs` uploads, plus a copy under
         // STORAGE_CALLS_CLIENT_STATS_KEY for `/call stats`, mirroring the v1 client.
+        // When this call captured no sample, clear the key so `/call stats` shows
+        // empty rather than leaking a previous call's stats.
         flushLogsToAccumulated(this.lastStats);
         if (this.lastStats) {
             getPersistentStorage().setItem(STORAGE_CALLS_CLIENT_STATS_KEY, JSON.stringify(this.lastStats));
+        } else {
+            getPersistentStorage().removeItem(STORAGE_CALLS_CLIENT_STATS_KEY);
         }
     }
 

--- a/webapp/src/clients/call/types.ts
+++ b/webapp/src/clients/call/types.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {EmojiData, RTCStats} from '@mattermost/calls-common/lib/types';
+import type {EmojiData} from '@mattermost/calls-common/lib/types';
+import type {RTCStats} from 'src/types/webrtc';
 
 export type RtcTokenResponse = {
     token: string;

--- a/webapp/src/clients/calls/index.ts
+++ b/webapp/src/clients/calls/index.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable max-lines */
 
-import {parseRTCStats, RTCPeer} from '@mattermost/calls-common';
+import {RTCPeer} from '@mattermost/calls-common';
 import type {CallsClientJoinData, EmojiData, RTPEncodingParameters, TrackInfo} from '@mattermost/calls-common/lib/types';
 import {EventEmitter} from 'events';
 import {strToU8, zlibSync} from 'fflate';
@@ -17,6 +17,7 @@ import {
 } from 'src/constants';
 import {type BgBlurData, getBgBlurData} from 'src/local_storage';
 import {logDebug, logErr, logInfo, logWarn, persistClientLogs} from 'src/log';
+import {parseRTCStats} from 'src/rtc_stats';
 import Segmenter from 'src/segmenter';
 import {CallsClientConfig, CallsClientStats, MediaDevices, TrackMetadata} from 'src/types/types';
 import {getPersistentStorage, getScreenStream} from 'src/utils';
@@ -1195,7 +1196,7 @@ export default class CallsClient extends EventEmitter {
 
         return {
             initTime: this.initTime,
-            callID: this.channelID,
+            channelID: this.channelID,
             tracksInfo,
             rtcStats: stats ? parseRTCStats(stats) : null,
         };

--- a/webapp/src/log.test.ts
+++ b/webapp/src/log.test.ts
@@ -77,7 +77,7 @@ describe('log', () => {
         test('should append stats when provided', () => {
             const stats: CallsClientStats = {
                 initTime: 123456,
-                callID: 'test-channel',
+                channelID: 'test-channel',
                 tracksInfo: [],
                 rtcStats: {
                     ssrcStats: {},
@@ -228,7 +228,7 @@ describe('log', () => {
 
             const stats: CallsClientStats = {
                 initTime: 123456,
-                callID: 'test-channel',
+                channelID: 'test-channel',
                 tracksInfo: [],
                 rtcStats: {
                     ssrcStats: {},

--- a/webapp/src/rtc_stats.ts
+++ b/webapp/src/rtc_stats.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Vendored from @mattermost/calls-common (src/rtc_stats.ts). calls-common is
+// being deprecated; this parses a standard W3C RTCStatsReport into the plugin's
+// RTCStats shape (see src/types/webrtc.ts). Kept byte-for-byte equivalent so the
+// `--- Call Stats ---` log output matches the legacy v1 client.
+
+import {ICEStats, RTCCandidatePairStats, RTCStats, SSRCStats} from 'src/types/webrtc';
+
+export function newRTCLocalInboundStats(report: any) {
+    return {
+        timestamp: report.timestamp,
+
+        // @ts-ignore: mid is missing current version, we need bump some dependencies to fix this.
+        mid: report.mid,
+        kind: report.kind,
+        trackIdentifier: report.trackIdentifier,
+        packetsReceived: report.packetsReceived,
+        packetsLost: report.packetsLost,
+        packetsDiscarded: report.packetsDiscarded,
+        bytesReceived: report.bytesReceived,
+        nackCount: report.nackCount,
+        pliCount: report.pliCount,
+        jitter: report.jitter,
+        jitterBufferDelay: report.jitterBufferDelay,
+    };
+}
+
+export function newRTCLocalOutboundStats(report: any) {
+    return {
+        timestamp: report.timestamp,
+
+        // @ts-ignore: mid is missing in current version, we need bump some dependencies to fix this.
+        mid: report.mid,
+        kind: report.kind,
+        packetsSent: report.packetsSent,
+        bytesSent: report.bytesSent,
+        retransmittedPacketsSent: report.retransmittedPacketsSent,
+        retransmittedBytesSent: report.retransmittedBytesSent,
+        nackCount: report.nackCount,
+        pliCount: report.pliCount,
+        targetBitrate: report.targetBitrate,
+    };
+}
+
+export function newRTCRemoteInboundStats(report: any) {
+    return {
+        timestamp: report.timestamp,
+        kind: report.kind,
+        packetsLost: report.packetsLost,
+        fractionLost: report.fractionLost,
+        jitter: report.jitter,
+        roundTripTime: report.roundTripTime,
+    };
+}
+
+export function newRTCRemoteOutboundStats(report: any) {
+    return {
+        timestamp: report.timestamp,
+        kind: report.kind,
+        packetsSent: report.packetsSent,
+        bytesSent: report.bytesSent,
+    };
+}
+
+export function newRTCCandidatePairStats(report: any, reports: RTCStatsReport): RTCCandidatePairStats {
+    let local;
+    let remote;
+    reports.forEach((r) => {
+        if (r.id === report.localCandidateId) {
+            local = r;
+        } else if (r.id === report.remoteCandidateId) {
+            remote = r;
+        }
+    });
+
+    return {
+        id: report.id,
+        timestamp: report.timestamp,
+        priority: report.priority,
+        packetsSent: report.packetsSent,
+        packetsReceived: report.packetsReceived,
+        currentRoundTripTime: report.currentRoundTripTime,
+        totalRoundTripTime: report.totalRoundTripTime,
+        nominated: report.nominated,
+        state: report.state,
+        local,
+        remote,
+    };
+}
+
+export function parseSSRCStats(reports: RTCStatsReport): SSRCStats {
+    const stats: SSRCStats = {};
+    reports.forEach((report) => {
+        if (!report.ssrc) {
+            return;
+        }
+
+        if (!stats[report.ssrc]) {
+            stats[report.ssrc] = {
+                local: {},
+                remote: {},
+            };
+        }
+
+        switch (report.type) {
+        case 'inbound-rtp':
+            stats[report.ssrc].local.in = newRTCLocalInboundStats(report);
+            break;
+        case 'outbound-rtp':
+            stats[report.ssrc].local.out = newRTCLocalOutboundStats(report);
+            break;
+        case 'remote-inbound-rtp':
+            stats[report.ssrc].remote.in = newRTCRemoteInboundStats(report);
+            break;
+        case 'remote-outbound-rtp':
+            stats[report.ssrc].remote.out = newRTCRemoteOutboundStats(report);
+            break;
+        }
+    });
+    return stats;
+}
+
+export function parseICEStats(reports: RTCStatsReport): ICEStats {
+    const stats: ICEStats = {};
+    reports.forEach((report: RTCIceCandidatePairStats) => {
+        if (report.type !== 'candidate-pair') {
+            return;
+        }
+
+        if (!stats[report.state]) {
+            stats[report.state] = [];
+        }
+
+        stats[report.state].push(newRTCCandidatePairStats(report, reports));
+    });
+
+    // We sort pairs so that first values are those nominated and/or have the highest priority.
+    for (const pairs of Object.values(stats)) {
+        pairs.sort((a, b) => {
+            if (a.nominated && !b.nominated) {
+                return -1;
+            }
+
+            if (b.nominated && !a.nominated) {
+                return 1;
+            }
+
+            // Highest priority should come first.
+            return (b.priority ?? 0) - (a.priority ?? 0);
+        });
+    }
+
+    return stats;
+}
+
+export function parseRTCStats(reports: RTCStatsReport): RTCStats {
+    return {
+        ssrcStats: parseSSRCStats(reports),
+        iceStats: parseICEStats(reports),
+    };
+}

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -1,8 +1,9 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {CallsConfig, LiveCaption, RTCStats, TranscribeAPI} from '@mattermost/calls-common/lib/types';
+import {CallsConfig, LiveCaption, TranscribeAPI} from '@mattermost/calls-common/lib/types';
 import {MessageDescriptor} from 'react-intl';
+import {RTCStats} from 'src/types/webrtc';
 
 export const CallsConfigDefault: CallsConfig = {
     ICEServers: [],
@@ -58,7 +59,7 @@ export type TrackMetadata = {
 
 export type CallsClientStats = {
     initTime: number;
-    callID: string;
+    channelID: string;
     tracksInfo: TrackMetadata[];
     rtcStats: RTCStats | null;
 }

--- a/webapp/src/types/webrtc.ts
+++ b/webapp/src/types/webrtc.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// RTC stats types vendored from @mattermost/calls-common (src/types/webrtc.ts).
+// calls-common is being deprecated; the parsed-stats shape lives here so the
+// plugin no longer depends on it for RTC stats. parseRTCStats (src/rtc_stats.ts)
+// produces these from a standard RTCStatsReport.
+
+export type SSRCStats = {
+    [key: number]: {
+        local: RTCLocalStats;
+        remote: RTCRemoteStats;
+    }
+}
+
+export type ICEStats = {
+    [key: string]: RTCCandidatePairStats[];
+}
+
+export type RTCStats = {
+    ssrcStats: SSRCStats;
+    iceStats: ICEStats;
+};
+
+export type RTCLocalStats = {
+    in?: RTCLocalInboundStats;
+    out?: RTCLocalOutboundStats;
+}
+
+export type RTCRemoteStats = {
+    in?: RTCRemoteInboundStats;
+    out?: RTCRemoteOutboundStats;
+}
+
+export type RTCLocalInboundStats = {
+    timestamp: number;
+    kind: string;
+    packetsReceived: number;
+    bytesReceived: number;
+    packetsLost: number;
+    packetsDiscarded: number;
+    jitter: number;
+    jitterBufferDelay: number;
+}
+
+export type RTCLocalOutboundStats = {
+    timestamp: number;
+    kind: string;
+    packetsSent: number;
+    bytesSent: number;
+    retransmittedPacketsSent: number;
+    retransmittedBytesSent: number;
+    nackCount: number;
+    targetBitrate: number;
+}
+
+export type RTCRemoteInboundStats = {
+    timestamp: number;
+    kind: string;
+    packetsLost: number;
+    fractionLost: number;
+    jitter: number;
+    roundTripTime: number;
+}
+
+export type RTCRemoteOutboundStats = {
+    timestamp: number;
+    kind: string;
+    packetsSent: number;
+    bytesSent: number;
+}
+
+// This should be in lib.dom.d.ts
+export type RTCIceCandidateStats = {
+    candidateType: string;
+    protocol: string;
+    port: number;
+}
+
+export type RTCCandidatePairStats = {
+    id: string;
+    timestamp: number;
+    priority?: number;
+    packetsSent: number;
+    packetsReceived: number;
+    currentRoundTripTime: number;
+    totalRoundTripTime: number;
+    nominated?: boolean;
+    state: RTCStatsIceCandidatePairState;
+    local?: RTCIceCandidateStats;
+    remote?: RTCIceCandidateStats;
+}


### PR DESCRIPTION
## Summary

Implements `getStats()` for the v2 LiveKit client (it was a `return null` stub, so the `--- Call Stats ---` block never appeared for LiveKit calls) and wires RTC stats + SDK errors into the call-log buffer. Follow-up to #1218 (MM-69079), which ported the logging infrastructure.

Webapp-only.

## What's in it

- **`CallClient.getStats()`** — gathers stats via the public SDK surface (`track.getRTCStatsReport()` over local published + subscribed remote tracks), merges the per-track `RTCStatsReport`s into one map keyed by stat id (deduping the shared transport/candidate-pair entries while preserving the distinct publisher/subscriber transports), and runs them through `parseRTCStats` for the full v1 `RTCStats` shape (`ssrcStats` + `iceStats`).
- **Stats sampling** — a fresh read at disconnect is impossible (the peer connections are already gone by the time we learn of a teardown, especially a remote one), so a last-known-good sample is kept: a 10s periodic poll (matching the v1 `RTCMonitor` cadence), plus an immediate sample on connect and on mic-publish. The mic is usually the first track on the transport, so the mic-publish sample captures ICE candidate pairs the moment they exist.
- **Flush on every disconnect path** — `handleDisconnected` flushes the latest sample into the `/call logs` buffer and persists a copy for `/call stats`. Covers clean leave, host-end, and network drop — the cases that previously logged no stats at all.
- **SDK error logging** — wired `TrackSubscriptionFailed` (the media-layer cause of "can't hear/see someone") and `EncryptionError`; `MediaDevicesError` was already logged. Chose discrete error events over piping the full SDK internal-log firehose, which would be largely redundant with the lifecycle events we already log and would crowd the 1MB buffer.
- **Vendored RTC-stats code** — copied `parseRTCStats` + the stats types out of the deprecating `@mattermost/calls-common` into `src/rtc_stats.ts` + `src/types/webrtc.ts`, and repointed both the v2 and v1 clients. No calls-common stats import remains.
- **Renamed `CallsClientStats.callID` → `channelID`** — the field always held the channel id in both clients; the real server call id isn't available to the client at stats time. Matches main.

## Test plan

- Full webapp unit suite green (405 tests). New coverage in `call_client.test.ts`: getStats per-track merge incl. ICE candidate resolution, periodic + connect + mic-publish sampling, flush on clean + remote teardown, and SDK error-event logging.
- `tsc` and `eslint` clean.