### PR TITLE
[MM-69371] Pin Calls E2E to a fixed ESR server image (release-11.7)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,13 @@ env:
   COMPOSE_PROJECT_NAME: "${{ github.run_id }}_playwright_1"
   # Control testing parallelism
   PARALLELISM: 1
+  # Pinned Mattermost server release for E2E. We pin to a fixed ESR so that
+  # unrelated changes in mattermost `master` can't turn Calls E2E red — E2E
+  # should surface regressions in Calls, not transient breakage upstream.
+  # This single var drives BOTH the server image tag (IMAGE_SERVER) and the
+  # mattermost/mattermost checkout ref (used for config generation); the two
+  # must stay in sync. Bump deliberately when a new ESR is designated (~yearly).
+  MM_SERVER_IMAGE_TAG: release-11.7
 
 jobs:
   build-mattermost-plugin-calls:
@@ -75,7 +82,6 @@ jobs:
       CONTAINER_SERVER: playwright_tests_server
       CONTAINER_PROXY: playwright_tests_proxy
       CONTAINER_LIVEKIT: playwright_tests_livekit
-      IMAGE_SERVER: mattermostdevelopment/mattermost-enterprise-edition:master
       IMAGE_CURL: curlimages/curl:8.7.1
       # LiveKit credentials match e2e/docker/livekit.yaml.
       MM_CALLS_LIVE_KIT_URL: ws://livekit:7880
@@ -90,10 +96,19 @@ jobs:
       - name: e2e/checkout-mattermost-plugin-calls-repo
         uses: actions/checkout@v4
 
+      # Compose IMAGE_SERVER from the pinned tag here: the `env` context can't be
+      # referenced inside a job-level `env:` block, so we build it via $GITHUB_ENV.
+      - name: e2e/set-server-image
+        run: echo "IMAGE_SERVER=mattermostdevelopment/mattermost-enterprise-edition:${MM_SERVER_IMAGE_TAG}" >> "${GITHUB_ENV}"
+
       - name: e2e/checkout-mattermost-repo
         uses: actions/checkout@v4
         with:
           repository: mattermost/mattermost
+          # Must match IMAGE_SERVER's tag: this checkout only feeds config
+          # generation, so a mismatch would generate config against the wrong
+          # server version.
+          ref: ${{ env.MM_SERVER_IMAGE_TAG }}
           path: mattermost
 
       - name: e2e/setup-docker-buildx


### PR DESCRIPTION
## Summary

Pins the Calls E2E harness to a fixed Mattermost server release (the current ESR, `release-11.7`) instead of the floating `mattermostdevelopment/mattermost-enterprise-edition:master` image. E2E should surface regressions in **Calls**, not transient breakage in mattermost `master`.

## Problem

`.github/workflows/e2e.yml` pinned nothing:
- `IMAGE_SERVER` used `:master`
- the `mattermost/mattermost` checkout used default HEAD (master)

Because `:master` is rebuilt continuously, an unrelated server/webapp change could turn Calls E2E red with zero Calls changes. Concrete instance (2026-06-17/18): the `switching products > playbooks @livekit` test began failing on every v2 PR. MM-69080 (`afc8b837`) passed this exact test on 6/16, then failed on a 6/18 rerun of the identical commit — only the `:master` image changed in between. Root cause was a mattermost `master` webapp change that stopped the Playbooks entry rendering in the product switcher.

## Changes

- Add a single `MM_SERVER_IMAGE_TAG: release-11.7` workflow-level var as the source of truth.
- Compose `IMAGE_SERVER` from it via `$GITHUB_ENV` in a new `set-server-image` step (the `env` context can't be referenced inside a job-level `env:` block, but it can in a step).
- Pin the `mattermost/mattermost` checkout `ref` to the same var (it feeds config generation and must match the image).

## Notes

- `release-11.7` is the current ESR, comfortably ≥ v2's `min_server_version` (`10.0.0`), and only moves for vetted patch fixes. A manual bump when a new ESR is designated (~yearly) is acceptable; there is no floating `:esr` tag, so a self-updating tag is not possible.
- Playbooks still installs via the marketplace, now constrained to a 11.7-compatible build by the pinned server.
- The optional non-blocking `:master` early-warning leg was intentionally left out.