### PR TITLE
fix issue not show icon start call in chaneel

### DIFF
--- a/server/enterprise/license.go
+++ b/server/enterprise/license.go
@@ -58,5 +58,15 @@ func (e *LicenseChecker) HostControlsAllowed() bool {
 }
 
 func (e *LicenseChecker) GroupCallsAllowed() bool {
-	return e.isAtLeastProfessionalLicensed() || os.Getenv("MM_CALLS_GROUP_CALLS_ALLOWED") == "true"
+	if os.Getenv("MM_CALLS_GROUP_CALLS_ALLOWED") == "true" {
+		return true
+	}
+	if os.Getenv("MM_CALLS_GROUP_CALLS_ALLOWED") == "false" {
+		return false
+	}
+	// Self-hosted deployments support calls in public/private channels without Professional.
+	if !license.IsCloud(e.api.GetLicense()) {
+		return true
+	}
+	return e.isAtLeastProfessionalLicensed()
 }

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -106,13 +106,20 @@ func TestAddUserSession(t *testing.T) {
 		require.Equal(t, retState, retState2)
 	})
 
-	t.Run("allow calls in DMs only when unlicensed", func(t *testing.T) {
+	t.Run("allow calls in DMs only on unlicensed cloud", func(t *testing.T) {
 		defer mockAPI.AssertExpectations(t)
 		defer mockMetrics.AssertExpectations(t)
 		defer ResetTestStore(t, p.store)
 
+		cloudLicense := &model.License{
+			SkuShortName: "starter",
+			Features: &model.Features{
+				Cloud: model.NewBool(true),
+			},
+		}
+
 		mockAPI.On("GetConfig").Return(&model.Config{}, nil).Times(6)
-		mockAPI.On("GetLicense").Return(&model.License{}, nil).Times(3)
+		mockAPI.On("GetLicense").Return(cloudLicense, nil).Times(3)
 
 		t.Run("public channel", func(t *testing.T) {
 			mockAPI.On("SendEphemeralPost", "userA", &model.Post{
@@ -159,5 +166,21 @@ func TestAddUserSession(t *testing.T) {
 			require.Len(t, retState.sessions, 1)
 			require.NotNil(t, retState.sessions["connA"])
 		})
+	})
+
+	t.Run("allow calls in all channels on self-hosted", func(t *testing.T) {
+		defer mockAPI.AssertExpectations(t)
+		defer mockMetrics.AssertExpectations(t)
+		defer ResetTestStore(t, p.store)
+
+		mockAPI.On("GetConfig").Return(&model.Config{}, nil).Times(2)
+		mockAPI.On("GetLicense").Return(&model.License{}, nil).Once()
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallHostChanged).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventCallHostChanged, mock.Anything,
+			&model.WebsocketBroadcast{UserId: "userA", ChannelId: "channelID", ReliableClusterSend: true}).Once()
+
+		retState, err := p.addUserSession(nil, model.NewPointer(true), "userA", "connA", "channelID", "", model.ChannelTypeOpen)
+		require.NoError(t, err)
+		require.NotNil(t, retState)
 	})
 }

--- a/webapp/src/components/channel_header_dropdown_button/index.ts
+++ b/webapp/src/components/channel_header_dropdown_button/index.ts
@@ -6,6 +6,7 @@ import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {connect} from 'react-redux';
 import {
+    areGroupCallsAllowed,
     callsShowButton,
     channelIDForCurrentCall,
     currentChannelHasCall,
@@ -14,6 +15,7 @@ import {
     isLimitRestricted,
     maxParticipants,
 } from 'src/selectors';
+import {isDmGmChannel} from 'src/utils';
 
 import ChannelHeaderDropdownButton from './component';
 
@@ -21,7 +23,7 @@ const mapStateToProps = (state: GlobalState) => {
     const channel = getCurrentChannel(state);
 
     return {
-        show: callsShowButton(state, channel?.id),
+        show: callsShowButton(state, channel?.id) && (areGroupCallsAllowed(state) || isDmGmChannel(channel)),
         inCall: Boolean(channelIDForCurrentCall(state) && channelIDForCurrentCall(state) === channel?.id),
         hasCall: currentChannelHasCall(state),
         isAdmin: isCurrentUserSystemAdmin(state),


### PR DESCRIPTION
…icense checker

- Updated session tests to allow calls in DMs only for unlicensed cloud environments and added a new test for self-hosted deployments.
- Modified the LicenseChecker to support group calls in self-hosted deployments without requiring a Professional license, based on environment variables.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the Schema Migration Template as a starting point to capture these details as release notes.
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.

Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.

NONE
-->
```release-note

```
