### PR TITLE
[MM-69195] Hide Calls bot from recordings and participant list

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -39,6 +39,11 @@ func (p *Plugin) createBotSession() (*model.Session, error) {
 		return nil, err
 	}
 
+	// Cache the bot user ID before creating the (per-node, possibly-lagging)
+	// session so getBotID never depends on botSession being set. See botID in
+	// plugin.go.
+	p.botID = botID
+
 	session, appErr := p.API.CreateSession(&model.Session{
 		UserId:    botID,
 		ExpiresAt: 0,

--- a/server/api.go
+++ b/server/api.go
@@ -552,6 +552,12 @@ func (p *Plugin) handleGetLiveKitToken(w http.ResponseWriter, r *http.Request) {
 		grant.SetCanPublish(false)
 		grant.SetCanPublishData(false)
 		grant.SetCanSubscribe(true)
+
+		// Flag the bot on the LiveKit side so clients can filter it out of the
+		// participant list regardless of how they learn about participants. The
+		// attribute is server-set (does not require CanUpdateOwnMetadata, which is
+		// deliberately off for the bot) and surfaces on RemoteParticipant.attributes.
+		at.SetAttributes(map[string]string{livekitAttributeBot: "true"})
 	} else {
 		grant.SetCanUpdateOwnMetadata(true)
 	}

--- a/server/bot_api.go
+++ b/server/bot_api.go
@@ -18,10 +18,7 @@ import (
 )
 
 func (p *Plugin) getBotID() string {
-	if p.botSession != nil {
-		return p.botSession.UserId
-	}
-	return ""
+	return p.botID
 }
 
 func (p *Plugin) isBot(userID string) bool {

--- a/server/bot_api_test.go
+++ b/server/bot_api_test.go
@@ -34,6 +34,7 @@ func TestHandleBotGetProfileForSession(t *testing.T) {
 			API: mockAPI,
 		},
 		metrics: mockMetrics,
+		botID:   botUserID,
 		botSession: &model.Session{
 			UserId: botUserID,
 		},
@@ -228,6 +229,7 @@ func TestHandleBotUploadData(t *testing.T) {
 			API: mockAPI,
 		},
 		metrics: mockMetrics,
+		botID:   botUserID,
 		botSession: &model.Session{
 			UserId: botUserID,
 		},

--- a/server/limits_test.go
+++ b/server/limits_test.go
@@ -118,6 +118,7 @@ func TestSendConcurrentSessionsWarning(t *testing.T) {
 			API: mockAPI,
 		},
 		metrics: mockMetrics,
+		botID:   "botID",
 		botSession: &model.Session{
 			UserId: "botID",
 		},

--- a/server/livekit_admin.go
+++ b/server/livekit_admin.go
@@ -23,6 +23,12 @@ const livekitAPITimeout = 5 * time.Second
 // round-trip.
 const livekitAttributeRaisedHand = "raised_hand"
 
+// livekitAttributeBot is the LiveKit participant attribute key that marks the
+// recording/transcribing bot. It mirrors CALL_ATTRIBUTES.BOT on the webapp and
+// is server-set on the bot's token grant so clients can filter the bot out of
+// the participant list independently of the plugin-WS bot filter.
+const livekitAttributeBot = "bot"
+
 var errLiveKitNotConfigured = errors.New("LiveKit is not configured")
 
 func composeLivekitIdentity(userID, sessionID string) string {

--- a/server/logs_test.go
+++ b/server/logs_test.go
@@ -34,6 +34,7 @@ func TestHandleUploadLogsToBot(t *testing.T) {
 		mockAPI := &pluginMocks.MockAPI{}
 		p := &Plugin{
 			MattermostPlugin: plugin.MattermostPlugin{API: mockAPI},
+			botID:            botID,
 			botSession:       &model.Session{UserId: botID},
 		}
 		return p, mockAPI

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -59,6 +59,11 @@ type Plugin struct {
 	apiLimiters    map[string]*rate.Limiter
 	apiLimitersMut sync.RWMutex
 
+	// botID is the Calls bot's user ID, resolved via EnsureBotUser at activation.
+	// It is cached independently of botSession so the bot filter (getBotID) keeps
+	// working even while botSession is nil (e.g. a node's activation window during
+	// a rolling restart), rather than silently returning "" and no-opping.
+	botID      string
 	botSession *model.Session
 
 	// A map of callID -> *cluster.Mutex to guarantee atomicity of call state

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -511,10 +511,14 @@ func TestPublishWebSocketEvent(t *testing.T) {
 	botUserID := model.NewId()
 
 	t.Run("bot", func(t *testing.T) {
+		p.botID = botUserID
 		p.botSession = &model.Session{
 			UserId: botUserID,
 		}
-		defer func() { p.botSession = nil }()
+		defer func() {
+			p.botID = ""
+			p.botSession = nil
+		}()
 
 		t.Run("wsEventUserJoined/wsEventUserLeft", func(t *testing.T) {
 			p.publishWebSocketEvent(wsEventUserJoined, map[string]any{

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -843,6 +843,10 @@ export default class CallClient extends EventEmitter {
         this.emitLiveKitOwnedState(localParticipant);
 
         for (const remoteParticipant of this.room.remoteParticipants.values()) {
+            // The bot is not a call participant; keep it out of the list.
+            if (this.isBotParticipant(remoteParticipant)) {
+                continue;
+            }
             const {userID: remoteUserId, sessionID: remoteSessionID} = this.parseUserIdAndSessionIdFromIdentity(remoteParticipant);
             this.emit(CALL_EVENT.USER_JOINED, remoteSessionID, remoteUserId, true);
             this.emitLiveKitOwnedState(remoteParticipant);
@@ -1158,6 +1162,10 @@ export default class CallClient extends EventEmitter {
      * Emits USER_JOINED so the dispatcher can populate Redux + play the join sound.
      */
     private handleParticipantConnected(remoteParticipant: RemoteParticipant) {
+        // The bot is not a call participant; keep it out of the list.
+        if (this.isBotParticipant(remoteParticipant)) {
+            return;
+        }
         const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(remoteParticipant);
         this.emit(CALL_EVENT.USER_JOINED, sessionID, userID);
 
@@ -1169,6 +1177,11 @@ export default class CallClient extends EventEmitter {
      * Emits USER_LEFT so the dispatcher can drop the session from Redux.
      */
     private handleParticipantDisconnected(remoteParticipant: RemoteParticipant) {
+        // The bot was never added to the list (see handleParticipantConnected),
+        // so don't emit USER_LEFT for it.
+        if (this.isBotParticipant(remoteParticipant)) {
+            return;
+        }
         const {userID, sessionID} = this.parseUserIdAndSessionIdFromIdentity(remoteParticipant);
         this.emit(CALL_EVENT.USER_LEFT, sessionID, userID);
 
@@ -1358,6 +1371,17 @@ export default class CallClient extends EventEmitter {
         }
 
         return new MediaStream([video, audio]);
+    }
+
+    /**
+     * Whether a participant is the recording/transcribing bot. The bot is flagged
+     * server-side with a LiveKit attribute on its token grant (see
+     * livekitAttributeBot), so this works regardless of how the participant was
+     * discovered and is robust to multi-node. Used to keep the bot out of the
+     * participant list (no USER_JOINED/USER_LEFT, no join/leave sound or tile).
+     */
+    private isBotParticipant(p: Participant): boolean {
+        return p.attributes?.[CALL_ATTRIBUTES.BOT] === 'true';
     }
 
     private parseUserIdAndSessionIdFromIdentity(p: Participant): {userID: string; sessionID: string} {

--- a/webapp/src/clients/call/constants.ts
+++ b/webapp/src/clients/call/constants.ts
@@ -34,6 +34,11 @@ export const CALL_EVENT = {
 
 export const CALL_ATTRIBUTES = {
     RAISED_HAND: 'raised_hand',
+
+    // BOT marks the recording/transcribing bot. Server-set on the bot's LiveKit
+    // token grant (see livekitAttributeBot server-side); used to filter the bot
+    // out of the participant list regardless of how participants are discovered.
+    BOT: 'bot',
 } as const;
 
 export const CALL_MESSAGE_TOPICS = {


### PR DESCRIPTION
## Summary

On Calls v2 (LiveKit) the recording/transcribing **Calls bot** leaks into the participant list — a bot tile in production recordings and a "Calls bot has joined the call" toast in the webapp. None of this happened in v1.

There are two independent paths by which a client learns who is in a call, and the bot was only filtered on one:

- **Path A — plugin WebSocket** (`user_joined` / `call_state`): server-filtered, keyed on `getBotID()`.
- **Path B — LiveKit room participants** (new in v2): `call_client.ts` derives participants directly from the LiveKit room with **no bot filtering**.

The server-side suppression (Path A) never applies to Path B. And Path A's filter depends entirely on `getBotID()` returning `p.botSession.UserId` — per-node state set late in `OnActivate`. During a node's activation window (e.g. a rolling restart with calls live), `botSession == nil`, `getBotID()` returns `""`, and the filter silently no-ops, letting the bot leak even on Path A.

## Changes

**Tag the bot on the LiveKit side and filter there (path-independent, multi-node safe)**
- Server: tag the bot's LiveKit token grant with a `bot` attribute (`server/api.go`, `livekitAttributeBot` in `server/livekit_admin.go`). Server-set, so it doesn't require `CanUpdateOwnMetadata` (which stays off for the bot).
- Webapp: add `CALL_ATTRIBUTES.BOT` and skip emitting `USER_JOINED`/`USER_LEFT` for bot-flagged participants in the `handleConnected` seed loop, `handleParticipantConnected`, and `handleParticipantDisconnected` (`webapp/src/clients/call/`).

**Harden the legacy Path A filter**
- Cache the bot user ID in `p.botID`, resolved via `EnsureBotUser` early in `createBotSession` (independent of `botSession`), and return it from `getBotID()` so the WS filter no longer silently disables when the session isn't ready.

## Test plan

- `go build ./server/...`, `go vet`, and affected server tests pass; updated tests that seeded `botSession` to also set `botID`.
- Webapp `tsc` type-check and eslint pass.
- Manual: verify no bot tile in a recording (multi-node/prod-like) and no "Calls bot has joined the call" toast; bot stays excluded from participant counts/list.