### PR TITLE
[MM-69320] Default "Share sound with screen" to on

### DIFF
--- a/webapp/src/components/user_settings/screen_sharing_settings_section.tsx
+++ b/webapp/src/components/user_settings/screen_sharing_settings_section.tsx
@@ -14,7 +14,7 @@ export default function ScreenSharingSettingsSection() {
     const description = formatMessage({defaultMessage: 'Configure your screen sharing settings.'});
     const editLabel = formatMessage({defaultMessage: 'Edit'});
 
-    const [shareAudio, setShareAudio] = useState(window.localStorage.getItem(STORAGE_CALLS_SHARE_AUDIO_WITH_SCREEN) || 'off');
+    const [shareAudio, setShareAudio] = useState(window.localStorage.getItem(STORAGE_CALLS_SHARE_AUDIO_WITH_SCREEN) || 'on');
 
     const onLabel = formatMessage({defaultMessage: 'On'});
     const offLabel = formatMessage({defaultMessage: 'Off'});

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -639,7 +639,8 @@ export function sendDesktopMessage(msg: DesktopMessage) {
 }
 
 export function shareAudioWithScreen() {
-    return window.localStorage.getItem(STORAGE_CALLS_SHARE_AUDIO_WITH_SCREEN) === 'on';
+    // Defaults to on when unset, so the browser surfaces its share-audio option.
+    return window.localStorage.getItem(STORAGE_CALLS_SHARE_AUDIO_WITH_SCREEN) !== 'off';
 }
 
 // Ported from mattermost-redux/src/utils/browser_info.ts


### PR DESCRIPTION
## Summary

The per-user **Share sound with screen** setting (Settings → Calls → Screen sharing settings) defaulted to **off**. While off, Calls requests `getDisplayMedia({audio: false})`, so the browser never shows any share-audio option — users had no way to discover audio sharing and ended up telling each other to flip a switch that's hidden by default.

This flips the default to **on** (`STORAGE_CALLS_SHARE_AUDIO_WITH_SCREEN`):

- `shareAudioWithScreen()` now returns `true` unless localStorage is explicitly `'off'`.
- The settings radio shows **On** by default when the user hasn't chosen.

A user who previously selected **Off** still has `'off'` stored and keeps that behavior.

## Why this is safe

- Chrome/Edge couple the audio option to the capture request: the checkbox only appears when we request audio (pre-checked for tab shares, opt-in for screen/window). No audio is captured without the picker showing the control.
- Firefox/Safari ignore audio entirely.

## Release notes

Tab-audio becomes on-by-default in Chromium when sharing your screen.

https://mattermost.atlassian.net/browse/MM-69320