### PR TITLE
[MM-69350] Capture popout client logs + log audio device counts

### DIFF
--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -1158,6 +1158,38 @@ describe('CallClient', () => {
             });
         });
 
+        it('logs the resolved audio input/output device counts after enumeration', async () => {
+            (navigator.mediaDevices.enumerateDevices as jest.Mock).mockResolvedValue([
+                inputDevice,
+                outputDevice,
+                inputDevice2,
+            ]);
+            const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+
+            await client.connect({channelID: 'test-channel'});
+            mockRoom.fire(RoomEvent.Connected);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            const logged = debugSpy.mock.calls.map((args) => args.join(' '));
+            expect(logged).toEqual(expect.arrayContaining([expect.stringContaining('enumerated audio devices: 2 input(s), 1 output(s)')]));
+
+            debugSpy.mockRestore();
+        });
+
+        it('logs zero input devices so the inert-mic-button condition is visible', async () => {
+            (navigator.mediaDevices.enumerateDevices as jest.Mock).mockResolvedValue([outputDevice]);
+            const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+
+            await client.connect({channelID: 'test-channel'});
+            mockRoom.fire(RoomEvent.Connected);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            const logged = debugSpy.mock.calls.map((args) => args.join(' '));
+            expect(logged).toEqual(expect.arrayContaining([expect.stringContaining('enumerated audio devices: 0 input(s), 1 output(s)')]));
+
+            debugSpy.mockRestore();
+        });
+
         it('setAudioInputDevice persists, switches the LiveKit device, and emits DEVICE_CHANGE', async () => {
             await client.connect({channelID: 'test-channel'});
             const deviceChangeListener = jest.fn();

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -1381,6 +1381,11 @@ export default class CallClient extends EventEmitter {
                 Room.getLocalDevices('audiooutput', false),
             ]);
             this.audioDevices = {inputs, outputs};
+
+            // Log the resolved counts so a "zero audio input devices" condition
+            // (which silently disables the mic button) can be confirmed directly
+            // from downloaded logs rather than inferred from absent log lines.
+            logDebug(`CallClient: enumerated audio devices: ${inputs.length} input(s), ${outputs.length} output(s)`);
         } catch (err) {
             logErr('CallClient: enumerating devices failed', err);
         }

--- a/webapp/src/log.test.ts
+++ b/webapp/src/log.test.ts
@@ -360,4 +360,65 @@ describe('log', () => {
             expect(logs).toBe('test logs');
         });
     });
+
+    describe('popout write-through', () => {
+        const originalOpener = Object.getOwnPropertyDescriptor(window, 'opener');
+
+        const setOpener = (opener: unknown) => {
+            Object.defineProperty(window, 'opener', {value: opener, configurable: true, writable: true});
+        };
+
+        afterEach(() => {
+            if (originalOpener) {
+                Object.defineProperty(window, 'opener', originalOpener);
+            } else {
+                setOpener(null);
+            }
+        });
+
+        test('routes logs to opener buffer when running as a popout', () => {
+            const append = jest.fn();
+            setOpener({callsClientLogAppend: append});
+
+            logInfo('popout gesture');
+            flushLogsToAccumulated();
+
+            // The formatted line went to the opener, not this realm's buffer.
+            expect(append).toHaveBeenCalledTimes(1);
+            expect(append.mock.calls[0][0]).toContain('popout gesture');
+            expect(append.mock.calls[0][0]).toContain('info');
+            expect(getClientLogs()).not.toContain('popout gesture');
+        });
+
+        test('falls back to local buffer when opener is same-origin without appender', () => {
+            setOpener({});
+
+            logInfo('no appender');
+            flushLogsToAccumulated();
+
+            expect(getClientLogs()).toContain('no appender');
+        });
+
+        test('falls back to local buffer when opener access throws (cross-origin)', () => {
+            setOpener(new Proxy({}, {
+                get() {
+                    throw new Error('Blocked a frame with origin');
+                },
+            }));
+
+            logInfo('cross origin opener');
+            flushLogsToAccumulated();
+
+            expect(getClientLogs()).toContain('cross origin opener');
+        });
+
+        test('does not route to itself when there is no opener', () => {
+            setOpener(null);
+
+            logInfo('main window');
+            flushLogsToAccumulated();
+
+            expect(getClientLogs()).toContain('main window');
+        });
+    });
 });

--- a/webapp/src/log.ts
+++ b/webapp/src/log.ts
@@ -32,9 +32,44 @@ function stringifyLogArg(arg: unknown): string {
     }
 }
 
+// Appends a fully-formatted log line to this realm's in-memory buffer. Exposed
+// on `window` (below) so the expanded-view popout can write through to its
+// opener's buffer rather than persisting separately.
+function appendLogLine(line: string) {
+    clientLogs += line;
+}
+
 function appendClientLog(level: string, ...args: unknown[]) {
+    // Serialize in the originating realm: Error/object args belong to this
+    // window's realm and would fail `instanceof Error` checks if handed to the
+    // opener's realm to format.
     const serialized = args.map(stringifyLogArg).join(' ');
-    clientLogs += `${level} [${new Date().toISOString()}] ${serialized}\n`;
+    const line = `${level} [${new Date().toISOString()}] ${serialized}\n`;
+
+    // In the expanded-view popout, route the line to the opener's buffer so
+    // popout-realm logs ride the main window's existing flush machinery (single
+    // source of truth, no cross-window localStorage read-modify-write race).
+    // Don't call isCallsPopOut()/logErr here — that would recurse back through
+    // appendClientLog. Inline the opener check and swallow the cross-origin
+    // SecurityError, mirroring getCallsWindow().
+    try {
+        const opener = window.opener as Window | null;
+        if (opener && opener !== window && typeof opener.callsClientLogAppend === 'function') {
+            opener.callsClientLogAppend(line);
+            return;
+        }
+    } catch {
+        // Cross-origin opener (e.g. MM opened from a calendar link): fall
+        // through to this realm's local buffer.
+    }
+
+    clientLogs += line;
+}
+
+// Expose this realm's appender so an expanded-view popout can write its logs
+// through to this (the opener's) buffer via window.opener.
+if (typeof window !== 'undefined') {
+    window.callsClientLogAppend = appendLogLine;
 }
 
 export function flushLogsToAccumulated(stats?: CallsClientStats | null) {

--- a/webapp/src/types/global.d.ts
+++ b/webapp/src/types/global.d.ts
@@ -11,6 +11,11 @@ import type {CallActions, CurrentCallData} from 'src/types/types';
 declare global {
     interface Window {
         callsClient?: CallClient,
+
+        // Appends a pre-formatted log line to this realm's in-memory client-log
+        // buffer. Exposed so the expanded-view popout can write through to its
+        // opener's buffer (single source of truth). See src/log.ts.
+        callsClientLogAppend?: (line: string) => void,
         webkitAudioContext: AudioContext,
         basename: string,
         desktop?: {


### PR DESCRIPTION
## Summary

Two client-logging gaps surfaced while diagnosing a "can't unmute" report on Calls v2. Both reduce our ability to diagnose audio/device issues from downloaded client logs. Builds on the client-logging work from MM-69079 (#1218).

### 1. Capture expanded-view popout logs

The expanded-view popout (`/expanded` route, `ExpandedView`) runs in a **separate browser window / JS realm**, so it has its own module-level `clientLogs` buffer (`webapp/src/log.ts`) that was never flushed. Logs emitted in the popout realm — gesture handlers (`onMuteToggle`, raise hand, reactions, recording), popout-only errors — were lost when the window closed and never reached the persisted/downloadable log. (The shared `CallsClient` logs to the main-window buffer already, since the popout reuses `window.opener.callsClient`; only popout-realm logs were dropped.)

Fix: `appendClientLog` now formats the line in the originating realm (so `Error`/object args serialize correctly before crossing realms), then routes it through `window.opener.callsClientLogAppend` to the main window's buffer when running as a popout — falling back to the local buffer otherwise. This makes the opener's buffer the single source of truth, so popout logs ride the main window's existing flush/upload path.

- **No cross-window `localStorage` race:** the popout never writes to storage, so there is no read-modify-write window for the two windows to clobber each other. The write-through is a single in-memory append, made atomic by JS's single-threaded event loop (popout and same-origin opener share it).
- **Ordering** is preserved — the timestamp is stamped at append time.
- The opener check is inlined with a `try/catch` for the cross-origin-opener `SecurityError` (mirroring `getCallsWindow()`), deliberately not via `isCallsPopOut()`/`logErr` to avoid recursing back through `appendClientLog`.

### 2. Log audio device-enumeration counts

`enumerateDevices()` was silent on how many input/output devices were found. When a client enumerates **zero** audio input devices, the mic button is silently disabled and clicks become no-ops — previously only inferable from the *absence* of other log lines.

`enumerateDevices()` now logs the resolved counts:

```
CallClient: enumerated audio devices: N input(s), M output(s)
```

This fires on the initial enumeration and on the `devicechange`-triggered re-enumeration that feeds `DEVICE_CHANGE`. (Selection-change `DEVICE_CHANGE` emits don't re-enumerate, so counts are unchanged there — no log line added, to avoid noise.)

Note: this client only enumerates *audio* in/out (`Room.getLocalDevices('audioinput'/'audiooutput')`); video device selection happens at the component/`getUserMedia` layer, outside this path.

## Test

- `log.test.ts`: 4 new cases — routes to opener when a popout, falls back to local when the opener lacks the appender, falls back on cross-origin throw, main-window (no opener) stays local.
- `call_client.test.ts`: 2 new cases — counts logged correctly (2 in / 1 out), and the `0 input(s)` case.
- Full webapp suite green (399/399); `tsc` and `eslint` clean on changed files.

## Manual verification (pending)

- [ ] Join via popout, toggle mute, leave → gesture + device-count lines present in the downloaded / bot-DM-uploaded log.