### PR TITLE
[MM-69509] Fix reconnect race that orphans calls on v2

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -469,9 +469,13 @@ func (p *Plugin) handleLeave(us *session, userID, connID, channelID string) erro
 		p.LogDebug("reconnected, returning", "userID", userID, "connID", connID, "channelID", channelID)
 
 		// Clearing the previous session since it gets copied over after
-		// successful reconnect.
+		// successful reconnect. Only delete if it's still our (old) session:
+		// a same-connID reconnect on the same node installs a new session
+		// under this connID, and deleting unconditionally would orphan it.
 		p.mut.Lock()
-		delete(p.sessions, connID)
+		if p.sessions[connID] == us {
+			delete(p.sessions, connID)
+		}
 		p.mut.Unlock()
 		return nil
 	case <-us.leaveCh:


### PR DESCRIPTION
## Summary

On v2, a call can be left "orphaned" — the call post and state stay active indefinitely after everyone has actually left — because a single participant's session is never removed from the in-memory `p.sessions` map.

The reconnect branch of `handleLeave` deleted `p.sessions[connID]` unconditionally. When a client reconnects reusing the **same connID** on the **same node**, lock ordering forces that delete to run *after* `handleReconnect` has installed the new session under the same connID, so it deletes the freshly-installed live session. That session is then untracked (no lookup by connID can reach it), so the call never ends and isn't cleaned up until the next plugin reload.

## Root cause

This is a v2-only regression. v1/`main` guarded the delete with `if p.sessions[connID] == us && !us.rtc`. Commit 9c4bcf80 ("[MM-68328] Remove embedded RTC server and RTCD client", #1163) replaced the whole conditional with an unconditional delete, dropping the identity check as collateral while correctly removing the now-obsolete `!us.rtc` clause.

## Fix

Restore the identity-checked delete (without the `!us.rtc` clause), so `handleLeave` only removes the session if it's still its own:

- Same-connID reconnect: `p.sessions[connID]` is the new session, so the live session survives.
- Normal new-connID reconnect: `handleReconnect` already deleted the original connID, so the guarded delete is a harmless no-op.

## Notes

- Independent of LiveKit/webhooks. A complementary reconciliation safety net is tracked separately in MM-69510.
- Jira: https://mattermost.atlassian.net/browse/MM-69509