### PR TITLE
[MM-69116] Remove vestigial server mute/hand/video plumbing (Phase 1)

### DIFF
--- a/server/client_message.go
+++ b/server/client_message.go
@@ -13,25 +13,19 @@ type clientMessage struct {
 }
 
 const (
-	clientMessageTypeJoin        = "join"
-	clientMessageTypeLeave       = "leave"
-	clientMessageTypeReconnect   = "reconnect"
-	clientMessageTypeSDP         = "sdp"
-	clientMessageTypeICE         = "ice"
-	clientMessageTypeMute        = "mute"
-	clientMessageTypeUnmute      = "unmute"
-	clientMessageTypeVoiceOn     = "voice_on"
-	clientMessageTypeVoiceOff    = "voice_off"
-	clientMessageTypeScreenOn    = "screen_on"
-	clientMessageTypeScreenOff   = "screen_off"
-	clientMessageTypeVideoOn     = "video_on"
-	clientMessageTypeVideoOff    = "video_off"
-	clientMessageTypeRaiseHand   = "raise_hand"
-	clientMessageTypeUnraiseHand = "unraise_hand"
-	clientMessageTypeReact       = "react"
-	clientMessageTypeCaption     = "caption"
-	clientMessageTypeMetric      = "metric"
-	clientMessageTypeCallState   = "call_state"
+	clientMessageTypeJoin      = "join"
+	clientMessageTypeLeave     = "leave"
+	clientMessageTypeReconnect = "reconnect"
+	clientMessageTypeSDP       = "sdp"
+	clientMessageTypeICE       = "ice"
+	clientMessageTypeVoiceOn   = "voice_on"
+	clientMessageTypeVoiceOff  = "voice_off"
+	clientMessageTypeScreenOn  = "screen_on"
+	clientMessageTypeScreenOff = "screen_off"
+	clientMessageTypeReact     = "react"
+	clientMessageTypeCaption   = "caption"
+	clientMessageTypeMetric    = "metric"
+	clientMessageTypeCallState = "call_state"
 )
 
 func (m *clientMessage) ToJSON() ([]byte, error) {
@@ -43,26 +37,20 @@ func (m *clientMessage) FromJSON(data []byte) error {
 }
 
 var validClientMessageTypes = map[string]bool{
-	clientMessageTypeJoin:        true,
-	clientMessageTypeLeave:       true,
-	clientMessageTypeReconnect:   true,
-	clientMessageTypeSDP:         true,
-	clientMessageTypeICE:         true,
-	clientMessageTypeMute:        true,
-	clientMessageTypeUnmute:      true,
-	clientMessageTypeVoiceOn:     true,
-	clientMessageTypeVoiceOff:    true,
-	clientMessageTypeScreenOn:    true,
-	clientMessageTypeScreenOff:   true,
-	clientMessageTypeVideoOn:     true,
-	clientMessageTypeVideoOff:    true,
-	clientMessageTypeRaiseHand:   true,
-	clientMessageTypeUnraiseHand: true,
-	clientMessageTypeReact:       true,
-	clientMessageTypeCaption:     true,
-	clientMessageTypeMetric:      true,
-	clientMessageTypeCallState:   true,
-	"ping":                       true, // Special case: standard ping message
+	clientMessageTypeJoin:      true,
+	clientMessageTypeLeave:     true,
+	clientMessageTypeReconnect: true,
+	clientMessageTypeSDP:       true,
+	clientMessageTypeICE:       true,
+	clientMessageTypeVoiceOn:   true,
+	clientMessageTypeVoiceOff:  true,
+	clientMessageTypeScreenOn:  true,
+	clientMessageTypeScreenOff: true,
+	clientMessageTypeReact:     true,
+	clientMessageTypeCaption:   true,
+	clientMessageTypeMetric:    true,
+	clientMessageTypeCallState: true,
+	"ping":                     true, // Special case: standard ping message
 }
 
 func isValidClientMessageType(msgType string) bool {

--- a/server/db/calls_sessions_store.go
+++ b/server/db/calls_sessions_store.go
@@ -14,7 +14,10 @@ import (
 	sq "github.com/mattermost/squirrel"
 )
 
-var callsSessionsColumns = []string{"ID", "CallID", "UserID", "JoinAt", "Unmuted", "RaisedHand", "Video", "IsSIPParticipant"}
+// NOTE: the calls_sessions table still has unmuted/raisedhand/video columns,
+// but transient per-participant state now lives in LiveKit so we no longer
+// read or write them. The columns are dropped in a later migration (Phase 2).
+var callsSessionsColumns = []string{"ID", "CallID", "UserID", "JoinAt", "IsSIPParticipant"}
 
 func (s *Store) CreateCallSession(session *public.CallSession) error {
 	s.metrics.IncStoreOp("CreateCallSession")
@@ -29,39 +32,7 @@ func (s *Store) CreateCallSession(session *public.CallSession) error {
 	qb := getQueryBuilder(s.driverName).
 		Insert("calls_sessions").
 		Columns(callsSessionsColumns...).
-		Values(session.ID, session.CallID, session.UserID, session.JoinAt, session.Unmuted, session.RaisedHand, session.Video, session.IsSIPParticipant)
-
-	q, args, err := qb.ToSql()
-	if err != nil {
-		return fmt.Errorf("failed to prepare query: %w", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*s.settings.QueryTimeout)*time.Second)
-	defer cancel()
-	_, err = s.wDB.ExecContext(ctx, q, args...)
-	if err != nil {
-		return fmt.Errorf("failed to run query: %w", err)
-	}
-
-	return nil
-}
-
-func (s *Store) UpdateCallSession(session *public.CallSession) error {
-	s.metrics.IncStoreOp("UpdateCallSession")
-	defer func(start time.Time) {
-		s.metrics.ObserveStoreMethodsTime("UpdateCallSession", time.Since(start).Seconds())
-	}(time.Now())
-
-	if err := session.IsValid(); err != nil {
-		return fmt.Errorf("invalid call session: %w", err)
-	}
-
-	qb := getQueryBuilder(s.driverName).
-		Update("calls_sessions").
-		Set("Unmuted", session.Unmuted).
-		Set("RaisedHand", session.RaisedHand).
-		Set("Video", session.Video).
-		Where(sq.Eq{"ID": session.ID})
+		Values(session.ID, session.CallID, session.UserID, session.JoinAt, session.IsSIPParticipant)
 
 	q, args, err := qb.ToSql()
 	if err != nil {
@@ -156,7 +127,7 @@ func (s *Store) GetCallSessions(callID string, opts GetCallSessionOpts) (map[str
 
 	for rows.Next() {
 		var session public.CallSession
-		if err := rows.Scan(&session.ID, &session.CallID, &session.UserID, &session.JoinAt, &session.Unmuted, &session.RaisedHand, &session.Video, &session.IsSIPParticipant); err != nil {
+		if err := rows.Scan(&session.ID, &session.CallID, &session.UserID, &session.JoinAt, &session.IsSIPParticipant); err != nil {
 			return nil, fmt.Errorf("failed to scan rows: %w", err)
 		}
 		sessionsMap[session.ID] = &session

--- a/server/db/calls_sessions_store_test.go
+++ b/server/db/calls_sessions_store_test.go
@@ -18,7 +18,6 @@ func TestCallsSessionsStore(t *testing.T) {
 	testStore(t, map[string]func(t *testing.T, store *Store){
 		"TestCreateCallSession":                testCreateCallSession,
 		"TestDeleteCallSession":                testDeleteCallSession,
-		"TestUpdateCallSession":                testUpdateCallSession,
 		"TestGetCallSession":                   testGetCallSession,
 		"TestGetCallSessions":                  testGetCallSessions,
 		"TestDeleteCallsSessions":              testDeleteCallsSessions,
@@ -57,51 +56,13 @@ func testCreateCallSession(t *testing.T, store *Store) {
 
 	t.Run("valid", func(t *testing.T) {
 		session := &public.CallSession{
-			ID:         model.NewId(),
-			CallID:     model.NewId(),
-			UserID:     model.NewId(),
-			JoinAt:     time.Now().UnixMilli(),
-			Unmuted:    true,
-			RaisedHand: time.Now().UnixMilli(),
-			Video:      true,
+			ID:     model.NewId(),
+			CallID: model.NewId(),
+			UserID: model.NewId(),
+			JoinAt: time.Now().UnixMilli(),
 		}
 
 		err := store.CreateCallSession(session)
-		require.NoError(t, err)
-
-		gotSession, err := store.GetCallSession(session.ID, GetCallSessionOpts{
-			FromWriter: true,
-		})
-		require.NoError(t, err)
-		require.Equal(t, session, gotSession)
-	})
-}
-
-func testUpdateCallSession(t *testing.T, store *Store) {
-	t.Run("nil", func(t *testing.T) {
-		var session *public.CallSession
-		err := store.UpdateCallSession(session)
-		require.EqualError(t, err, "invalid call session: should not be nil")
-	})
-
-	t.Run("existing", func(t *testing.T) {
-		session := &public.CallSession{
-			ID:      model.NewId(),
-			CallID:  model.NewId(),
-			UserID:  model.NewId(),
-			JoinAt:  time.Now().UnixMilli(),
-			Unmuted: true,
-			Video:   true,
-		}
-
-		err := store.CreateCallSession(session)
-		require.NoError(t, err)
-
-		session.RaisedHand = time.Now().UnixMilli()
-		session.Unmuted = false
-		session.Video = false
-
-		err = store.UpdateCallSession(session)
 		require.NoError(t, err)
 
 		gotSession, err := store.GetCallSession(session.ID, GetCallSessionOpts{
@@ -114,12 +75,10 @@ func testUpdateCallSession(t *testing.T, store *Store) {
 
 func testDeleteCallSession(t *testing.T, store *Store) {
 	session := &public.CallSession{
-		ID:      model.NewId(),
-		CallID:  model.NewId(),
-		UserID:  model.NewId(),
-		JoinAt:  time.Now().UnixMilli(),
-		Unmuted: true,
-		Video:   true,
+		ID:     model.NewId(),
+		CallID: model.NewId(),
+		UserID: model.NewId(),
+		JoinAt: time.Now().UnixMilli(),
 	}
 
 	err := store.CreateCallSession(session)
@@ -148,12 +107,10 @@ func testGetCallSession(t *testing.T, store *Store) {
 
 	t.Run("existing", func(t *testing.T) {
 		session := &public.CallSession{
-			ID:      model.NewId(),
-			CallID:  model.NewId(),
-			UserID:  model.NewId(),
-			JoinAt:  time.Now().UnixMilli(),
-			Unmuted: true,
-			Video:   true,
+			ID:     model.NewId(),
+			CallID: model.NewId(),
+			UserID: model.NewId(),
+			JoinAt: time.Now().UnixMilli(),
 		}
 
 		err := store.CreateCallSession(session)
@@ -211,12 +168,10 @@ func testDeleteCallsSessions(t *testing.T, store *Store) {
 
 		for i := 0; i < 10; i++ {
 			session := &public.CallSession{
-				ID:      model.NewId(),
-				CallID:  callID,
-				UserID:  model.NewId(),
-				JoinAt:  time.Now().UnixMilli(),
-				Unmuted: true,
-				Video:   true,
+				ID:     model.NewId(),
+				CallID: callID,
+				UserID: model.NewId(),
+				JoinAt: time.Now().UnixMilli(),
 			}
 
 			err := store.CreateCallSession(session)
@@ -326,12 +281,10 @@ func testCallsSessionsTableColumnAddition(t *testing.T, store *Store) {
 
 	// Create a session with the current schema
 	session := &public.CallSession{
-		ID:         model.NewId(),
-		CallID:     model.NewId(),
-		UserID:     model.NewId(),
-		JoinAt:     time.Now().UnixMilli(),
-		Unmuted:    true,
-		RaisedHand: time.Now().UnixMilli(),
+		ID:     model.NewId(),
+		CallID: model.NewId(),
+		UserID: model.NewId(),
+		JoinAt: time.Now().UnixMilli(),
 	}
 
 	err := store.CreateCallSession(session)
@@ -352,18 +305,6 @@ func testCallsSessionsTableColumnAddition(t *testing.T, store *Store) {
 	gotSession, err := store.GetCallSession(session.ID, GetCallSessionOpts{FromWriter: true})
 	require.NoError(t, err)
 	require.Equal(t, session, gotSession)
-
-	// Verify we can still update the session
-	session.Unmuted = false
-	session.RaisedHand = time.Now().UnixMilli()
-	err = store.UpdateCallSession(session)
-	require.NoError(t, err)
-
-	// Verify the update worked correctly
-	updatedSession, err := store.GetCallSession(session.ID, GetCallSessionOpts{FromWriter: true})
-	require.NoError(t, err)
-	require.Equal(t, session.Unmuted, updatedSession.Unmuted)
-	require.Equal(t, session.RaisedHand, updatedSession.RaisedHand)
 
 	// Clean up - drop the test column
 	var dropColumnSQL string

--- a/server/host_controls.go
+++ b/server/host_controls.go
@@ -94,10 +94,9 @@ func (p *Plugin) hostMuteParticipant(requesterID, channelID, sessionID string) e
 		return ErrNotInCall
 	}
 
-	// NB: we deliberately do not gate on server-side mute state. Under LiveKit
-	// (v2) mute lives in the track state; the server's session.Unmuted is
-	// vestigial (never updated post-migration, see MM-69116) and would always
-	// read false here. livekitMuteParticipant is idempotent — it no-ops if the
+	// NB: there is no server-side mute state to gate on. Under LiveKit (v2) mute
+	// lives in the track state (the vestigial session.Unmuted was removed in
+	// MM-69116). livekitMuteParticipant is idempotent — it no-ops if the
 	// participant has no unmuted mic track.
 	if err := p.livekitMuteParticipant(channelID, composeLivekitIdentity(ust.UserID, sessionID)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
 		p.LogError("hostMuteParticipant: failed to mute participant via LiveKit",
@@ -128,12 +127,11 @@ func (p *Plugin) hostMuteAllParticipants(requesterID, channelID string) error {
 		}
 	}
 
-	// Mute every participant except the host/requester. We deliberately do not
-	// gate on server-side mute state: under LiveKit (v2) mute lives in the track
-	// state and the server's session.Unmuted is vestigial (never updated
-	// post-migration, see MM-69116) — it would read false for everyone and skip
-	// the whole loop. livekitMuteParticipant is idempotent, so muting an
-	// already-muted participant is a harmless no-op.
+	// Mute every participant except the host/requester. There is no server-side
+	// mute state to gate on: under LiveKit (v2) mute lives in the track state
+	// (the vestigial session.Unmuted was removed in MM-69116).
+	// livekitMuteParticipant is idempotent, so muting an already-muted
+	// participant is a harmless no-op.
 	for id, s := range state.sessions {
 		if s.UserID == requesterID {
 			continue
@@ -207,10 +205,9 @@ func (p *Plugin) hostLowerParticipantHand(requesterID, channelID, sessionID stri
 		return ErrNotInCall
 	}
 
-	// NB: we deliberately do not gate on server-side raised-hand state. Under
-	// LiveKit (v2) the hand is a participant attribute the client owns; the
-	// server's session.RaisedHand is vestigial (never updated post-migration,
-	// see MM-69116) and would always read 0 here. Clearing an already-empty
+	// NB: there is no server-side raised-hand state to gate on. Under LiveKit
+	// (v2) the hand is a participant attribute the client owns (the vestigial
+	// session.RaisedHand was removed in MM-69116). Clearing an already-empty
 	// attribute is a harmless no-op.
 	//
 	// Clear the raised-hand attribute directly on the LiveKit server. This is the

--- a/server/public/call_session.go
+++ b/server/public/call_session.go
@@ -12,9 +12,6 @@ type CallSession struct {
 	CallID           string `json:"call_id"`
 	UserID           string `json:"user_id"`
 	JoinAt           int64  `json:"join_at"`
-	Unmuted          bool   `json:"unmuted"`
-	RaisedHand       int64  `json:"raised_hand"`
-	Video            bool   `json:"video"`
 	IsSIPParticipant bool   `json:"is_sip_participant,omitempty"`
 }
 

--- a/server/session.go
+++ b/server/session.go
@@ -284,8 +284,6 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		return fmt.Errorf("session not found in call state")
 	}
 
-	us := state.sessions[originalConnID]
-
 	if err := p.store.DeleteCallSession(originalConnID); err != nil {
 		return fmt.Errorf("failed to delete call session: %w", err)
 	}
@@ -307,20 +305,6 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		}
 		p.LogDebug("removed session was sharing, sending screen off event", "userID", userID, "connID", connID, "originalConnID", originalConnID)
 		p.publishWebSocketEvent(wsEventUserScreenOff, map[string]interface{}{}, &WebSocketBroadcast{
-			ChannelID:           channelID,
-			ReliableClusterSend: true,
-			UserIDs:             getUserIDsFromSessions(state.sessions),
-		})
-	}
-
-	// Check if leaving session had video on.
-	if us.Video {
-		p.LogDebug("removed session had video on, sending video off event", "userID", userID, "connID", connID, "originalConnID", originalConnID)
-		// TODO: consider tracking some stats
-		p.publishWebSocketEvent(wsEventUserVideoOff, map[string]interface{}{
-			"userID":     userID,
-			"session_id": originalConnID,
-		}, &WebSocketBroadcast{
 			ChannelID:           channelID,
 			ReliableClusterSend: true,
 			UserIDs:             getUserIDsFromSessions(state.sessions),

--- a/server/state.go
+++ b/server/state.go
@@ -80,11 +80,8 @@ func (cs *callState) Clone() *callState {
 }
 
 type UserStateClient struct {
-	SessionID  string `json:"session_id"`
-	UserID     string `json:"user_id"`
-	Unmuted    bool   `json:"unmuted"`
-	RaisedHand int64  `json:"raised_hand"`
-	Video      bool   `json:"video"`
+	SessionID string `json:"session_id"`
+	UserID    string `json:"user_id"`
 }
 
 type CallStateClient struct {
@@ -254,11 +251,8 @@ func (cs *callState) getStates(botID string) []UserStateClient {
 			continue
 		}
 		states = append(states, UserStateClient{
-			SessionID:  session.ID,
-			UserID:     session.UserID,
-			Unmuted:    session.Unmuted,
-			RaisedHand: session.RaisedHand,
-			Video:      session.Video,
+			SessionID: session.ID,
+			UserID:    session.UserID,
 		})
 	}
 	return states

--- a/server/state_test.go
+++ b/server/state_test.go
@@ -44,10 +44,9 @@ func TestCallStateGetClientState(t *testing.T) {
 			},
 			sessions: map[string]*public.CallSession{
 				"sessionA": {
-					ID:         "sessionA",
-					UserID:     "userA",
-					JoinAt:     1000,
-					RaisedHand: 1100,
+					ID:     "sessionA",
+					UserID: "userA",
+					JoinAt: 1000,
 				},
 			},
 		}
@@ -56,9 +55,8 @@ func TestCallStateGetClientState(t *testing.T) {
 			StartAt: cs.StartAt,
 			Sessions: []UserStateClient{
 				{
-					SessionID:  "sessionA",
-					UserID:     "userA",
-					RaisedHand: 1100,
+					SessionID: "sessionA",
+					UserID:    "userA",
 				},
 			},
 			ThreadID:               cs.ThreadID,
@@ -78,10 +76,9 @@ func TestCallStateGetClientState(t *testing.T) {
 			},
 			sessions: map[string]*public.CallSession{
 				"sessionA": {
-					ID:         "sessionA",
-					UserID:     "userA",
-					JoinAt:     1000,
-					RaisedHand: 1100,
+					ID:     "sessionA",
+					UserID: "userA",
+					JoinAt: 1000,
 				},
 				"botSessionID": {
 					ID:     "botSessionID",
@@ -96,9 +93,8 @@ func TestCallStateGetClientState(t *testing.T) {
 			StartAt: 100,
 			Sessions: []UserStateClient{
 				{
-					SessionID:  "sessionA",
-					UserID:     "userA",
-					RaisedHand: 1100,
+					SessionID: "sessionA",
+					UserID:    "userA",
 				},
 			},
 		}
@@ -134,19 +130,16 @@ func TestCallStateGetClientState(t *testing.T) {
 		ccs := CallStateClient{
 			Sessions: []UserStateClient{
 				{
-					SessionID:  "sessionA",
-					UserID:     "userA",
-					RaisedHand: 0,
+					SessionID: "sessionA",
+					UserID:    "userA",
 				},
 				{
-					SessionID:  "sessionB",
-					UserID:     "userA",
-					RaisedHand: 0,
+					SessionID: "sessionB",
+					UserID:    "userA",
 				},
 				{
-					SessionID:  "sessionC",
-					UserID:     "userB",
-					RaisedHand: 0,
+					SessionID: "sessionC",
+					UserID:    "userB",
 				},
 			},
 		}
@@ -171,10 +164,9 @@ func TestCallStateGetHostID(t *testing.T) {
 			},
 			sessions: map[string]*public.CallSession{
 				"sessionA": {
-					ID:         "sessionA",
-					UserID:     "userA",
-					JoinAt:     1000,
-					RaisedHand: 1100,
+					ID:     "sessionA",
+					UserID: "userA",
+					JoinAt: 1000,
 				},
 			},
 		}
@@ -190,22 +182,19 @@ func TestCallStateGetHostID(t *testing.T) {
 			},
 			sessions: map[string]*public.CallSession{
 				"sessionA": {
-					ID:         "sessionA",
-					UserID:     "userA",
-					JoinAt:     1000,
-					RaisedHand: 1100,
+					ID:     "sessionA",
+					UserID: "userA",
+					JoinAt: 1000,
 				},
 				"sessionB": {
-					ID:      "sessionB",
-					UserID:  "userB",
-					JoinAt:  800,
-					Unmuted: true,
+					ID:     "sessionB",
+					UserID: "userB",
+					JoinAt: 800,
 				},
 				"sessionC": {
-					ID:      "sessionC",
-					UserID:  "userC",
-					JoinAt:  1100,
-					Unmuted: true,
+					ID:     "sessionC",
+					UserID: "userC",
+					JoinAt: 1100,
 				},
 			},
 		}
@@ -226,22 +215,19 @@ func TestCallStateGetHostID(t *testing.T) {
 					JoinAt: 800,
 				},
 				"sessionA": {
-					ID:         "sessionA",
-					UserID:     "userA",
-					JoinAt:     1000,
-					RaisedHand: 1100,
+					ID:     "sessionA",
+					UserID: "userA",
+					JoinAt: 1000,
 				},
 				"sessionB": {
-					ID:      "sessionB",
-					UserID:  "userB",
-					JoinAt:  1100,
-					Unmuted: true,
+					ID:     "sessionB",
+					UserID: "userB",
+					JoinAt: 1100,
 				},
 				"sessionC": {
-					ID:      "sessionC",
-					UserID:  "userC",
-					JoinAt:  1200,
-					Unmuted: true,
+					ID:     "sessionC",
+					UserID: "userC",
+					JoinAt: 1200,
 				},
 			},
 		}
@@ -359,18 +345,16 @@ func TestCallStateClone(t *testing.T) {
 			},
 			sessions: map[string]*public.CallSession{
 				model.NewId(): {
-					ID:         model.NewId(),
-					CallID:     model.NewId(),
-					UserID:     model.NewId(),
-					JoinAt:     time.Now().UnixMilli(),
-					RaisedHand: time.Now().UnixMilli(),
+					ID:     model.NewId(),
+					CallID: model.NewId(),
+					UserID: model.NewId(),
+					JoinAt: time.Now().UnixMilli(),
 				},
 				model.NewId(): {
-					ID:      model.NewId(),
-					CallID:  model.NewId(),
-					UserID:  model.NewId(),
-					JoinAt:  time.Now().UnixMilli(),
-					Unmuted: true,
+					ID:     model.NewId(),
+					CallID: model.NewId(),
+					UserID: model.NewId(),
+					JoinAt: time.Now().UnixMilli(),
 				},
 				model.NewId(): {
 					ID:     model.NewId(),

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -23,17 +23,11 @@ import (
 const (
 	wsEventUserJoined                = "user_joined"
 	wsEventUserLeft                  = "user_left"
-	wsEventUserMuted                 = "user_muted"
-	wsEventUserUnmuted               = "user_unmuted"
 	wsEventUserScreenOn              = "user_screen_on"
 	wsEventUserScreenOff             = "user_screen_off"
-	wsEventUserVideoOn               = "user_video_on"
-	wsEventUserVideoOff              = "user_video_off"
 	wsEventCallStart                 = "call_start"
 	wsEventCallState                 = "call_state"
 	wsEventCallEnd                   = "call_ended"
-	wsEventUserRaiseHand             = "user_raise_hand"
-	wsEventUserUnraiseHand           = "user_unraise_hand"
 	wsEventUserReacted               = "user_reacted"
 	wsEventJoin                      = "join"
 	wsEventError                     = "error"
@@ -230,115 +224,10 @@ func (p *Plugin) handleClientMsg(us *session, msg clientMessage) error {
 	case clientMessageTypeICE:
 		// No-op: LiveKit SDK handles ICE candidates directly.
 		p.LogDebug("received ice (ignored, LiveKit handles signaling)", "connID", us.connID, "userID", us.userID)
-	case clientMessageTypeMute, clientMessageTypeUnmute:
-		// State-update-only: update DB and broadcast WS event.
-		// LiveKit SDK handles the actual media track muting on the client.
-		state, err := p.lockCallReturnState(us.channelID)
-		if err != nil {
-			return fmt.Errorf("failed to lock call: %w", err)
-		}
-		defer p.unlockCall(us.channelID)
-		if state == nil {
-			return fmt.Errorf("no call ongoing")
-		}
-		session := state.sessions[us.originalConnID]
-		if session == nil {
-			return fmt.Errorf("user state is missing from call state")
-		}
-		session.Unmuted = msg.Type == clientMessageTypeUnmute
-
-		if err := p.store.UpdateCallSession(session); err != nil {
-			return fmt.Errorf("failed to update call session: %w", err)
-		}
-
-		evType := wsEventUserUnmuted
-		if msg.Type == clientMessageTypeMute {
-			evType = wsEventUserMuted
-		}
-		p.publishWebSocketEvent(evType, map[string]interface{}{
-			"userID":     us.userID,
-			"session_id": us.originalConnID,
-		}, &WebSocketBroadcast{
-			ChannelID:           us.channelID,
-			ReliableClusterSend: true,
-			UserIDs:             getUserIDsFromSessions(state.sessions),
-		})
 	case clientMessageTypeScreenOn, clientMessageTypeScreenOff:
 		if err := p.handleClientMessageTypeScreen(us, msg); err != nil {
 			return err
 		}
-	case clientMessageTypeVideoOn, clientMessageTypeVideoOff:
-		// State-update-only: update DB and broadcast WS event.
-		// LiveKit SDK handles the actual video track on the client.
-		state, err := p.lockCallReturnState(us.channelID)
-		if err != nil {
-			return fmt.Errorf("failed to lock call: %w", err)
-		}
-		defer p.unlockCall(us.channelID)
-		if state == nil {
-			return fmt.Errorf("channel state is missing from store")
-		}
-		session := state.sessions[us.originalConnID]
-		if session == nil {
-			return fmt.Errorf("user session is missing from call state")
-		}
-		session.Video = msg.Type == clientMessageTypeVideoOn
-
-		if err := p.store.UpdateCallSession(session); err != nil {
-			return fmt.Errorf("failed to update call session: %w", err)
-		}
-
-		evType := wsEventUserVideoOn
-		if msg.Type == clientMessageTypeVideoOff {
-			evType = wsEventUserVideoOff
-		}
-		p.publishWebSocketEvent(evType, map[string]interface{}{
-			"userID":     us.userID,
-			"session_id": us.originalConnID,
-		}, &WebSocketBroadcast{
-			ChannelID:           us.channelID,
-			ReliableClusterSend: true,
-			UserIDs:             getUserIDsFromSessions(state.sessions),
-		})
-	case clientMessageTypeRaiseHand, clientMessageTypeUnraiseHand:
-		evType := wsEventUserUnraiseHand
-		if msg.Type == clientMessageTypeRaiseHand {
-			evType = wsEventUserRaiseHand
-		}
-
-		state, err := p.lockCallReturnState(us.channelID)
-		if err != nil {
-			return fmt.Errorf("failed to lock call: %w", err)
-		}
-		defer p.unlockCall(us.channelID)
-		if state == nil {
-			return fmt.Errorf("no call ongoing")
-		}
-
-		session := state.sessions[us.originalConnID]
-		if session == nil {
-			return fmt.Errorf("user session is missing from call state")
-		}
-
-		if msg.Type == clientMessageTypeRaiseHand {
-			session.RaisedHand = time.Now().UnixMilli()
-		} else {
-			session.RaisedHand = 0
-		}
-
-		if err := p.store.UpdateCallSession(session); err != nil {
-			return fmt.Errorf("failed to update call session: %w", err)
-		}
-
-		p.publishWebSocketEvent(evType, map[string]interface{}{
-			"userID":      us.userID,
-			"session_id":  us.originalConnID,
-			"raised_hand": session.RaisedHand,
-		}, &WebSocketBroadcast{
-			ChannelID:           us.channelID,
-			ReliableClusterSend: true,
-			UserIDs:             getUserIDsFromSessions(state.sessions),
-		})
 	case clientMessageTypeReact:
 		evType := wsEventUserReacted
 
@@ -1008,7 +897,7 @@ func (p *Plugin) WebSocketMessageHasBeenPosted(connID, userID string, req *model
 			return
 		}
 		msg.Data = data
-	case clientMessageTypeICE, clientMessageTypeScreenOn, clientMessageTypeVideoOn:
+	case clientMessageTypeICE, clientMessageTypeScreenOn:
 		msgData, ok := req.Data["data"].(string)
 		if !ok {
 			p.LogError("invalid or missing data")

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -538,22 +538,22 @@ func TestPublishWebSocketEvent(t *testing.T) {
 				ChannelID: callChannelID,
 			}
 
-			mockMetrics.On("IncWebSocketEvent", "out", wsEventUserMuted).Twice()
+			mockMetrics.On("IncWebSocketEvent", "out", wsEventUserScreenOn).Twice()
 
-			mockAPI.On("PublishWebSocketEvent", wsEventUserMuted, map[string]any{
+			mockAPI.On("PublishWebSocketEvent", wsEventUserScreenOn, map[string]any{
 				"channelID": callChannelID,
 			}, &model.WebsocketBroadcast{
 				UserId: botUserID,
 			}).Once()
 
-			mockAPI.On("PublishWebSocketEvent", wsEventUserMuted, map[string]any{
+			mockAPI.On("PublishWebSocketEvent", wsEventUserScreenOn, map[string]any{
 				"channelID": callChannelID,
 			}, &model.WebsocketBroadcast{
 				ChannelId: callChannelID,
 				OmitUsers: map[string]bool{botUserID: true},
 			}).Once()
 
-			p.publishWebSocketEvent(wsEventUserMuted, data, bc)
+			p.publishWebSocketEvent(wsEventUserScreenOn, data, bc)
 		})
 
 		t.Run("specified users, including bot", func(_ *testing.T) {
@@ -610,14 +610,14 @@ func TestPublishWebSocketEvent(t *testing.T) {
 			ConnectionID: "userConnID",
 		}
 
-		mockMetrics.On("IncWebSocketEvent", "out", wsEventUserMuted).Once()
-		mockAPI.On("PublishWebSocketEvent", wsEventUserMuted, map[string]any{
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventUserScreenOn).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventUserScreenOn, map[string]any{
 			"session_id": "userSessionID",
 		}, &model.WebsocketBroadcast{
 			ConnectionId: "userConnID",
 		}).Once()
 
-		p.publishWebSocketEvent(wsEventUserMuted, data, bc)
+		p.publishWebSocketEvent(wsEventUserScreenOn, data, bc)
 	})
 
 	t.Run("specified users", func(_ *testing.T) {
@@ -633,22 +633,22 @@ func TestPublishWebSocketEvent(t *testing.T) {
 				"userD",
 			},
 		}
-		mockMetrics.On("IncWebSocketEvent", "out", wsEventUserMuted).Once()
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventUserScreenOn).Once()
 
-		mockAPI.On("PublishWebSocketEvent", wsEventUserMuted, data, &model.WebsocketBroadcast{
+		mockAPI.On("PublishWebSocketEvent", wsEventUserScreenOn, data, &model.WebsocketBroadcast{
 			ChannelId: callChannelID,
 			UserId:    "userA",
 		}).Once()
-		mockAPI.On("PublishWebSocketEvent", wsEventUserMuted, data, &model.WebsocketBroadcast{
+		mockAPI.On("PublishWebSocketEvent", wsEventUserScreenOn, data, &model.WebsocketBroadcast{
 			ChannelId: callChannelID,
 			UserId:    "userC",
 		}).Once()
-		mockAPI.On("PublishWebSocketEvent", wsEventUserMuted, data, &model.WebsocketBroadcast{
+		mockAPI.On("PublishWebSocketEvent", wsEventUserScreenOn, data, &model.WebsocketBroadcast{
 			ChannelId: callChannelID,
 			UserId:    "userD",
 		}).Once()
 
-		p.publishWebSocketEvent(wsEventUserMuted, data, bc)
+		p.publishWebSocketEvent(wsEventUserScreenOn, data, bc)
 	})
 }
 
@@ -725,8 +725,8 @@ func TestWebSocketMessageHasBeenPostedUTF8Validation(t *testing.T) {
 		// Test that isValidClientMessageType recognizes all defined message types
 		validTypes := []string{
 			"join", "leave", "reconnect", "sdp", "ice",
-			"mute", "unmute", "voice_on", "voice_off",
-			"screen_on", "screen_off", "raise_hand", "unraise_hand",
+			"voice_on", "voice_off",
+			"screen_on", "screen_off",
 			"react", "caption", "metric", "call_state", "ping",
 		}
 
@@ -736,9 +736,11 @@ func TestWebSocketMessageHasBeenPostedUTF8Validation(t *testing.T) {
 			}
 		}
 
-		// Test that invalid types are rejected
+		// Test that invalid types are rejected. This includes the v1 transient-state
+		// messages removed in MM-69116 (mute/video/raise-hand now live in LiveKit).
 		invalidTypes := []string{
 			"invalid", "unknown", "hack", "exploit", "",
+			"mute", "unmute", "video_on", "video_off", "raise_hand", "unraise_hand",
 		}
 
 		for _, msgType := range invalidTypes {

--- a/standalone/src/index.ts
+++ b/standalone/src/index.ts
@@ -25,7 +25,6 @@ import {
     UserLeftData,
     UserRemovedData,
     UserScreenOnOffData,
-    UserVideoOnOffData,
     WebsocketEventData,
 } from '@mattermost/calls-common/lib/types';
 import {WebSocketMessage} from '@mattermost/client/websocket';
@@ -67,8 +66,6 @@ import {
     handleUserRemovedFromChannel,
     handleUserScreenOff,
     handleUserScreenOn,
-    handleUserVideoOff,
-    handleUserVideoOn,
 } from 'plugin/websocket_handlers';
 import {Reducer} from 'redux';
 import {CurrentCallDataDefault} from 'src/types/types';
@@ -337,12 +334,6 @@ export default async function initialiseEmbedApp(cfg: InitConfig) {
             break;
         case `custom_${pluginId}_host_removed`:
             handleHostRemoved(store, ev as WebSocketMessage<HostControlRemoved>);
-            break;
-        case `custom_${pluginId}_user_video_on`:
-            handleUserVideoOn(store, ev as WebSocketMessage<UserVideoOnOffData>);
-            break;
-        case `custom_${pluginId}_user_video_off`:
-            handleUserVideoOff(store, ev as WebSocketMessage<UserVideoOnOffData>);
             break;
         case 'user_removed':
             handleUserRemovedFromChannel(store, ev as WebSocketMessage<UserRemovedData>);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -178,14 +178,10 @@ import {
     handleUserDismissedNotification,
     handleUserJoined,
     handleUserLeft,
-    handleUserRaisedHand,
     handleUserReaction,
     handleUserRemovedFromChannel,
     handleUserScreenOff,
     handleUserScreenOn,
-    handleUserUnraisedHand,
-    handleUserVideoOff,
-    handleUserVideoOn,
 } from './websocket_handlers';
 
 export default class Plugin {
@@ -244,14 +240,6 @@ export default class Plugin {
             handleUserScreenOff(store, ev);
         });
 
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_user_raise_hand`, (ev) => {
-            handleUserRaisedHand(store, ev);
-        });
-
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_user_unraise_hand`, (ev) => {
-            handleUserUnraisedHand(store, ev);
-        });
-
         registry.registerWebSocketEventHandler(`custom_${pluginId}_user_reacted`, (ev) => {
             handleUserReaction(store, ev);
         });
@@ -294,14 +282,6 @@ export default class Plugin {
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_host_removed`, (ev) => {
             handleHostRemoved(store, ev);
-        });
-
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_user_video_on`, (ev) => {
-            handleUserVideoOn(store, ev);
-        });
-
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_user_video_off`, (ev) => {
-            handleUserVideoOff(store, ev);
         });
     }
 

--- a/webapp/src/websocket_handlers.ts
+++ b/webapp/src/websocket_handlers.ts
@@ -18,12 +18,9 @@ import {
     UserDismissedNotification,
     UserJoinedData,
     UserLeftData,
-    UserMutedUnmutedData,
-    UserRaiseUnraiseHandData,
     UserReactionData,
     UserRemovedData,
     UserScreenOnOffData,
-    UserVideoOnOffData,
     UserVoiceOnOffData,
 } from '@mattermost/calls-common/lib/types';
 import {WebSocketMessage} from '@mattermost/client/websocket';
@@ -49,7 +46,7 @@ import {
     REACTION_TIMEOUT_IN_REACTION_STREAM,
 } from 'src/constants';
 import {userScreenShared, userScreenUnshared} from 'src/state/screen_sharing_ids/actions';
-import {userLoweredHand, userMuted, userRaisedHand, userReacted, userReactedTimeout, userUnmuted} from 'src/state/session/actions';
+import {userReacted, userReactedTimeout} from 'src/state/session/actions';
 import {
     HostControlNotice,
     HostControlNoticeType,
@@ -180,20 +177,6 @@ export function handleUserJoined(store: Store, ev: WebSocketMessage<UserJoinedDa
     store.dispatch(joinUser(channelID, userID, sessionID, false));
 }
 
-// NOTE: it's important this function is kept synchronous in order to guarantee the order of
-// state mutating operations.
-export function handleUserMuted(store: Store, ev: WebSocketMessage<UserMutedUnmutedData>) {
-    const channelID = ev.data.channelID || ev.broadcast.channel_id;
-    store.dispatch(userMuted(channelID, ev.data.session_id, ev.data.userID));
-}
-
-// NOTE: it's important this function is kept synchronous in order to guarantee the order of
-// state mutating operations.
-export function handleUserUnmuted(store: Store, ev: WebSocketMessage<UserMutedUnmutedData>) {
-    const channelID = ev.data.channelID || ev.broadcast.channel_id;
-    store.dispatch(userUnmuted(channelID, ev.data.session_id, ev.data.userID));
-}
-
 export function handleUserVoiceOn(store: Store, ev: WebSocketMessage<UserVoiceOnOffData>) {
     const channelID = ev.data.channelID || ev.broadcast.channel_id;
     store.dispatch({
@@ -230,20 +213,6 @@ export function handleUserScreenOn(store: Store, ev: WebSocketMessage<UserScreen
 export function handleUserScreenOff(store: Store, ev: WebSocketMessage<UserScreenOnOffData>) {
     const channelID = ev.data.channelID || ev.broadcast.channel_id;
     store.dispatch(userScreenUnshared(channelID, ev.data.session_id, ev.data.userID));
-}
-
-// NOTE: it's important this function is kept synchronous in order to guarantee the order of
-// state mutating operations.
-export function handleUserRaisedHand(store: Store, ev: WebSocketMessage<UserRaiseUnraiseHandData>) {
-    const channelID = ev.data.channelID || ev.broadcast.channel_id;
-    store.dispatch(userRaisedHand(channelID, ev.data.session_id, ev.data.userID, ev.data.raised_hand));
-}
-
-// NOTE: it's important this function is kept synchronous in order to guarantee the order of
-// state mutating operations.
-export function handleUserUnraisedHand(store: Store, ev: WebSocketMessage<UserRaiseUnraiseHandData>) {
-    const channelID = ev.data.channelID || ev.broadcast.channel_id;
-    store.dispatch(userLoweredHand(channelID, ev.data.session_id, ev.data.userID));
 }
 
 // dispatchReaction stores a reaction (with the sender's display name resolved from the
@@ -525,28 +494,4 @@ export function handleHostRemoved(store: Store, ev: WebSocketMessage<HostControl
             },
         });
     }, HOST_CONTROL_NOTICE_TIMEOUT);
-}
-
-export function handleUserVideoOn(store: Store, ev: WebSocketMessage<UserVideoOnOffData>) {
-    const channelID = ev.data.channelID || ev.broadcast.channel_id;
-    store.dispatch({
-        type: 'USER_VIDEO_ON',
-        data: {
-            channelID,
-            userID: ev.data.userID,
-            session_id: ev.data.session_id,
-        },
-    });
-}
-
-export function handleUserVideoOff(store: Store, ev: WebSocketMessage<UserVideoOnOffData>) {
-    const channelID = ev.data.channelID || ev.broadcast.channel_id;
-    store.dispatch({
-        type: 'USER_VIDEO_OFF',
-        data: {
-            channelID,
-            userID: ev.data.userID,
-            session_id: ev.data.session_id,
-        },
-    });
 }


### PR DESCRIPTION
## Summary

LiveKit (v2) is authoritative for transient per-participant state, but the v1 server plumbing for mute / raised-hand / video was left in place and orphaned: `CallClient` no longer round-trips that state to the plugin, so the server DB fields were never updated and the `call_state` snapshot served stale values. This removes the dead plumbing rather than adding another broadcast.

This is **Phase 1** of MM-69116: code-only removal. The DB columns are intentionally **kept** — see migration note below.

The host-control half of the original observer-sync fix already landed separately under MM-69107 (#1209); this PR is the server-side vestigial-state cleanup, plus the matching dead client-side WS handlers.

## Changes

**Server**
- Drop `Unmuted` / `RaisedHand` / `Video` from `public.CallSession` and from the store INSERT/SELECT/Scan (columns retained physically).
- Delete `UpdateCallSession` (it only ever wrote those three fields).
- Remove the three fields from `UserStateClient` / `getStates`; `call_state` now carries structural state only.
- Delete the inbound mute/unmute/video/raise-hand WS handlers and the now-unused `user_muted` / `user_unmuted` / `user_video_on` / `user_video_off` / `user_raise_hand` / `user_unraise_hand` events.
- Remove the six dead `clientMessageType*` constants + validity entries and the `video_on` data-extraction case.
- Remove the dead video-off-on-leave broadcast.
- Refresh `host_controls.go` comments that described the (now removed) fields as vestigial.

**Webapp / standalone**
- Remove the dead WS event registrations and handler functions for the six events.
- The mute/raised-hand Redux paths stay, fed solely by LiveKit `CALL_EVENT.*`. The widget's local-only `USER_VIDEO_ON/OFF` dispatch (driven by the `callsClient` video event, not WS) is unchanged.

## Migration note (why the columns stay)

Dropping `unmuted`/`raisedhand`/`video` in the same release that stops using them breaks **rollback** (a downgraded plugin still references the columns; `morph` never auto-runs down migrations) and the **rolling-upgrade window** (old + new nodes share one DB). Phase 1 keeps the columns physically present (nullable; subset-INSERTs are fine) and only stops referencing them. **Phase 2** (separate follow-up ticket, a later release) adds the drop migration once the Phase 1 rollback window closes.

## Testing

- `go build`, `go vet`, `gofmt` clean; server unit tests for the touched code pass.
- Acceptance is the manual two-user repro (observer's UI updates from LiveKit within ~1s of a host mute). Automated E2E for the quarantined host-control tests is owned by MM-69158.