### PR TITLE
[MM-69469] Fix stale call-post and global-widget participant lists on Desktop

### DIFF
--- a/standalone/src/index.ts
+++ b/standalone/src/index.ts
@@ -35,7 +35,7 @@ import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTheme, Theme} from 'mattermost-redux/selectors/entities/preferences';
 import configureStore from 'mattermost-redux/store';
-import {getCallActive, getCallsConfig, getCallsVersionInfo, localSessionClose, setClientConnecting} from 'plugin/actions';
+import {getCallActive, getCallsConfig, getCallsVersionInfo, joinUser, leaveUser, localSessionClose, setClientConnecting} from 'plugin/actions';
 import CallClient, {CALL_EVENT, ConnectPayload, DisconnectReason} from 'plugin/clients/call';
 import RestClient from 'plugin/clients/rest';
 import {
@@ -113,11 +113,20 @@ function connectCall(
         callClient.on(CALL_EVENT.WEBSOCKET_EVENT, wsEventHandler);
 
         // Bridge LiveKit-owned per-participant state into the store. After the
-        // LiveKit migration mute/speaking/raised-hand/reactions no longer travel
-        // over the plugin WebSocket; CallClient re-emits them as CALL_EVENTs. The
-        // main webapp wires these in its own index.tsx and the popout reuses the
-        // opener's client — the standalone bundles (widget + recording) need the
-        // same bridge here so their indicators reflect real, live state.
+        // LiveKit migration session membership and mute/speaking/raised-hand/reactions
+        // no longer travel over the plugin WebSocket; CallClient re-emits them as
+        // CALL_EVENTs. The main webapp wires these in its own index.tsx and the popout
+        // reuses the opener's client — the standalone bundles (widget + recording) need
+        // the same bridge here so their participant list and indicators reflect real,
+        // live state. (The channel-wide user_joined/user_left WS broadcast is gated off
+        // for a renderer that owns the live client, so these LiveKit events are the only
+        // source of session join/leave here.)
+        callClient.on(CALL_EVENT.USER_JOINED, (sessionID: string, userID: string, isFromInitialSync?: boolean) => {
+            store.dispatch(joinUser(callClient.channelID, userID, sessionID, Boolean(isFromInitialSync)));
+        });
+        callClient.on(CALL_EVENT.USER_LEFT, (sessionID: string, userID: string) => {
+            store.dispatch(leaveUser(callClient.channelID, userID, sessionID));
+        });
         callClient.on(CALL_EVENT.MUTE, (sessionID: string, userID: string) => {
             store.dispatch(userMuted(callClient.channelID, sessionID, userID));
         });

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -16,6 +16,7 @@ import {
     getPlatformInfo,
     getWebappUtils,
     getWSConnectionURL,
+    hasLiveCallClient,
     maxAttemptsReachedErr,
     runWithRetry,
     shouldRenderCallsIncoming,
@@ -537,6 +538,38 @@ describe('utils', () => {
             const callsClient = getCallsClient();
             expect(callsClient).toBeUndefined();
             global.window = originalWindow;
+        });
+    });
+
+    describe('hasLiveCallClient', () => {
+        beforeEach(() => {
+            delete window.callsClient;
+            delete global.window.opener;
+        });
+        afterEach(() => {
+            delete window.callsClient;
+            delete global.window.opener;
+        });
+
+        test('no client: false', () => {
+            expect(hasLiveCallClient('channelID')).toBe(false);
+        });
+
+        test('own client, channel matches: true', () => {
+            window.callsClient = {channelID: 'channelID'} as CallClient;
+            expect(hasLiveCallClient('channelID')).toBe(true);
+        });
+
+        test('own client, channel differs: false', () => {
+            window.callsClient = {channelID: 'other-channel'} as CallClient;
+            expect(hasLiveCallClient('channelID')).toBe(false);
+        });
+
+        test('popout (opener client), channel matches: true', () => {
+            global.window.opener = {
+                callsClient: {channelID: 'channelID'} as CallClient,
+            };
+            expect(hasLiveCallClient('channelID')).toBe(true);
         });
     });
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -97,6 +97,13 @@ export function getCallsClientChannelID(): string {
     return getCallsClient()?.channelID || '';
 }
 
+// True when this renderer owns the live LiveKit client for the channel (directly via
+// window.callsClient, or the opener's in a popout). When so, participant state is driven by
+// LiveKit events and the channel-wide join/leave broadcast must be ignored to avoid racing it.
+export function hasLiveCallClient(channelID: string): boolean {
+    return getCallsClient()?.channelID === channelID;
+}
+
 export function getCallsClientSessionID(): string {
     return getCallsClient()?.getSessionID() || '';
 }

--- a/webapp/src/websocket_handlers.test.ts
+++ b/webapp/src/websocket_handlers.test.ts
@@ -4,16 +4,18 @@
 import {HostControlRemoved, UserRemovedData} from '@mattermost/calls-common/lib/types';
 import {WebSocketMessage} from '@mattermost/client/websocket';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {displayCallErrorModal} from 'src/actions';
+import {displayCallErrorModal, joinUser, leaveUser} from 'src/actions';
 import {userLeftChannelErr, userRemovedFromChannelErr} from 'src/clients/calls';
 import {HostRemovedYouFromCallErr} from 'src/components/error_modal/error_messages';
 
 import {channelIDForCurrentCall} from './selectors';
-import {getCallsClient} from './utils';
-import {handleHostRemoved, handleUserRemovedFromChannel} from './websocket_handlers';
+import {getCallsClient, hasLiveCallClient} from './utils';
+import {handleHostRemoved, handleUserJoined, handleUserLeft, handleUserRemovedFromChannel} from './websocket_handlers';
 
 jest.mock('src/actions', () => ({
     displayCallErrorModal: jest.fn((err, channelID) => ({type: 'mock/displayCallErrorModal', err, channelID})),
+    joinUser: jest.fn((channelID, userID, sessionID, isFromInitialSync) => ({type: 'mock/joinUser', channelID, userID, sessionID, isFromInitialSync})),
+    leaveUser: jest.fn((channelID, userID, sessionID) => ({type: 'mock/leaveUser', channelID, userID, sessionID})),
 }));
 jest.mock('./selectors', () => ({
     channelIDForCurrentCall: jest.fn(),
@@ -22,6 +24,7 @@ jest.mock('./selectors', () => ({
 jest.mock('./utils', () => ({
     getCallsClient: jest.fn(),
     getUserDisplayName: jest.fn(() => 'Test User'),
+    hasLiveCallClient: jest.fn(),
 }));
 jest.mock('mattermost-redux/selectors/entities/users', () => ({
     ...jest.requireActual('mattermost-redux/selectors/entities/users'),
@@ -33,6 +36,9 @@ const mockedGetCurrentUserId = getCurrentUserId as jest.Mock;
 const mockedChannelIDForCurrentCall = channelIDForCurrentCall as jest.Mock;
 const mockedGetCallsClient = getCallsClient as jest.Mock;
 const mockedDisplayCallErrorModal = displayCallErrorModal as unknown as jest.Mock;
+const mockedJoinUser = joinUser as unknown as jest.Mock;
+const mockedLeaveUser = leaveUser as unknown as jest.Mock;
+const mockedHasLiveCallClient = hasLiveCallClient as jest.Mock;
 
 describe('websocket_handlers', () => {
     const makeStore = () => ({
@@ -117,6 +123,65 @@ describe('websocket_handlers', () => {
             expect(mockedDisplayCallErrorModal).not.toHaveBeenCalled();
             expect(store.dispatch).not.toHaveBeenCalled();
             expect(disconnect).not.toHaveBeenCalled();
+        });
+    });
+
+    // Regression coverage for MM-69189: the channel-wide join/leave broadcasts must keep
+    // updating the call-post participant list in renderers that have no live LiveKit client
+    // (e.g. Desktop's center channel). Only renderers fed by LiveKit — where hasLiveCallClient
+    // is true — skip the broadcast. (hasLiveCallClient's own topology cases are covered in
+    // utils.test.ts.)
+    describe('handleUserJoined', () => {
+        const buildEvent = (channelID: string) => ({
+            data: {channelID, user_id: 'user-1', session_id: 'session-1'},
+            broadcast: {channel_id: ''},
+        }) as unknown as WebSocketMessage<never>;
+
+        it('renderer owns the live LiveKit client: ignores the broadcast', () => {
+            mockedHasLiveCallClient.mockReturnValue(true);
+            const store = makeStore();
+
+            handleUserJoined(store as never, buildEvent('call-channel'));
+
+            expect(mockedJoinUser).not.toHaveBeenCalled();
+            expect(store.dispatch).not.toHaveBeenCalled();
+        });
+
+        it('no live LiveKit client (e.g. Desktop center channel / observer): processes the broadcast', () => {
+            mockedHasLiveCallClient.mockReturnValue(false);
+            const store = makeStore();
+
+            handleUserJoined(store as never, buildEvent('call-channel'));
+
+            expect(mockedJoinUser).toHaveBeenCalledWith('call-channel', 'user-1', 'session-1', false);
+            expect(store.dispatch).toHaveBeenCalledWith(mockedJoinUser.mock.results[0].value);
+        });
+    });
+
+    describe('handleUserLeft', () => {
+        const buildEvent = (channelID: string) => ({
+            data: {channelID, user_id: 'user-1', session_id: 'session-1'},
+            broadcast: {channel_id: ''},
+        }) as unknown as WebSocketMessage<never>;
+
+        it('renderer owns the live LiveKit client: ignores the broadcast', () => {
+            mockedHasLiveCallClient.mockReturnValue(true);
+            const store = makeStore();
+
+            handleUserLeft(store as never, buildEvent('call-channel'));
+
+            expect(mockedLeaveUser).not.toHaveBeenCalled();
+            expect(store.dispatch).not.toHaveBeenCalled();
+        });
+
+        it('no live LiveKit client (e.g. Desktop center channel / observer): processes the broadcast', () => {
+            mockedHasLiveCallClient.mockReturnValue(false);
+            const store = makeStore();
+
+            handleUserLeft(store as never, buildEvent('call-channel'));
+
+            expect(mockedLeaveUser).toHaveBeenCalledWith('call-channel', 'user-1', 'session-1');
+            expect(store.dispatch).toHaveBeenCalledWith(mockedLeaveUser.mock.results[0].value);
         });
     });
 

--- a/webapp/src/websocket_handlers.ts
+++ b/webapp/src/websocket_handlers.ts
@@ -77,6 +77,7 @@ import {
     followThread,
     getCallsClient,
     getUserDisplayName,
+    hasLiveCallClient,
 } from './utils';
 
 // NOTE: it's important this function is kept synchronous in order to guarantee the order of
@@ -154,9 +155,10 @@ export function handleCallStart(store: Store, ev: WebSocketMessage<CallStartData
 export function handleUserLeft(store: Store, ev: WebSocketMessage<UserLeftData>) {
     const channelID = ev.data.channelID || ev.broadcast.channel_id;
 
-    // For the call we're connected to, the LiveKit room is the source of truth for session
-    // state; ignore the channel-wide broadcast to avoid racing the local participant feed.
-    if (channelIDForCurrentCall(store.getState()) === channelID) {
+    // The channel-wide join/leave broadcast keeps the call post's participant list live for
+    // observers. Where this renderer owns the live LiveKit client, that state arrives via LiveKit
+    // events instead, so skip the broadcast to avoid racing it.
+    if (hasLiveCallClient(channelID)) {
         return;
     }
     store.dispatch(leaveUser(channelID, ev.data.user_id, ev.data.session_id));
@@ -169,9 +171,10 @@ export function handleUserJoined(store: Store, ev: WebSocketMessage<UserJoinedDa
     const channelID = ev.data.channelID || ev.broadcast.channel_id;
     const sessionID = ev.data.session_id;
 
-    // For the call we're connected to, the LiveKit room is the source of truth for session
-    // state; ignore the channel-wide broadcast to avoid racing the local participant feed.
-    if (channelIDForCurrentCall(store.getState()) === channelID) {
+    // The channel-wide join/leave broadcast keeps the call post's participant list live for
+    // observers. Where this renderer owns the live LiveKit client, that state arrives via LiveKit
+    // events instead, so skip the broadcast to avoid racing it.
+    if (hasLiveCallClient(channelID)) {
         return;
     }
     store.dispatch(joinUser(channelID, userID, sessionID, false));


### PR DESCRIPTION
Follow-up to MM-69189 (merged), which re-registered the channel-wide `user_joined`/`user_left` websocket handlers so observers see the call-post participant list update live, but gated them so a client already in the call ignores the broadcast (the LiveKit room is the source of truth there). This PR fixes two related Desktop participant-list bugs surfaced together during that verification.

## Issue 1 — call-post participant list (observer view)

**Problem:** On Desktop, the call starter's channel post card shows only themselves and never updates as others join/leave. A user who viewed the post as an observer *before* joining sees the list correctly, so the symptom is asymmetric (starter vs. later joiner) and only reproduces on Desktop.

**Root cause:** The gate used `channelIDForCurrentCall`, which falls back to `clientStateReducer.channelID`. On Desktop the center-channel renderer (where the post card lives) has *no* LiveKit `CallClient` — that lives in the separate global-widget renderer — yet `clientStateReducer.channelID` is still set there (via `DESKTOP_WIDGET_CONNECTED`). So the gate fired in the one renderer whose only data source is the websocket broadcast, freezing its participant list.

**Fix:** Gate on whether *this* renderer actually owns the live LiveKit client for the channel — `getCallsClient()?.channelID === channelID`, extracted as a `hasLiveCallClient(channelID)` predicate. `getCallsClient()` resolves to the local `window.callsClient` or, in a popout, the opener's, so the gate is a no-op in every web and popout case and only changes the Desktop center-channel renderer, which now processes the broadcast again.

Changed: `webapp/src/websocket_handlers.ts`, `webapp/src/utils.ts` (+ unit tests for the handlers and the predicate).

## Issue 2 — global widget participant list + "End call for everyone" (connected view)

**Problem:** On Desktop, the global call widget's *own* participant list does not update as users join/leave (the starter sees only themselves), and the starter — though correctly the host — never gets the "End call for everyone" option.

**Root cause:** The Desktop global widget runs the standalone bundle (`standalone/src/index.ts`). After the LiveKit migration, session membership travels as LiveKit `ParticipantConnected`/`Disconnected` events that `CallClient` re-emits as `CALL_EVENT.USER_JOINED`/`USER_LEFT`. The main webapp bridges those into the store, but the standalone bundle bridged only mute/speaking/raised-hand/reaction — never join/leave. And the channel-wide `user_joined`/`user_left` WS broadcast is (correctly) gated off for this renderer because it owns the live client (Issue 1's `hasLiveCallClient`), so there was no join/leave source at all. The widget's list froze at the initial `call_state` seed. "End call for everyone" is a downstream symptom: the menu item is gated on `(isHost || isAdmin) && numParticipants > 1`, and `numParticipants` was the frozen session count, stuck at 1.

This is a pre-existing v2 gap (the standalone widget has lacked a join/leave source since the LiveKit migration), exposed during MM-69469 verification — not a regression.

**Fix:** Bridge `CALL_EVENT.USER_JOINED`/`USER_LEFT` into the store in `standalone/src/index.ts` (dispatching `joinUser`/`leaveUser`), mirroring the webapp. The existing reSync seed dance for mute/hand state is unchanged.

Changed: `standalone/src/index.ts`.

## Testing

Verified on Desktop: call-post cards update live for observers, the global widget participant list updates on join/leave, and the host correctly gets "End call for everyone" once a second participant joins.

https://mattermost.atlassian.net/browse/MM-69469
