### PR TITLE
[MM-69189] Restore live participant list for call-post observers

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -176,6 +176,8 @@ import {
     handleHostRemoved,
     handleHostScreenOff,
     handleUserDismissedNotification,
+    handleUserJoined,
+    handleUserLeft,
     handleUserRaisedHand,
     handleUserReaction,
     handleUserRemovedFromChannel,
@@ -221,6 +223,17 @@ export default class Plugin {
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_call_ended`, (ev) => {
             handleCallEnd(store, ev);
+        });
+
+        // Channel-wide join/leave broadcasts keep the call post's participant list live for
+        // observers who haven't joined the call. Connected users get session state from the
+        // LiveKit room instead; the handlers ignore broadcasts for that channel.
+        registry.registerWebSocketEventHandler(`custom_${pluginId}_user_joined`, (ev) => {
+            handleUserJoined(store, ev);
+        });
+
+        registry.registerWebSocketEventHandler(`custom_${pluginId}_user_left`, (ev) => {
+            handleUserLeft(store, ev);
         });
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_user_screen_on`, (ev) => {

--- a/webapp/src/state/session/reducer.ts
+++ b/webapp/src/state/session/reducer.ts
@@ -29,7 +29,7 @@ type State = {
 
 const emptyState: State = {};
 
-export const reducer: Reducer<State, Actions> = (currentState = emptyState, action) : State => {
+export const reducer: Reducer<State, Actions> = (initialState = emptyState, action) : State => {
     switch (action.type) {
     case UN_INITIALIZED: {
         return emptyState;
@@ -37,16 +37,16 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
 
     case SESSIONS_RECEIVED: {
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: action.data.sessions,
         };
     }
 
     case USER_JOINED: {
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: {
-                ...currentState[action.data.channelID],
+                ...initialState[action.data.channelID],
                 [action.data.session_id]: {
                     session_id: action.data.session_id,
                     user_id: action.data.userID,
@@ -60,10 +60,10 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
     }
 
     case USERS_VOICE_ACTIVITY_CHANGED: {
-        const allSessions = currentState[action.data.channelID];
+        const allSessions = initialState[action.data.channelID];
 
         if (!allSessions) {
-            return currentState;
+            return initialState;
         }
 
         // With this flag we avoid creating a new state object if no changes are made
@@ -88,25 +88,25 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
         }
 
         if (!stateChanged) {
-            return currentState;
+            return initialState;
         }
 
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: nextState,
         };
     }
 
     case USER_MUTED: {
-        const allSessions = currentState[action.data.channelID];
+        const allSessions = initialState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return currentState;
+            return initialState;
         }
 
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -118,15 +118,15 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
     }
 
     case USER_UNMUTED: {
-        const allSessions = currentState[action.data.channelID];
+        const allSessions = initialState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return currentState;
+            return initialState;
         }
 
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -138,15 +138,15 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
     }
 
     case USER_HAND_RAISED: {
-        const allSessions = currentState[action.data.channelID];
+        const allSessions = initialState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return currentState;
+            return initialState;
         }
 
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -158,15 +158,15 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
     }
 
     case USER_HAND_LOWERED: {
-        const allSessions = currentState[action.data.channelID];
+        const allSessions = initialState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return currentState;
+            return initialState;
         }
 
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -178,15 +178,15 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
     }
 
     case USER_REACTED: {
-        const allSessions = currentState[action.data.channelID];
+        const allSessions = initialState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return currentState;
+            return initialState;
         }
 
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -198,17 +198,17 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
     }
 
     case USER_REACTED_TIMEOUT: {
-        const allSessions = currentState[action.data.channelID];
+        const allSessions = initialState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         // Only clear if the timing-out reaction is still the one displayed — a newer
         // reaction within the window must not be cleared by an older reaction's timeout.
         if (!currentSession || currentSession.reaction?.timestamp !== action.data.reaction.timestamp) {
-            return currentState;
+            return initialState;
         }
 
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -220,27 +220,27 @@ export const reducer: Reducer<State, Actions> = (currentState = emptyState, acti
     }
 
     case USER_LEFT: {
-        if (!currentState[action.data.channelID]?.[action.data.session_id]) {
-            return currentState;
+        if (!initialState[action.data.channelID]?.[action.data.session_id]) {
+            return initialState;
         }
 
-        const nextChannelSessions = {...currentState[action.data.channelID]};
+        const nextChannelSessions = {...initialState[action.data.channelID]};
         delete nextChannelSessions[action.data.session_id];
 
         return {
-            ...currentState,
+            ...initialState,
             [action.data.channelID]: nextChannelSessions,
         };
     }
 
     case CALL_ENDED: {
-        const nextState = {...currentState};
+        const nextState = {...initialState};
         delete nextState[action.data.channelID];
 
         return nextState;
     }
 
     default:
-        return currentState;
+        return initialState;
     }
 };

--- a/webapp/src/state/session/reducer.ts
+++ b/webapp/src/state/session/reducer.ts
@@ -29,7 +29,7 @@ type State = {
 
 const emptyState: State = {};
 
-export const reducer: Reducer<State, Actions> = (initialState = emptyState, action) : State => {
+export const reducer: Reducer<State, Actions> = (currentState = emptyState, action) : State => {
     switch (action.type) {
     case UN_INITIALIZED: {
         return emptyState;
@@ -37,16 +37,16 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
 
     case SESSIONS_RECEIVED: {
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: action.data.sessions,
         };
     }
 
     case USER_JOINED: {
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: {
-                ...initialState[action.data.channelID],
+                ...currentState[action.data.channelID],
                 [action.data.session_id]: {
                     session_id: action.data.session_id,
                     user_id: action.data.userID,
@@ -60,10 +60,10 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
     }
 
     case USERS_VOICE_ACTIVITY_CHANGED: {
-        const allSessions = initialState[action.data.channelID];
+        const allSessions = currentState[action.data.channelID];
 
         if (!allSessions) {
-            return initialState;
+            return currentState;
         }
 
         // With this flag we avoid creating a new state object if no changes are made
@@ -88,25 +88,25 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
         }
 
         if (!stateChanged) {
-            return initialState;
+            return currentState;
         }
 
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: nextState,
         };
     }
 
     case USER_MUTED: {
-        const allSessions = initialState[action.data.channelID];
+        const allSessions = currentState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return initialState;
+            return currentState;
         }
 
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -118,15 +118,15 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
     }
 
     case USER_UNMUTED: {
-        const allSessions = initialState[action.data.channelID];
+        const allSessions = currentState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return initialState;
+            return currentState;
         }
 
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -138,15 +138,15 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
     }
 
     case USER_HAND_RAISED: {
-        const allSessions = initialState[action.data.channelID];
+        const allSessions = currentState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return initialState;
+            return currentState;
         }
 
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -158,15 +158,15 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
     }
 
     case USER_HAND_LOWERED: {
-        const allSessions = initialState[action.data.channelID];
+        const allSessions = currentState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return initialState;
+            return currentState;
         }
 
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -178,15 +178,15 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
     }
 
     case USER_REACTED: {
-        const allSessions = initialState[action.data.channelID];
+        const allSessions = currentState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         if (!currentSession) {
-            return initialState;
+            return currentState;
         }
 
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -198,17 +198,17 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
     }
 
     case USER_REACTED_TIMEOUT: {
-        const allSessions = initialState[action.data.channelID];
+        const allSessions = currentState[action.data.channelID];
         const currentSession = allSessions?.[action.data.session_id];
 
         // Only clear if the timing-out reaction is still the one displayed — a newer
         // reaction within the window must not be cleared by an older reaction's timeout.
         if (!currentSession || currentSession.reaction?.timestamp !== action.data.reaction.timestamp) {
-            return initialState;
+            return currentState;
         }
 
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: {
                 ...allSessions,
                 [action.data.session_id]: {
@@ -220,27 +220,27 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
     }
 
     case USER_LEFT: {
-        if (!initialState[action.data.channelID]?.[action.data.session_id]) {
-            return initialState;
+        if (!currentState[action.data.channelID]?.[action.data.session_id]) {
+            return currentState;
         }
 
-        const nextChannelSessions = {...initialState[action.data.channelID]};
+        const nextChannelSessions = {...currentState[action.data.channelID]};
         delete nextChannelSessions[action.data.session_id];
 
         return {
-            ...initialState,
+            ...currentState,
             [action.data.channelID]: nextChannelSessions,
         };
     }
 
     case CALL_ENDED: {
-        const nextState = {...initialState};
+        const nextState = {...currentState};
         delete nextState[action.data.channelID];
 
         return nextState;
     }
 
     default:
-        return initialState;
+        return currentState;
     }
 };

--- a/webapp/src/websocket_handlers.ts
+++ b/webapp/src/websocket_handlers.ts
@@ -153,6 +153,12 @@ export function handleCallStart(store: Store, ev: WebSocketMessage<CallStartData
 // state mutating operations.
 export function handleUserLeft(store: Store, ev: WebSocketMessage<UserLeftData>) {
     const channelID = ev.data.channelID || ev.broadcast.channel_id;
+
+    // For the call we're connected to, the LiveKit room is the source of truth for session
+    // state; ignore the channel-wide broadcast to avoid racing the local participant feed.
+    if (channelIDForCurrentCall(store.getState()) === channelID) {
+        return;
+    }
     store.dispatch(leaveUser(channelID, ev.data.user_id, ev.data.session_id));
 }
 
@@ -162,6 +168,12 @@ export function handleUserJoined(store: Store, ev: WebSocketMessage<UserJoinedDa
     const userID = ev.data.user_id;
     const channelID = ev.data.channelID || ev.broadcast.channel_id;
     const sessionID = ev.data.session_id;
+
+    // For the call we're connected to, the LiveKit room is the source of truth for session
+    // state; ignore the channel-wide broadcast to avoid racing the local participant feed.
+    if (channelIDForCurrentCall(store.getState()) === channelID) {
+        return;
+    }
     store.dispatch(joinUser(channelID, userID, sessionID, false));
 }
 


### PR DESCRIPTION
## Summary

The participant list on a call's channel post stopped updating for users who hadn't joined the call — it only populated once the viewing user joined. On `main` (v1) the webapp registered channel-wide `user_joined`/`user_left` websocket handlers that kept observers' Redux state in sync. v2 (LiveKit) dropped those two registrations; the only remaining dispatcher of `joinUser`/`leaveUser` is the local LiveKit room, which exists only after you've joined. The server still broadcasts the events channel-wide and the handler functions still existed — they were just orphaned.

## Changes

- Re-register `custom_<pluginId>_user_joined` / `_user_left` handlers in `index.tsx`, reusing the existing `handleUserJoined`/`handleUserLeft`.
- Gate both handlers to skip the channel the viewer is currently connected to: for that channel the LiveKit room stays the source of truth, which avoids racing the local participant feed and the `USER_JOINED` reset of `unmuted/voice/video/raised_hand` to defaults. The gate is per-channel, so a call in a *different* channel still updates live.
- Rename the session reducer's misleading `initialState` parameter to `currentState` (it's the live current state Redux passes, not the initial state). Pure rename, no behavior change.

## Test

Verified locally with two sessions: an observer viewing the channel post without joining sees a second user appear when they join the call and disappear when they leave.

## Still open (separate follow-up)

The server writes the `participants` post prop only at call end (`plugin.go`), never during the call, so a fresh page load / permalink for a pure observer relies on `call_state` hydration. Not addressed here.

Jira: https://mattermost.atlassian.net/browse/MM-69189