### PR TITLE
[MM-69368] SIP outbound dev & E2E test tooling (LiveKit SIP stack)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -580,6 +580,26 @@ livekit-tls-docker-start:
 livekit-tls-docker-stop:
 	LIVEKIT_NODE_IP=$$(ipconfig getifaddr en0) docker compose -f docker-compose.livekit.yaml down
 
+## Start LiveKit + Redis + SIP bridge (outbound SIP; dial an external provider). Set the LiveKit outbound trunk URI to the provider at runtime.
+.PHONY: livekit-sip-docker-start
+livekit-sip-docker-start:
+	LIVEKIT_NODE_IP=$$(ipconfig getifaddr en0) LIVEKIT_CONFIG=./livekit-sip.yaml \
+		docker compose -f docker-compose.livekit.yaml up livekit-dev redis livekit-sip
+
+## Start LiveKit + Redis + SIP bridge + bundled Asterisk auto-answer sink (outbound SIP loopback for manual media testing)
+.PHONY: livekit-sip-sink-docker-start
+livekit-sip-sink-docker-start:
+	LIVEKIT_NODE_IP=$$(ipconfig getifaddr en0) LIVEKIT_CONFIG=./livekit-sip.yaml \
+		docker compose -f docker-compose.livekit.yaml up livekit-dev redis livekit-sip asterisk
+
+## Stop the SIP stack (LiveKit + Redis + SIP bridge + Asterisk sink)
+.PHONY: livekit-sip-docker-stop
+livekit-sip-docker-stop:
+	# --profile flags are required: `down` won't remove containers belonging to
+	# profiles that aren't activated.
+	LIVEKIT_NODE_IP=$$(ipconfig getifaddr en0) \
+		docker compose --profile sip --profile sink -f docker-compose.livekit.yaml down
+
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
 	@cat Makefile build/*.mk | grep -v '\.PHONY' |  grep -v '\help:' | grep -B1 -E '^[a-zA-Z0-9_.-]+:.*' | sed -e "s/:.*//" | sed -e "s/^## //" |  grep -v '\-\-' | sed '1!G;h;$$!d' | awk 'NR%2{printf "\033[36m%-30s\033[0m",$$0;next;}1' | sort

--- a/docker-compose.livekit.yaml
+++ b/docker-compose.livekit.yaml
@@ -7,7 +7,10 @@ services:
       - "7881:7881"       # TURN/TCP fallback
       - "7882:7882/udp"   # WebRTC/UDP media
     volumes:
-      - ./livekit.yaml:/etc/livekit.yaml
+      # Default is the lean, no-redis config. The SIP make targets override
+      # LIVEKIT_CONFIG=./livekit-sip.yaml to add the `redis:` block (distributed
+      # mode) the SIP bridge requires.
+      - ${LIVEKIT_CONFIG:-./livekit.yaml}:/etc/livekit.yaml
     command: >
       --config /etc/livekit.yaml
       --node-ip=${LIVEKIT_NODE_IP}
@@ -31,3 +34,55 @@ services:
       - ${LIVEKIT_TLS_KEY:-/dev/null}:/etc/certs/key.pem:ro
     depends_on:
       - livekit-dev
+
+  # --- SIP outbound dialing infra (opt-in via the `sip` profile) ---------------
+  # Brought up by `make livekit-sip-docker-start`, which also points livekit-dev
+  # at livekit-sip.yaml (redis-enabled). These never start on the default
+  # `make livekit-docker-start` path.
+
+  # Dedicated Redis for the LiveKit <-> SIP PSRPC bus. Deliberately NOT
+  # Mattermost's Redis: avoids an availability dependency on MM's (optional)
+  # local Redis and a pub/sub cross-DB collision (Redis pub/sub isn't namespaced
+  # by db index).
+  redis:
+    image: redis:7-alpine
+    profiles: ["sip"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+
+  # LiveKit SIP bridge. Originates outbound INVITEs to the destination set at
+  # runtime via the LiveKit API (outbound trunk + dispatch rule) — either the
+  # bundled Asterisk sink (`sink` profile) or an external provider.
+  livekit-sip:
+    image: livekit/sip:v1.5.0
+    profiles: ["sip"]
+    restart: unless-stopped
+    volumes:
+      - ./sip.yaml:/etc/sip.yaml
+    command: --config /etc/sip.yaml
+    # To dial an EXTERNAL provider instead of the bundled sink, publish the SIP
+    # signaling + RTP ports to the host and flip use_external_ip in sip.yaml:
+    # ports:
+    #   - "5060:5060/udp"
+    #   - "10000-10100:10000-10100/udp"
+    depends_on:
+      redis:
+        condition: service_healthy
+      livekit-dev:
+        condition: service_started
+
+  # --- Auto-answer SIP sink (opt-in via the `sink` profile) --------------------
+  # Brought up by `make livekit-sip-sink-docker-start`. Anonymous auto-answering
+  # UAS that Answer()s, plays a greeting, then Echo()s the caller's RTP back to
+  # confirm bidirectional media. For human/manual validation only.
+  asterisk:
+    image: andrius/asterisk:20
+    profiles: ["sink"]
+    restart: unless-stopped
+    volumes:
+      - ./docker/asterisk/pjsip.conf:/etc/asterisk/pjsip.conf:ro
+      - ./docker/asterisk/extensions.conf:/etc/asterisk/extensions.conf:ro

--- a/docker/asterisk/extensions.conf
+++ b/docker/asterisk/extensions.conf
@@ -1,0 +1,17 @@
+; Asterisk dialplan for the auto-answer sink (`sink` profile).
+;
+; Answer any inbound number, play a short greeting, then Echo() — which bounces
+; the caller's RTP straight back so a human on the LiveKit side can confirm
+; BIDIRECTIONAL media (they hear themselves). Hang up when Echo() ends (caller
+; presses # or drops).
+
+[sink]
+; Match any dialed number (digits, '+', '*', '#') plus the 's' fallback for
+; calls that arrive without a target extension.
+exten => _[+*#0-9].,1,NoOp(SIP sink: inbound call to ${EXTEN} from ${CALLERID(all)})
+ same => n,Answer()
+ same => n,Playback(hello-world)
+ same => n,Echo()
+ same => n,Hangup()
+
+exten => s,1,Goto(sink,_[+*#0-9].,1)

--- a/docker/asterisk/pjsip.conf
+++ b/docker/asterisk/pjsip.conf
@@ -1,0 +1,19 @@
+; Asterisk PJSIP config for the auto-answer sink (`sink` profile).
+;
+; Accepts anonymous (unauthenticated) inbound calls over UDP and routes them
+; into the [sink] dialplan context. G.711 only (PCMU/PCMA) — what the LiveKit
+; SIP bridge negotiates by default, no transcoding.
+
+[transport-udp]
+type=transport
+protocol=udp
+bind=0.0.0.0:5060
+
+; PJSIP routes calls from unknown/unauthenticated peers through the special
+; "anonymous" endpoint. allow_anonymous traffic by defining it.
+[anonymous]
+type=endpoint
+context=sink
+disallow=all
+allow=ulaw
+allow=alaw

--- a/e2e/docker/docker-compose.yaml
+++ b/e2e/docker/docker-compose.yaml
@@ -40,10 +40,58 @@ services:
     volumes:
       - ./livekit.yaml:/etc/livekit.yaml
     command: --config /etc/livekit.yaml
+    depends_on:
+      - redis
     networks:
       default:
         aliases:
           - livekit
+          # The shared ../../sip.yaml dials LiveKit at ws://livekit-dev:7880
+          # (the dev compose's service name); this alias makes it resolve here too.
+          - livekit-dev
+
+  # --- SIP outbound test harness (MM-69368) -----------------------------------
+  # Dedicated Redis for the LiveKit <-> SIP PSRPC bus (see the design note in the
+  # root docker-compose.livekit.yaml for why it isn't shared with anything else).
+  redis:
+    image: redis:7-alpine
+    restart: on-failure
+    networks:
+      default:
+        aliases:
+          - redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+
+  # LiveKit SIP bridge. Shares the dev compose's config (../../sip.yaml) so the
+  # two paths can't drift; the smoke test drives it via the LiveKit SIP API.
+  livekit-sip:
+    image: livekit/sip:v1.5.0
+    restart: on-failure
+    volumes:
+      - ../../sip.yaml:/etc/sip.yaml
+    command: --config /etc/sip.yaml
+    depends_on:
+      redis:
+        condition: service_healthy
+      livekit:
+        condition: service_started
+    networks:
+      default:
+        aliases:
+          - livekit-sip
+
+  # Auto-answering SIPp UAS — the deterministic CI sink the bridge dials.
+  sipp:
+    build: ./sipp
+    restart: on-failure
+    networks:
+      default:
+        aliases:
+          - sipp
 
   start_dependencies:
     image: mattermost/mattermost-wait-for-dep:latest
@@ -51,6 +99,9 @@ services:
       - postgres
       - haproxy
       - livekit
+      - redis
+      - livekit-sip
+      - sipp
     command: postgres:5432
     networks:
       default:

--- a/e2e/docker/livekit.yaml
+++ b/e2e/docker/livekit.yaml
@@ -5,11 +5,19 @@ rtc:
   tcp_port: 7881
   udp_port: 7882
   use_ice_lite: true
+# Distributed mode: required for the SIP bridge, which reaches LiveKit only over
+# the Redis PSRPC bus. `redis` is the dedicated SIP Redis in docker-compose.yaml.
+redis:
+  address: redis:6379
 # LiveKit's `keys:` block is an api_key -> api_secret map (LiveKit signs/
-# verifies JWTs against this pair). Values must match MM_CALLS_LIVE_KIT_API_KEY
-# and MM_CALLS_LIVE_KIT_API_SECRET in .github/workflows/e2e.yml.
+# verifies JWTs against this pair).
 keys:
   # api_key: api_secret
+  # Used by the plugin; must match MM_CALLS_LIVE_KIT_API_KEY / _SECRET in
+  # .github/workflows/e2e.yml.
   devkey_for_livekit_e2e_ci_tests: secret_for_livekit_server_ci_e2e_tests
+  # Used by the SIP bridge (the shared ../../sip.yaml). A second pair on the same
+  # server lets the bridge config stay byte-identical to the dev compose's.
+  devkey: this-is-a-32-plus-character-dev-secret
 logging:
   level: info

--- a/e2e/docker/sipp/Dockerfile
+++ b/e2e/docker/sipp/Dockerfile
@@ -1,0 +1,30 @@
+# SIPp UAS sink for the LiveKit SIP E2E harness.
+#
+# Built from Debian's sip-tester package rather than a public SIPp image: those
+# only ship a floating `latest` tag (and some wrap an opaque entrypoint), which
+# breaks the repo's pin-everything norm. The Debian release pins the version.
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends sip-tester \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY uas.xml /etc/sipp/uas.xml
+
+# `-i` needs the container's own IP (it goes into the Contact + SDP that LiveKit
+# dials media back to), so compute it at runtime. No `-m` limit: run as a
+# long-lived server answering calls across test retries. `-bg` is omitted so
+# SIPp stays the foreground process and the container lives as long as it does.
+# `-trace_msg` logs every SIP message as it arrives (e.g. the inbound INVITE) to
+# a file in the workdir; `-trace_err` records protocol errors. (`-screen_file`
+# is deliberately not used: SIPp only writes the stats screen on quit, so it
+# yields nothing for a server that never exits.)
+#
+# `-default_behaviors all,-abortunexp`: LiveKit sends a post-answer re-INVITE
+# (media renegotiation) the smoke scenario doesn't model. Default SIPp would
+# abort the call on that "unexpected" message; we keep every other default
+# (auto-BYE, ping reply) but stop aborting, so the trailing re-INVITE/ACK is
+# logged and ignored instead of flagged as a failure.
+WORKDIR /var/log/sipp
+ENTRYPOINT ["/bin/sh", "-c"]
+CMD ["exec sipp -i \"$(hostname -i)\" -p 5060 -sf /etc/sipp/uas.xml -nostdin -trace_err -trace_msg -default_behaviors all,-abortunexp"]

--- a/e2e/docker/sipp/uas.xml
+++ b/e2e/docker/sipp/uas.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Auto-answering UAS sink for the LiveKit SIP harness (CI).
+     Answers any inbound INVITE with 180 then 200 OK (G.711 SDP), accepts the
+     ACK, and waits for the BYE that LiveKit sends when the room is torn down.
+     SIPp runs this in server mode (no call limit) so it keeps answering across
+     test retries. Exit code stays 0 while the scenario completes cleanly.
+
+     This is the shared template for MM-69369's SIP-layer coverage: <recv>
+     elements can grow `regexp`-matched asserts on INVITE headers/SDP to turn a
+     received message into a hard pass/fail. -->
+<scenario name="LiveKit SIP smoke sink (UAS)">
+  <recv request="INVITE" crlf="true"/>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=sink 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[local_ip_type] [local_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0 8
+      a=rtpmap:0 PCMU/8000
+      a=rtpmap:8 PCMA/8000
+
+    ]]>
+  </send>
+
+  <recv request="ACK" rtd="true" crlf="true"/>
+
+  <recv request="BYE"/>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="2000"/>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+</scenario>

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@babel/core": "7.29.0",
         "@babel/eslint-parser": "7.28.6",
+        "@livekit/protocol": "1.47.0",
         "@mattermost/types": "11.4.0",
         "@playwright/test": "1.59.1",
         "@types/node": "^24.12.0",
@@ -20,6 +21,7 @@
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-unused-imports": "^3.2.0",
+        "livekit-server-sdk": "2.15.5",
         "typescript": "^5.6.3"
       },
       "engines": {
@@ -268,6 +270,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -522,6 +531,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.47.0.tgz",
+      "integrity": "sha512-oJW1OpVAQ+/QZlSnvwwAtkP0fJ6OerlL68k7DFxXScMqaKnkMncwffPOLHjLmem7xNpPUiD0tJ2KSDdsIrNcpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@mattermost/types": {
@@ -1278,6 +1297,51 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-9.1.3.tgz",
+      "integrity": "sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^8.0.0",
+        "map-obj": "5.0.0",
+        "quick-lru": "^6.1.1",
+        "type-fest": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3161,6 +3225,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
@@ -3296,6 +3370,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/livekit-server-sdk": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/livekit-server-sdk/-/livekit-server-sdk-2.15.5.tgz",
+      "integrity": "sha512-Uzs4tVebvY4/+pO9pG1nMMVRDZPnOJolZIOWIiSEnUXFBywq+eNWHrR8mplKL8Qn13mSTQLjKVXfGCGTAMQeYg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.1",
+        "@livekit/protocol": "^1.46.6",
+        "camelcase-keys": "^9.0.0",
+        "jose": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3345,6 +3435,19 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.0.tgz",
+      "integrity": "sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3785,6 +3888,19 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@babel/core": "7.29.0",
     "@babel/eslint-parser": "7.28.6",
+    "@livekit/protocol": "1.47.0",
     "@mattermost/types": "11.4.0",
     "@playwright/test": "1.59.1",
     "@types/node": "^24.12.0",
@@ -25,6 +26,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-unused-imports": "^3.2.0",
+    "livekit-server-sdk": "2.15.5",
     "typescript": "^5.6.3"
   }
 }

--- a/e2e/scripts/prepare-server.sh
+++ b/e2e/scripts/prepare-server.sh
@@ -20,7 +20,12 @@ docker rmi -f ${IMAGE_SERVER}
 
 docker network create ${DOCKER_NETWORK}
 
-# Start server dependencies (postgres, haproxy, livekit).
+# Build the SIPp sink image up front (the other services use prebuilt images).
+echo "Building SIP test sink image ... "
+docker compose -f ${DOCKER_COMPOSE_FILE} build sipp
+
+# Start server dependencies (postgres, haproxy, livekit, + the SIP harness:
+# redis, livekit-sip, sipp).
 echo "Starting server dependencies ... "
 DOCKER_NETWORK=${DOCKER_NETWORK} CONTAINER_PROXY=${CONTAINER_PROXY} docker compose -f ${DOCKER_COMPOSE_FILE} run -d --rm start_dependencies
 timeout --foreground 90s bash -c "until docker compose -f ${DOCKER_COMPOSE_FILE} exec -T postgres pg_isready ; do sleep 5 ; done"

--- a/e2e/scripts/run.sh
+++ b/e2e/scripts/run.sh
@@ -11,6 +11,11 @@ function print_logs {
 		docker logs ${CONTAINER_PROXY}
 		docker logs ${CONTAINER_LIVEKIT}
 
+		# SIP harness (compose-generated names) — best effort, for @sip-smoke triage.
+		docker logs "$(docker ps -aqf name=livekit-sip)" 2>/dev/null || true
+		# SIPp logs SIP messages to files, not stdout — dump them from the container.
+		docker exec "$(docker ps -aqf name=sipp)" sh -c 'cat /var/log/sipp/*_messages.log /var/log/sipp/*_errors.log 2>/dev/null' || true
+
 		# Log all containers
 		docker ps -a
 	fi
@@ -80,11 +85,18 @@ echo "Spawning playwright image ..."
 # test.skip'd as each PR in the MM-68570 series lands; only the smoke test
 # actually executes today. Constrained to chromium because that's the browser
 # both the smoke test and the early MM-68570 specs were authored against.
+# LiveKit SIP API endpoint + the SIP-bridge credentials (the `devkey` pair shared
+# with sip.yaml) + the SIPp sink address, consumed by the @sip-smoke test. The
+# SDK needs an http(s) URL, so this is not MM_CALLS_LIVE_KIT_URL (ws://).
 docker run -d --name playwright-e2e \
 	--network=container:${CONTAINER_PROXY} \
 	--entrypoint "" \
+	-e LIVEKIT_HOST="http://livekit:7880" \
+	-e LIVEKIT_API_KEY="devkey" \
+	-e LIVEKIT_API_SECRET="this-is-a-32-plus-character-dev-secret" \
+	-e SIP_SINK_ADDRESS="sipp:5060" \
 	mm-playwright \
-	bash -c "npm ci && npx playwright install && npx playwright test --project=chromium --grep '@livekit-smoke|@livekit' --shard=${CI_NODE_INDEX}/${CI_NODE_TOTAL}"
+	bash -c "npm ci && npx playwright install && npx playwright test --project=chromium --grep '@livekit-smoke|@livekit|@sip-smoke' --shard=${CI_NODE_INDEX}/${CI_NODE_TOTAL}"
 
 docker logs -f playwright-e2e
 

--- a/e2e/tests/sip_smoke.spec.ts
+++ b/e2e/tests/sip_smoke.spec.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint-disable no-process-env */
+
+import {SIPTransport} from '@livekit/protocol';
+import {expect, test} from '@playwright/test';
+import {RoomServiceClient, SipClient} from 'livekit-server-sdk';
+
+// LiveKit API endpoint + credentials, supplied to the playwright container by
+// e2e/scripts/run.sh. The `devkey` pair is the one shared with the SIP bridge
+// config (e2e/docker/livekit.yaml + ../../sip.yaml).
+const livekitHost = process.env.LIVEKIT_HOST || 'http://livekit:7880';
+const livekitApiKey = process.env.LIVEKIT_API_KEY || 'devkey';
+const livekitApiSecret = process.env.LIVEKIT_API_SECRET || 'this-is-a-32-plus-character-dev-secret';
+
+// Address of the SIPp UAS sink the bridge dials (host:port on the e2e network).
+const sipSinkAddress = process.env.SIP_SINK_ADDRESS || 'sipp:5060';
+
+// This proves the SIP *harness* end to end — LiveKit SIP service is reachable
+// over Redis, an outbound trunk + CreateSIPParticipant makes it send an INVITE,
+// and the SIPp sink answers it — independent of the SIP outbound feature
+// (MM-68360), which the plugin doesn't ship yet. Comprehensive SIP coverage
+// that builds on this harness is tracked in MM-69369.
+test.describe('SIP harness smoke', {tag: '@sip-smoke'}, () => {
+    test('outbound INVITE reaches the SIPp sink', async () => {
+        const sip = new SipClient(livekitHost, livekitApiKey, livekitApiSecret);
+        const rooms = new RoomServiceClient(livekitHost, livekitApiKey, livekitApiSecret);
+
+        // Unique suffix so concurrent shards / retries don't collide.
+        const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+        const roomName = `sip-smoke-${suffix}`;
+
+        let trunkId = '';
+        try {
+            const trunk = await sip.createSipOutboundTrunk(
+                `sip-smoke-sink-${suffix}`,
+                sipSinkAddress,
+                ['+10000000000'],
+                {transport: SIPTransport.SIP_TRANSPORT_UDP},
+            );
+            trunkId = trunk.sipTrunkId;
+            expect(trunkId).toBeTruthy();
+
+            // waitUntilAnswered makes this resolve only after the bridge sends the
+            // INVITE and the SIPp sink replies 200 OK — so a successful return is
+            // the proof. A dead bridge, a misrouted INVITE, or a silent sink all
+            // surface here as a thrown error / timeout.
+            const participant = await sip.createSipParticipant(
+                trunkId,
+                '+15551234567',
+                roomName,
+                {
+                    participantIdentity: `sip-sink-${suffix}`,
+                    participantName: 'SIP smoke sink',
+                    waitUntilAnswered: true,
+                    timeout: 60,
+                },
+            );
+
+            expect(participant.sipCallId).toBeTruthy();
+            expect(participant.participantId).toBeTruthy();
+            expect(participant.roomName).toBe(roomName);
+        } finally {
+            // Tear the room down (LiveKit sends BYE to the sink) and remove the
+            // trunk, regardless of assertion outcome.
+            await rooms.deleteRoom(roomName).catch(() => { /* room may not exist on early failure */ });
+            if (trunkId) {
+                await sip.deleteSipTrunk(trunkId).catch(() => { /* best-effort cleanup */ });
+            }
+        }
+    });
+});

--- a/livekit-sip.yaml
+++ b/livekit-sip.yaml
@@ -1,0 +1,20 @@
+# LiveKit config for the SIP dev path (`make livekit-sip-docker-start`).
+#
+# Identical to livekit.yaml EXCEPT for the `redis:` block. The LiveKit SIP
+# service talks to LiveKit only over Redis (PSRPC bus), and a `redis:` block
+# flips LiveKit into distributed mode — it refuses to boot if Redis is
+# unreachable. That's why this can't be a conditional block in livekit.yaml
+# and lives in its own file instead.
+port: 7880
+bind_addresses:
+  - "0.0.0.0"
+rtc:
+  tcp_port: 7881
+  udp_port: 7882
+  use_ice_lite: true
+redis:
+  address: redis:6379
+keys:
+  devkey: this-is-a-32-plus-character-dev-secret
+logging:
+  level: info

--- a/sip.yaml
+++ b/sip.yaml
@@ -1,0 +1,21 @@
+# LiveKit SIP bridge config. Shared between the dev compose
+# (docker-compose.livekit.yaml, `sip` profile) and the E2E stack
+# (e2e/docker/) so the two paths can't drift.
+#
+# api_key/api_secret MUST match a pair in the LiveKit server `keys:` block
+# (livekit-sip.yaml); the bridge signs its own JWTs to call the LiveKit API.
+api_key: devkey
+api_secret: this-is-a-32-plus-character-dev-secret
+ws_url: ws://livekit-dev:7880
+redis:
+  address: redis:6379
+sip_port: 5060
+rtp_port: 10000-10100
+# false advertises the bridge's own container IP in SDP, which the bundled
+# Asterisk sink reaches directly over the compose network (the default
+# `sink`-loopback path). To dial an EXTERNAL provider, set this true (advertise
+# the host's STUN-discovered public IP) and publish the SIP/RTP ports on the
+# livekit-sip service in docker-compose.livekit.yaml.
+use_external_ip: false
+logging:
+  level: info


### PR DESCRIPTION
## Summary

Tooling to develop and test SIP/VOIP outbound calling (Milestone 2, MM-68360) both locally and in CI. Outbound SIP requires the LiveKit SIP bridge — which needs Redis (it talks to LiveKit only over the PSRPC bus, flipping LiveKit into distributed mode) — plus a SIP endpoint to receive the outbound INVITE.

This is the **tooling/machinery** ticket. Comprehensive SIP E2E **coverage** is tracked separately under the umbrella **MM-69369**, which runs on the harness built here.

## Local dev — additive compose profiles in `docker-compose.livekit.yaml`

- _(no profile)_ — **LiveKit only**, unchanged daily WebRTC driver.
- `sip` — **+ dedicated Redis + LiveKit SIP bridge** (dial an external provider).
- `sink` — **+ Asterisk** auto-answer endpoint (`Answer → Playback → Echo → Hangup`) for manual bidirectional-media validation.

Because the `redis:` block can't be conditional (LiveKit won't boot if it's set but Redis is down), the SIP path runs from a separate `livekit-sip.yaml`; the default `livekit.yaml` stays lean. Three make targets mirror the layers:

- `make livekit-docker-start` (unchanged)
- `make livekit-sip-docker-start` (`sip`)
- `make livekit-sip-sink-docker-start` (`sip,sink`)

The dedicated Redis is deliberately not Mattermost's (avoids an availability dependency + a pub/sub cross-DB collision). The outbound destination (bundled Asterisk vs external provider) is a runtime LiveKit API concern, so the sink stays cleanly opt-in.

## CI — SIPp harness in the E2E stack (`e2e/docker/`)

Adds the same Redis + SIP bridge plus a **SIPp** auto-answer UAS (built from Debian `sip-tester`; public images only ship a floating `latest`). A single `@sip-smoke` test drives an outbound INVITE through the bridge to the SIPp sink **via the LiveKit SIP API** (`createSipOutboundTrunk` → `createSipParticipant` with `waitUntilAnswered`) — proving the harness end to end, independent of the not-yet-shipped SIP feature. The SIP-bridge config (`sip.yaml`) is shared with the dev compose to avoid drift; the e2e LiveKit just gains the Redis block, a second `devkey` keypair, and a `livekit-dev` network alias so the shared config resolves unchanged.

## Testing

Verified locally end to end: booted Redis + LiveKit + SIP bridge + SIPp, drove a real outbound INVITE, and confirmed the call is answered (`sipCallId` returned) with the INVITE captured in SIPp's message trace. `tsc` and eslint pass on the new test.

## Out of scope

- The SIP outbound **feature** (dialing, trunk/dispatch wiring, UI) — MM-68360.
- Comprehensive SIP E2E coverage — MM-69369.