### PR TITLE
[MM-69206] Fix screen share starting at small size in popout

### DIFF
--- a/webapp/src/components/expanded_view/component.tsx
+++ b/webapp/src/components/expanded_view/component.tsx
@@ -149,10 +149,18 @@ interface State {
 }
 
 const StyledMediaController = styled(MediaController)`
+    width: 100%;
+    height: 100%;
     max-height: calc(100% - 32px);
     background-color: transparent;
     margin-top: auto;
     margin-bottom: auto;
+
+    #screen-player {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+    }
 `;
 
 const StyledMediaControlBar = styled(MediaControlBar)`


### PR DESCRIPTION
### Summary

Fixes the screen-share "starts small, then grows to fill the frame" behavior in the Calls v2 (LiveKit) expanded/popout view.

### Root cause

This is a layout bug, distinct from the resolution/adaptiveStream work in MM-69110 / MM-69133.

In the popout, the screen-share `<video id="screen-player">` has no explicit `width`/`height`/`object-fit`. It is wrapped in a media-chrome `<media-controller>` (`StyledMediaController`) whose only sizing constraint was `max-height: calc(100% - 32px)`. A `<media-controller>` with no explicit size sizes itself to the media's *intrinsic* dimensions (`videoWidth × videoHeight`), so the rendered box tracked the encoded resolution of the incoming track — which ramps upward over the first several seconds (BWE + quality scaler). That produced the "starts small, expands after ~5–10s" symptom.

For contrast, the in-channel widget's `#screen-player` is pinned to `width=100% height=100%` inside a fixed box, so its displayed size is stable. The popout never got that treatment — that asymmetry is the bug.

### Fix

Pin the screen-share box to fill the available frame and let `object-fit: contain` handle aspect ratio, so the displayed area is stable from the first frame:

- Give `StyledMediaController` a fill size (`width: 100%; height: 100%`).
- Give `#screen-player` `width: 100%; height: 100%; object-fit: contain`.

This mirrors what the widget already does. It is purely cosmetic — it does not touch `adaptiveStream` (still correctly `false`) and does not depend on MM-69133. The encoder ramp now manifests only as a low-res→high-res sharpness transition, not a change in dimensions.

### Ticket

https://mattermost.atlassian.net/browse/MM-69206

### Testing

Built and verified locally that the shared screen fills the frame immediately on render.
