### PR TITLE
[MM-69374] Enable LiveKit transcription on v2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -564,6 +564,6 @@
   "props": {
     "min_offloader_version": "v0.9.0",
     "calls_recorder_version": "v0.8.13",
-    "calls_transcriber_version": "v0.7.2"
+    "calls_transcriber_version": "v1.0.0-dev0"
   }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -564,6 +564,6 @@
   "props": {
     "min_offloader_version": "v0.9.0",
     "calls_recorder_version": "v0.8.13",
-    "calls_transcriber_version": "v1.0.0-dev0"
+    "calls_transcriber_version": "v1.0.0-dev1"
   }
 }

--- a/server/recording_api.go
+++ b/server/recording_api.go
@@ -73,11 +73,6 @@ func (p *Plugin) recJobTimeoutChecker(callID, jobID string) {
 	}
 }
 
-// errTranscriptionNotSupported gates the transcription entry points while the
-// transcriber is being migrated to LiveKit. The orchestration logic below the
-// gate is kept intact so it can be re-enabled by deleting the guard.
-var errTranscriptionNotSupported = fmt.Errorf("transcription is not yet supported on this version")
-
 func (p *Plugin) startRecordingJob(state *callState, callID, userID string) (rst *JobStateClient, rcode int, rerr error) {
 	if state.Recording != nil && state.Recording.EndAt == 0 {
 		return nil, http.StatusForbidden, fmt.Errorf("recording already in progress")

--- a/server/transcription_api.go
+++ b/server/transcription_api.go
@@ -100,10 +100,6 @@ func (p *Plugin) transcriptionJobTimeoutChecker(callID, jobID string) {
 }
 
 func (p *Plugin) startTranscribingJob(state *callState, callID, userID, trID string) (rerr error) {
-	if true { // LiveKit migration gate; delete to restore transcription
-		return errTranscriptionNotSupported
-	}
-
 	if state.Transcription != nil && state.Transcription.EndAt == 0 {
 		return fmt.Errorf("transcription already in progress")
 	}
@@ -236,10 +232,6 @@ func (p *Plugin) startTranscribingJob(state *callState, callID, userID, trID str
 }
 
 func (p *Plugin) stopTranscribingJob(state *callState, callID string) (rerr error) {
-	if true { // LiveKit migration gate; delete to restore transcription
-		return errTranscriptionNotSupported
-	}
-
 	p.LogDebug("stopping transcribing job", "callID", callID)
 
 	if state.Transcription == nil || state.Transcription.EndAt != 0 {


### PR DESCRIPTION
## Summary

Enables transcription (and live captions) on Calls v2 / LiveKit. The transcriber itself was ported to LiveKit separately (calls-transcriber `v1.0.0-dev0`, commit `efc8629`); this is the coordinated plugin-side change that turns it on.

- Delete the two migration gates in `server/transcription_api.go` (`startTranscribingJob` and `stopTranscribingJob`), plus the now-unused `errTranscriptionNotSupported` var in `server/recording_api.go`.
- Bump `calls_transcriber_version` `v0.7.2` → `v1.0.0-dev0` in `plugin.json`. Required alongside the gate deletion: without it, v2 would launch the old RTCD transcriber against a LiveKit room and fail.

The `/livekit-token` endpoint, `composeLivekitIdentity`, and the caption/metric inbound WS handlers already exist on v2 (the recording bot work in MM-69144 also covered the transcriber bot), so no other plugin-side additions are needed.

## Testing

- `go build ./server/...`, `go vet ./server/`, and the `server` package tests pass.
- Verified end-to-end: transcription works against a live LiveKit call.

## Note

`v1.0.0-dev0` is the pre-release transcriber image. Swap to GA `v1.0.0` before final merge once the transcriber PR merges and the GA tag is cut.

Ref: https://mattermost.atlassian.net/browse/MM-69374