### PR TITLE
[MM-69251] Port outbound SIP dialing (server) from livekit-poc to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.34.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.34.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.34.0
+	github.com/twitchtv/twirp v8.1.3+incompatible
 	golang.org/x/time v0.14.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -154,7 +155,6 @@ require (
 	github.com/tinylib/msgp v1.2.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect
-	github.com/twitchtv/twirp v8.1.3+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/wiggin77/merror v1.0.5 // indirect

--- a/plugin.json
+++ b/plugin.json
@@ -119,6 +119,22 @@
             "help_text": "The API secret used to authenticate with the LiveKit server.",
             "default": "",
             "hosting": "on-prem"
+          },
+          {
+            "key": "EnableSIPOutbound",
+            "display_name": "Enable outbound phone dialing",
+            "type": "bool",
+            "default": false,
+            "help_text": "When set to true, users can dial external phone numbers via LiveKit SIP. Requires a configured SIP Outbound Trunk ID.",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "LiveKitSIPOutboundTrunkID",
+            "display_name": "SIP Outbound Trunk ID",
+            "type": "text",
+            "default": "",
+            "help_text": "LiveKit outbound SIP trunk ID (e.g., ST_xxx). The trunk is created in LiveKit (via CLI or Cloud dashboard) with the SIP provider address and credentials. Leave empty to disable outbound dialing.",
+            "hosting": "on-prem"
           }
         ]
       },
@@ -344,6 +360,22 @@
         "type": "text",
         "help_text": "The API secret used to authenticate with the LiveKit server.",
         "default": "",
+        "hosting": "on-prem"
+      },
+      {
+        "key": "EnableSIPOutbound",
+        "display_name": "Enable outbound phone dialing",
+        "type": "bool",
+        "default": false,
+        "help_text": "When set to true, users can dial external phone numbers via LiveKit SIP. Requires a configured SIP Outbound Trunk ID.",
+        "hosting": "on-prem"
+      },
+      {
+        "key": "LiveKitSIPOutboundTrunkID",
+        "display_name": "SIP Outbound Trunk ID",
+        "type": "text",
+        "default": "",
+        "help_text": "LiveKit outbound SIP trunk ID (e.g., ST_xxx). The trunk is created in LiveKit (via CLI or Cloud dashboard) with the SIP provider address and credentials. Leave empty to disable outbound dialing.",
         "hosting": "on-prem"
       },
       {

--- a/server/api.go
+++ b/server/api.go
@@ -623,7 +623,9 @@ func (p *Plugin) handlePhoneCall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The call is hosted on the user<->bot DM channel (the phone-call container).
+	// The call is hosted on the user<->bot DM channel. The client creates/joins
+	// the call on this channel before calling /phone-call, so the SIP leg dials
+	// into the existing call's room and the join webhook finds an active call.
 	dmChannel, appErr := p.API.GetDirectChannel(userID, botID)
 	if appErr != nil {
 		res.Err = fmt.Errorf("failed to get bot DM channel: %w", appErr).Error()

--- a/server/api.go
+++ b/server/api.go
@@ -576,6 +576,77 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handlePhoneCall dials an external phone number via LiveKit SIP and joins the
+// remote party to a call hosted on the requesting user's DM channel with the
+// Calls bot. LiveKit auto-creates the room on demand, so we dial in a goroutine
+// without waiting for the user's own join flow to create the room first.
+func (p *Plugin) handlePhoneCall(w http.ResponseWriter, r *http.Request) {
+	var res httpResponse
+	defer p.httpAudit("handlePhoneCall", &res, w, r)
+
+	userID := r.Header.Get("Mattermost-User-Id")
+
+	var req struct {
+		Number string `json:"number"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, requestBodyMaxSizeBytes)).Decode(&req); err != nil {
+		res.Err = "invalid request body"
+		res.Code = http.StatusBadRequest
+		return
+	}
+
+	number := normalizePhoneNumber(req.Number)
+	if number == "" {
+		res.Err = "number is required"
+		res.Code = http.StatusBadRequest
+		return
+	}
+
+	cfg := p.getConfiguration()
+	if cfg.EnableSIPOutbound == nil || !*cfg.EnableSIPOutbound {
+		res.Err = "outbound dialing is disabled. Enable it in the admin console."
+		res.Code = http.StatusBadRequest
+		return
+	}
+
+	trunkID := cfg.LiveKitSIPOutboundTrunkID
+	if trunkID == "" {
+		res.Err = "outbound dialing is not configured. Set the SIP Outbound Trunk ID in the admin console."
+		res.Code = http.StatusBadRequest
+		return
+	}
+
+	botID := p.getBotID()
+	if botID == "" {
+		res.Err = "bot not initialized"
+		res.Code = http.StatusInternalServerError
+		return
+	}
+
+	// The call is hosted on the user<->bot DM channel (the phone-call container).
+	dmChannel, appErr := p.API.GetDirectChannel(userID, botID)
+	if appErr != nil {
+		res.Err = fmt.Errorf("failed to get bot DM channel: %w", appErr).Error()
+		res.Code = http.StatusInternalServerError
+		return
+	}
+	channelID := dmChannel.Id
+
+	go func() {
+		if err := p.createSIPParticipant(trunkID, number, channelID, req.Number); err != nil {
+			p.LogError("handlePhoneCall: failed to create SIP participant",
+				"err", err.Error(), "number", number, "channelID", channelID)
+		}
+	}()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]string{
+		"channel_id": channelID,
+	}); err != nil {
+		p.LogError("failed to encode phone-call response", "err", err.Error())
+	}
+}
+
 // handleConfig returns the client configuration, and cloud license information
 // that isn't exposed to clients yet on the webapp
 func (p *Plugin) handleConfig(w http.ResponseWriter, r *http.Request) error {
@@ -658,6 +729,61 @@ func (p *Plugin) handleGetStats(w http.ResponseWriter) error {
 	}
 
 	return nil
+}
+
+// normalizePhoneNumber strips formatting from a phone number, keeping only
+// digits and a leading '+'. A number with no '+' prefix and >= 10 digits is
+// assumed to be E.164 and gets a '+' prepended. Examples:
+//
+//	"1-781-307-8753"    -> "+17813078753"
+//	"+1 (555) 123-4567" -> "+15551234567"
+//	"tel:+17813078753"  -> "+17813078753"
+func normalizePhoneNumber(raw string) string {
+	s := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(raw), "tel:"))
+
+	var b strings.Builder
+	for i, c := range s {
+		if (c == '+' && i == 0) || (c >= '0' && c <= '9') {
+			b.WriteRune(c)
+		}
+	}
+
+	num := b.String()
+	if len(num) >= 10 && num[0] != '+' {
+		num = "+" + num
+	}
+	return num
+}
+
+// isPhoneCallChannel reports whether the channel is a DM with the Calls bot,
+// i.e. an outbound phone-call container rather than a regular channel (where a
+// SIP participant would be an inbound dial-in guest).
+func (p *Plugin) isPhoneCallChannel(channelID string) bool {
+	botID := p.getBotID()
+	if botID == "" {
+		return false
+	}
+
+	channel, appErr := p.API.GetChannel(channelID)
+	if appErr != nil {
+		p.LogError("isPhoneCallChannel: failed to get channel", "channelID", channelID, "err", appErr.Error())
+		return false
+	}
+	if channel.Type != model.ChannelTypeDirect {
+		return false
+	}
+
+	members, appErr := p.API.GetChannelMembers(channelID, 0, 10)
+	if appErr != nil {
+		p.LogError("isPhoneCallChannel: failed to get channel members", "channelID", channelID, "err", appErr.Error())
+		return false
+	}
+	for _, m := range members {
+		if m.UserId == botID {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Plugin) handleLiveKitWebhook(w http.ResponseWriter, r *http.Request) {
@@ -826,6 +952,31 @@ func (p *Plugin) handleLiveKitSIPParticipantLeft(event *livekit.WebhookEvent) {
 		return
 	}
 	delete(state.sessions, sid)
+
+	// Outbound phone calls live in the user<->bot DM channel. When the last SIP
+	// participant hangs up, end the call so the remaining MM user is dropped too.
+	if !sipParticipantsRemain(state.sessions) && p.isPhoneCallChannel(channelID) {
+		p.LogInfo("handleLiveKitSIPParticipantLeft: last SIP participant left phone call, ending call",
+			"channelID", channelID, "callID", state.Call.ID)
+
+		// Tear down the media room so the MM user's client disconnects, mirroring
+		// the host-end path; clients also get wsEventCallEnd as a fallback.
+		if err := p.livekitDeleteRoom(channelID); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
+			p.LogError("handleLiveKitSIPParticipantLeft: failed to delete LiveKit room",
+				"channelID", channelID, "err", err.Error())
+		}
+
+		p.publishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &WebSocketBroadcast{
+			ChannelID:           channelID,
+			ReliableClusterSend: true,
+		})
+
+		if err := p.cleanCallState(&state.Call, "sip_hangup"); err != nil {
+			p.LogError("handleLiveKitSIPParticipantLeft: failed to clean call state",
+				"channelID", channelID, "err", err.Error())
+		}
+		return
+	}
 
 	if state.Call.GetHostID() == identity && len(state.sessions) > 0 {
 		if newHostID := state.getHostID(p.getBotID()); newHostID != identity {

--- a/server/api_livekit_test.go
+++ b/server/api_livekit_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -421,5 +422,88 @@ func TestHandleGetLiveKitToken(t *testing.T) {
 
 		resp := w.Result()
 		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func TestHandlePhoneCall(t *testing.T) {
+	setupPlugin := func(t *testing.T) (*Plugin, *pluginMocks.MockAPI) {
+		t.Helper()
+		mockAPI := &pluginMocks.MockAPI{}
+		mockMetrics := &serverMocks.MockMetrics{}
+
+		p := &Plugin{
+			MattermostPlugin:  plugin.MattermostPlugin{API: mockAPI},
+			metrics:           mockMetrics,
+			apiLimiters:       map[string]*rate.Limiter{},
+			callsClusterLocks: map[string]*cluster.Mutex{},
+			sessions:          map[string]*session{},
+		}
+		p.licenseChecker = enterprise.NewLicenseChecker(p.API)
+
+		mockMetrics.On("Handler").Return(nil)
+		mockMetrics.On("ObserveAppHandlersTime", mock.AnythingOfType("string"), mock.AnythingOfType("float64")).Maybe()
+		mockAPI.On("GetConfig").Return(&model.Config{}, nil)
+		mockAPI.On("LogDebug", "handlePhoneCall",
+			"origin", mock.AnythingOfType("string"), mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+		return p, mockAPI
+	}
+
+	doRequest := func(t *testing.T, p *Plugin, number string) *http.Response {
+		t.Helper()
+		apiRouter := p.newAPIRouter()
+		body, err := json.Marshal(map[string]string{"number": number})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/phone-call", bytes.NewReader(body))
+		r.Header.Set("Mattermost-User-Id", model.NewId())
+		apiRouter.ServeHTTP(w, r)
+		return w.Result()
+	}
+
+	t.Run("number required", func(t *testing.T) {
+		p, _ := setupPlugin(t)
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		cfg.EnableSIPOutbound = model.NewPointer(true)
+		cfg.LiveKitSIPOutboundTrunkID = "ST_test"
+		p.configuration = cfg
+
+		resp := doRequest(t, p, "")
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var res httpResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		require.Equal(t, "number is required", res.Msg)
+	})
+
+	t.Run("disabled toggle rejects even with trunk configured", func(t *testing.T) {
+		p, _ := setupPlugin(t)
+		cfg := &configuration{}
+		cfg.SetDefaults() // EnableSIPOutbound defaults to false
+		cfg.LiveKitSIPOutboundTrunkID = "ST_test"
+		p.configuration = cfg
+
+		resp := doRequest(t, p, "+14155551234")
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var res httpResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		require.Equal(t, "outbound dialing is disabled. Enable it in the admin console.", res.Msg)
+	})
+
+	t.Run("enabled but no trunk configured", func(t *testing.T) {
+		p, _ := setupPlugin(t)
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		cfg.EnableSIPOutbound = model.NewPointer(true) // trunk left empty
+		p.configuration = cfg
+
+		resp := doRequest(t, p, "+14155551234")
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var res httpResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		require.Equal(t, "outbound dialing is not configured. Set the SIP Outbound Trunk ID in the admin console.", res.Msg)
 	})
 }

--- a/server/api_livekit_webhook_test.go
+++ b/server/api_livekit_webhook_test.go
@@ -405,6 +405,102 @@ func TestHandleLiveKitSIPParticipant(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 	})
+
+	t.Run("last SIP participant left in bot DM ends the phone call", func(t *testing.T) {
+		p, mockAPI, mockMetrics := setupPlugin(t)
+		defer ResetTestStore(t, p.store)
+
+		botID := model.NewId()
+		p.botSession = &model.Session{UserId: botID}
+
+		channelID := model.NewId()
+		postID := model.NewId()
+		call := createActiveCall(t, p, channelID, postID)
+
+		// A human session remains; only the SIP participant is leaving.
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID: model.NewId(), CallID: call.ID, UserID: model.NewId(), JoinAt: time.Now().UnixMilli(),
+		}))
+		sipSid := model.NewId()
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID: sipSid, CallID: call.ID, UserID: "+14155551234", JoinAt: time.Now().UnixMilli(), IsSIPParticipant: true,
+		}))
+
+		setupLock(mockAPI, mockMetrics, channelID)
+		mockAPI.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeDirect}, nil)
+		mockAPI.On("GetChannelMembers", channelID, 0, 10).Return(model.ChannelMembers{{ChannelId: channelID, UserId: botID}}, nil)
+		mockAPI.On("UpdatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{Id: postID}, nil)
+		mockAPI.On("GetConfig").Return(&model.Config{}, nil)
+
+		event := &livekit.WebhookEvent{
+			Event: "participant_left",
+			Room:  &livekit.Room{Name: channelID},
+			Participant: &livekit.ParticipantInfo{
+				Sid:      sipSid,
+				Identity: "+14155551234",
+				Kind:     livekit.ParticipantInfo_SIP,
+			},
+		}
+
+		apiRouter := p.newAPIRouter()
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+		// The call is ended even though a human session remained.
+		ended, err := p.store.GetCall(call.ID, db.GetCallOpts{})
+		require.NoError(t, err)
+		require.Greater(t, ended.EndAt, int64(0))
+
+		mockAPI.AssertCalled(t, "PublishWebSocketEvent", wsEventCallEnd, mock.Anything, mock.Anything)
+	})
+
+	t.Run("non-bot-DM channel does not end the call on SIP left", func(t *testing.T) {
+		p, mockAPI, mockMetrics := setupPlugin(t)
+		defer ResetTestStore(t, p.store)
+
+		botID := model.NewId()
+		p.botSession = &model.Session{UserId: botID}
+
+		channelID := model.NewId()
+		postID := model.NewId()
+		call := createActiveCall(t, p, channelID, postID)
+
+		sipSid := model.NewId()
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID: sipSid, CallID: call.ID, UserID: "+14155551234", JoinAt: time.Now().UnixMilli(), IsSIPParticipant: true,
+		}))
+
+		setupLock(mockAPI, mockMetrics, channelID)
+		// Regular channel (inbound SIP dial-in), not a phone-call container.
+		mockAPI.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeOpen}, nil)
+
+		event := &livekit.WebhookEvent{
+			Event: "participant_left",
+			Room:  &livekit.Room{Name: channelID},
+			Participant: &livekit.ParticipantInfo{
+				Sid:      sipSid,
+				Identity: "+14155551234",
+				Kind:     livekit.ParticipantInfo_SIP,
+			},
+		}
+
+		apiRouter := p.newAPIRouter()
+		r := newSignedWebhookRequest(t, testAPIKey, testAPISecret, event)
+		w := httptest.NewRecorder()
+		apiRouter.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+		// The call is still active; only user_left was published.
+		active, err := p.store.GetCall(call.ID, db.GetCallOpts{})
+		require.NoError(t, err)
+		require.Equal(t, int64(0), active.EndAt)
+
+		mockAPI.AssertCalled(t, "PublishWebSocketEvent", wsEventUserLeft, mock.Anything, mock.Anything)
+	})
 }
 
 func TestGetHostIDSIPDeprioritization(t *testing.T) {

--- a/server/api_router.go
+++ b/server/api_router.go
@@ -160,6 +160,9 @@ func (p *Plugin) newAPIRouter() *mux.Router {
 	// LiveKit
 	router.HandleFunc("/livekit-token", p.handleGetLiveKitToken).Methods("GET")
 
+	// Outbound phone call
+	router.HandleFunc("/phone-call", p.handlePhoneCall).Methods("POST")
+
 	// Cloud
 	router.HandleFunc("/cloud-notify-admins", func(w http.ResponseWriter, r *http.Request) {
 		// End user has requested to notify their admin about upgrading for calls

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -56,6 +56,8 @@ type configuration struct {
 	LiveKitAPIKey string
 	// The API secret used to authenticate with the LiveKit server.
 	LiveKitAPISecret string
+	// SIP outbound trunk ID for outbound phone calls (e.g., ST_xxx). Empty disables outbound dialing.
+	LiveKitSIPOutboundTrunkID string
 	// When set to true live captions will be enabled when starting transcription jobs.
 	EnableLiveCaptions *bool
 	// The speech-to-text model size to use to transcribe live captions.
@@ -97,6 +99,9 @@ type ClientConfig struct {
 	EnableSimulcast *bool
 	// When set to true it enables ringing for DM/GM channels.
 	EnableRinging *bool
+	// When set to true it enables outbound SIP phone dialing. Requires a configured
+	// LiveKitSIPOutboundTrunkID; this toggle disables dialing without clearing it.
+	EnableSIPOutbound *bool
 	// (Cloud) License information that isn't exposed to clients yet on the webapp
 	SkuShortName string `json:"sku_short_name"`
 	// Let the server determine whether or not host controls are allowed (through license checks or otherwise)
@@ -149,6 +154,9 @@ func (c *configuration) SetDefaults() {
 	}
 	if c.EnableRinging == nil {
 		c.EnableRinging = model.NewPointer(false)
+	}
+	if c.EnableSIPOutbound == nil {
+		c.EnableSIPOutbound = model.NewPointer(false)
 	}
 	if c.TranscriberModelSize == "" {
 		c.TranscriberModelSize = transcriber.ModelSizeDefault
@@ -244,6 +252,7 @@ func (c *configuration) Clone() *configuration {
 	cfg.LiveKitURL = c.LiveKitURL
 	cfg.LiveKitAPIKey = c.LiveKitAPIKey
 	cfg.LiveKitAPISecret = c.LiveKitAPISecret
+	cfg.LiveKitSIPOutboundTrunkID = c.LiveKitSIPOutboundTrunkID
 
 	// AllowEnableCalls is always true
 	cfg.AllowEnableCalls = model.NewPointer(true)
@@ -286,6 +295,10 @@ func (c *configuration) Clone() *configuration {
 
 	if c.EnableRinging != nil {
 		cfg.EnableRinging = model.NewPointer(*c.EnableRinging)
+	}
+
+	if c.EnableSIPOutbound != nil {
+		cfg.EnableSIPOutbound = model.NewPointer(*c.EnableSIPOutbound)
 	}
 
 	if c.LiveCaptionsNumTranscribers != nil {
@@ -378,6 +391,7 @@ func (p *Plugin) getClientConfig(c *configuration) ClientConfig {
 		MaxRecordingDuration: c.MaxRecordingDuration,
 		EnableSimulcast:      c.EnableSimulcast,
 		EnableRinging:        c.EnableRinging,
+		EnableSIPOutbound:    c.EnableSIPOutbound,
 		SkuShortName:         skuShortName,
 		HostControlsAllowed:  p.licenseChecker.HostControlsAllowed(),
 		EnableAV1:            c.EnableAV1,
@@ -566,6 +580,7 @@ func (p *Plugin) setOverrides(cfg *configuration) {
 
 	cfg.JobServiceURL = strings.TrimSpace(cfg.JobServiceURL)
 	cfg.LiveKitURL = strings.TrimSpace(cfg.LiveKitURL)
+	cfg.LiveKitSIPOutboundTrunkID = strings.TrimSpace(cfg.LiveKitSIPOutboundTrunkID)
 }
 
 func (p *Plugin) isSingleHandler() bool {

--- a/server/session.go
+++ b/server/session.go
@@ -449,6 +449,29 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		}
 	}
 
+	// Outbound phone calls (bot-DM containers) are 1:1: once the last human
+	// leaves, any lingering SIP participant has no one to talk to. Hang up the
+	// phone by deleting the LiveKit room (which sends a SIP BYE) and drop the SIP
+	// session(s), so the call ends below instead of orphaning the PSTN leg. The
+	// resulting participant_left webhook finds the call already ended and no-ops.
+	if onlySIPParticipantsRemain(state.sessions) && p.isPhoneCallChannel(channelID) {
+		p.LogInfo("removeUserSession: last human left phone call, hanging up SIP",
+			"callID", state.Call.ID, "channelID", channelID)
+
+		if err := p.livekitDeleteRoom(channelID); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
+			p.LogError("removeUserSession: failed to delete LiveKit room",
+				"channelID", channelID, "err", err.Error())
+		}
+
+		for sid := range state.sessions {
+			if err := p.store.DeleteCallSession(sid); err != nil {
+				p.LogError("removeUserSession: failed to delete SIP session",
+					"channelID", channelID, "sid", sid, "err", err.Error())
+			}
+			delete(state.sessions, sid)
+		}
+	}
+
 	// Call has ended
 	if len(state.sessions) == 0 {
 		if state.Call.Props.ScreenStartAt > 0 {

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-calls/server/cluster"
+	"github.com/mattermost/mattermost-plugin-calls/server/db"
 	"github.com/mattermost/mattermost-plugin-calls/server/enterprise"
 	"github.com/mattermost/mattermost-plugin-calls/server/public"
 
@@ -165,4 +166,93 @@ func TestAddUserSession(t *testing.T) {
 			require.NotNil(t, retState.sessions["connA"])
 		})
 	})
+}
+
+// TestRemoveUserSessionPhoneCall verifies scenario 1: when the last human leaves
+// an outbound phone call (bot-DM container), the lingering SIP participant is
+// hung up and the call ends, instead of orphaning the PSTN leg.
+func TestRemoveUserSessionPhoneCall(t *testing.T) {
+	mockAPI := &pluginMocks.MockAPI{}
+	mockMetrics := &serverMocks.MockMetrics{}
+
+	botID := model.NewId()
+	p := Plugin{
+		MattermostPlugin:  plugin.MattermostPlugin{API: mockAPI},
+		callsClusterLocks: map[string]*cluster.Mutex{},
+		metrics:           mockMetrics,
+		configuration:     &configuration{}, // no LiveKitURL: livekitDeleteRoom is a no-op
+		botSession:        &model.Session{UserId: botID},
+		sessions:          map[string]*session{},
+	}
+	p.licenseChecker = enterprise.NewLicenseChecker(p.API)
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+	p.store = store
+
+	mockMetrics.On("ObserveAppHandlersTime", mock.AnythingOfType("string"), mock.AnythingOfType("float64")).Maybe()
+	mockMetrics.On("IncWebSocketEvent", mock.Anything, mock.Anything).Maybe()
+	// Generous matcher counts: the LogInfo/LogDebug/LogError wrappers prepend an
+	// "origin" pair, and testify tolerates extra expected matchers but not extra
+	// actual args, so over-provide mock.Anything to match any key-value count.
+	anys := make([]interface{}, 18)
+	for i := range anys {
+		anys[i] = mock.Anything
+	}
+	mockAPI.On("LogInfo", append([]interface{}{mock.AnythingOfType("string")}, anys...)...).Maybe()
+	mockAPI.On("LogDebug", append([]interface{}{mock.AnythingOfType("string")}, anys...)...).Maybe()
+	mockAPI.On("LogError", append([]interface{}{mock.AnythingOfType("string")}, anys...)...).Maybe()
+	mockAPI.On("PublishWebSocketEvent", mock.AnythingOfType("string"), mock.Anything,
+		mock.AnythingOfType("*model.WebsocketBroadcast")).Maybe()
+	mockAPI.On("GetConfig").Return(&model.Config{}, nil)
+
+	channelID := model.NewId()
+	postID := model.NewId()
+	humanConnID := model.NewId()
+	humanUserID := model.NewId()
+	sipSid := model.NewId()
+	callID := model.NewId()
+
+	createPost(t, store, postID, humanUserID, channelID)
+	call := &public.Call{
+		ID:        callID,
+		CreateAt:  time.Now().UnixMilli(),
+		StartAt:   time.Now().UnixMilli(),
+		ChannelID: channelID,
+		PostID:    postID,
+		ThreadID:  model.NewId(),
+		OwnerID:   humanUserID,
+		Props:     public.CallProps{NodeID: "test-node"},
+	}
+	require.NoError(t, store.CreateCall(call))
+
+	humanSession := &public.CallSession{ID: humanConnID, CallID: callID, UserID: humanUserID, JoinAt: time.Now().UnixMilli()}
+	sipSession := &public.CallSession{ID: sipSid, CallID: callID, UserID: "+14155551234", JoinAt: time.Now().UnixMilli(), IsSIPParticipant: true}
+	require.NoError(t, store.CreateCallSession(humanSession))
+	require.NoError(t, store.CreateCallSession(sipSession))
+
+	state := &callState{
+		Call:     *call,
+		sessions: map[string]*public.CallSession{humanConnID: humanSession, sipSid: sipSession},
+	}
+
+	// The DM is a phone-call container (bot is a member).
+	mockAPI.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, Type: model.ChannelTypeDirect}, nil)
+	mockAPI.On("GetChannelMembers", channelID, 0, 10).Return(model.ChannelMembers{{ChannelId: channelID, UserId: botID}}, nil)
+	mockAPI.On("UpdatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{Id: postID}, nil)
+
+	err := p.removeUserSession(state, humanUserID, humanConnID, humanConnID, channelID)
+	require.NoError(t, err)
+
+	// The SIP session was dropped and the call ended.
+	require.Empty(t, state.sessions)
+	ended, err := store.GetCall(callID, db.GetCallOpts{})
+	require.NoError(t, err)
+	require.Greater(t, ended.EndAt, int64(0))
+
+	sessions, err := store.GetCallSessions(callID, db.GetCallSessionOpts{})
+	require.NoError(t, err)
+	require.Empty(t, sessions)
+
+	mockAPI.AssertCalled(t, "PublishWebSocketEvent", wsEventCallEnd, mock.Anything, mock.Anything)
 }

--- a/server/sip.go
+++ b/server/sip.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/livekit/protocol/auth"
+	"github.com/livekit/protocol/livekit"
+	"github.com/twitchtv/twirp"
+)
+
+// livekitHTTPURL converts the configured LiveKit WebSocket URL to an HTTP URL
+// suitable for Twirp API calls.
+func livekitHTTPURL(wsURL string) string {
+	u := strings.TrimSpace(wsURL)
+	u = strings.Replace(u, "wss://", "https://", 1)
+	u = strings.Replace(u, "ws://", "http://", 1)
+	return u
+}
+
+// createSIPParticipant dials an outbound phone number and adds the SIP participant to a LiveKit room.
+func (p *Plugin) createSIPParticipant(trunkID, phoneNumber, roomName, displayName string) error {
+	cfg := p.getConfiguration()
+	sipClient := livekit.NewSIPProtobufClient(livekitHTTPURL(cfg.LiveKitURL), &http.Client{})
+
+	// CreateSIPParticipant requires both SIP and video admin grants; the video
+	// grant also lets LiveKit auto-create the room when it doesn't exist yet.
+	at := auth.NewAccessToken(cfg.LiveKitAPIKey, cfg.LiveKitAPISecret)
+	at.SetSIPGrant(&auth.SIPGrant{Admin: true, Call: true}).
+		SetVideoGrant(&auth.VideoGrant{RoomAdmin: true, RoomCreate: true}).
+		SetValidFor(30 * time.Second)
+	token, err := at.ToJWT()
+	if err != nil {
+		return fmt.Errorf("failed to create SIP token: %w", err)
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+token)
+	ctx, err := twirp.WithHTTPRequestHeaders(context.Background(), header)
+	if err != nil {
+		return fmt.Errorf("failed to set twirp headers: %w", err)
+	}
+
+	resp, err := sipClient.CreateSIPParticipant(ctx, &livekit.CreateSIPParticipantRequest{
+		SipTrunkId:          trunkID,
+		SipCallTo:           phoneNumber,
+		RoomName:            roomName,
+		ParticipantIdentity: "sip:" + phoneNumber,
+		ParticipantName:     displayName,
+		PlayDialtone:        true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create SIP participant: %w", err)
+	}
+
+	p.LogDebug("created SIP participant for outbound call",
+		"participantID", resp.ParticipantId, "phoneNumber", phoneNumber, "room", roomName)
+
+	return nil
+}

--- a/server/sip.go
+++ b/server/sip.go
@@ -13,7 +13,12 @@ import (
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
 	"github.com/twitchtv/twirp"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
+
+// sipOutboundRingingTimeout cancels an unanswered outbound call so a ringing
+// leg doesn't hold a trunk channel indefinitely.
+const sipOutboundRingingTimeout = 60 * time.Second
 
 // livekitHTTPURL converts the configured LiveKit WebSocket URL to an HTTP URL
 // suitable for Twirp API calls.
@@ -54,6 +59,7 @@ func (p *Plugin) createSIPParticipant(trunkID, phoneNumber, roomName, displayNam
 		ParticipantIdentity: "sip:" + phoneNumber,
 		ParticipantName:     displayName,
 		PlayDialtone:        true,
+		RingingTimeout:      durationpb.New(sipOutboundRingingTimeout),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create SIP participant: %w", err)

--- a/server/sip_test.go
+++ b/server/sip_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizePhoneNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"plain digits short", "12345", "12345"},
+		{"dashes prepends plus", "1-781-307-8753", "+17813078753"},
+		{"parens and spaces", "+1 (555) 123-4567", "+15551234567"},
+		{"tel prefix", "tel:+17813078753", "+17813078753"},
+		{"tel prefix no plus", "tel:17813078753", "+17813078753"},
+		{"already e164", "+447911123456", "+447911123456"},
+		{"surrounding whitespace", "  +1 555 0000  ", "+15550000"},
+		{"plus only first position kept", "1+555", "1555"},
+		{"letters stripped", "1-800-FLOWERS", "1800"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, normalizePhoneNumber(tc.input))
+		})
+	}
+}
+
+func TestLivekitHTTPURL(t *testing.T) {
+	require.Equal(t, "https://livekit.example.com", livekitHTTPURL("wss://livekit.example.com"))
+	require.Equal(t, "http://localhost:7880", livekitHTTPURL("ws://localhost:7880"))
+	require.Equal(t, "https://livekit.example.com", livekitHTTPURL("  wss://livekit.example.com  "))
+	require.Equal(t, "https://livekit.example.com", livekitHTTPURL("https://livekit.example.com"))
+}

--- a/server/slash_command.go
+++ b/server/slash_command.go
@@ -20,6 +20,7 @@ const (
 	joinCommandTrigger      = "join"
 	leaveCommandTrigger     = "leave"
 	linkCommandTrigger      = "link"
+	dialCommandTrigger      = "dial"
 	statsCommandTrigger     = "stats"
 	endCommandTrigger       = "end"
 	recordingCommandTrigger = "recording"
@@ -32,6 +33,7 @@ var subCommands = []string{
 	joinCommandTrigger,
 	leaveCommandTrigger,
 	linkCommandTrigger,
+	dialCommandTrigger,
 	endCommandTrigger,
 	statsCommandTrigger,
 	recordingCommandTrigger,
@@ -47,6 +49,9 @@ func (p *Plugin) getAutocompleteData() *model.AutocompleteData {
 	data.AddCommand(model.NewAutocompleteData(joinCommandTrigger, "", "Joins a call in the current channel"))
 	data.AddCommand(model.NewAutocompleteData(leaveCommandTrigger, "", "Leave a call in the current channel."))
 	data.AddCommand(model.NewAutocompleteData(linkCommandTrigger, "", "Generate a link to join a call in the current channel."))
+	dialCmdData := model.NewAutocompleteData(dialCommandTrigger, "[phone number]", "Dial an outbound phone number.")
+	dialCmdData.AddTextArgument("[phone number]", "Phone number to dial", "")
+	data.AddCommand(dialCmdData)
 	data.AddCommand(model.NewAutocompleteData(statsCommandTrigger, "", "Show client-generated statistics about the call."))
 	data.AddCommand(model.NewAutocompleteData(endCommandTrigger, "", "End the call for everyone. All the participants will drop immediately."))
 	data.AddCommand(model.NewAutocompleteData(logsCommandTrigger, "", "Show client logs."))
@@ -210,6 +215,15 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 
 	if subCmd == endCommandTrigger {
 		return buildCommandResponse(p.handleEndCallCommand())
+	}
+
+	if subCmd == dialCommandTrigger {
+		// The webapp intercepts /call dial client-side. Reaching the server
+		// means the client didn't handle it (e.g. mobile), so just inform.
+		return &model.CommandResponse{
+			ResponseType: model.CommandResponseTypeEphemeral,
+			Text:         "Outbound dialing is only supported in the web/desktop app.",
+		}, nil
 	}
 
 	if subCmd == recordingCommandTrigger {

--- a/server/utils.go
+++ b/server/utils.go
@@ -223,6 +223,30 @@ func getUserIDsFromSessions(sessions map[string]*public.CallSession) []string {
 	return userIDs
 }
 
+// sipParticipantsRemain reports whether any SIP participant session is still present.
+func sipParticipantsRemain(sessions map[string]*public.CallSession) bool {
+	for _, session := range sessions {
+		if session.IsSIPParticipant {
+			return true
+		}
+	}
+	return false
+}
+
+// onlySIPParticipantsRemain reports whether there is at least one session left
+// and every remaining session is a SIP participant (i.e. no humans remain).
+func onlySIPParticipantsRemain(sessions map[string]*public.CallSession) bool {
+	if len(sessions) == 0 {
+		return false
+	}
+	for _, session := range sessions {
+		if !session.IsSIPParticipant {
+			return false
+		}
+	}
+	return true
+}
+
 func (p *Plugin) getTranslationFunc(locale string) i18n.TranslateFunc {
 	if locale != "" {
 		return i18n.GetUserTranslations(locale)


### PR DESCRIPTION
## Summary

Ports the **server-side** of LiveKit SIP outbound phone dialing from the `livekit-poc` branch (commit `4c019e7b`) to `v2`. A Mattermost user can dial an external phone number; LiveKit places the outbound SIP call and joins the remote party to a call hosted on the user↔Calls-bot DM channel. This is a port-and-adapt onto v2's existing webhook/session-tracking model (MM-68698 / #1173), not a clean cherry-pick.

Client/webapp/standalone work (tel: interception, phone-mode widget) is tracked in the companion client ticket and is **not** in this PR.

## What's included

- **Config:** `EnableSIPOutbound` toggle and `LiveKitSIPOutboundTrunkID` text setting (both in `plugin.json` + `configuration`). The two are independent gates — turning the toggle off disables dialing without clearing the trunk config.
- **`server/sip.go`:** `createSIPParticipant()` + a `livekitHTTPURL()` helper. Uses the raw `livekit.NewSIPProtobufClient` with explicit SIP (`Admin`+`Call`) and video (`RoomAdmin`+`RoomCreate`) grants — the video grant lets LiveKit auto-create the room when the SIP leg reaches it before the user's join.
- **`POST /phone-call`** (`handlePhoneCall`) + `normalizePhoneNumber()` — resolves the user↔bot DM, validates the toggle/trunk, dials in a goroutine, returns `{channel_id}`.
- **`dial` slash command** — registered with autocomplete; the server handler returns the ephemeral "web/desktop only" fallback (the webapp intercepts it on web/desktop).
- **Teardown:** ends the phone call whenever **either** side leaves. SIP hangup is handled in v2's existing `handleLiveKitSIPParticipantLeft`; the last-human-leaves case is handled in `removeUserSession` (deletes the LiveKit room → SIP BYE), so the PSTN leg is never orphaned.

## Testing

- Unit tests for `normalizePhoneNumber`/`livekitHTTPURL`, the `/phone-call` gating (disabled toggle, missing trunk), the webhook end-call path, and the last-human-leaves teardown.
- Manually verified end to end against a local LiveKit + SIP-bridge + Asterisk sink stack: dial connects with bidirectional audio, and all three teardown paths (SIP hangup, leave, end-for-all) drop the phone leg.
- `go build`, `go vet`, and `gofmt` clean. (golangci-lint couldn't run locally due to a toolchain version mismatch; relying on CI.)