### PR TITLE
[MM-69552] Configure LiveKit to send webhooks in local dev and CI

### DIFF
--- a/e2e/docker/livekit.yaml
+++ b/e2e/docker/livekit.yaml
@@ -19,5 +19,16 @@ keys:
   # Used by the SIP bridge (the shared ../../sip.yaml). A second pair on the same
   # server lets the bridge config stay byte-identical to the dev compose's.
   devkey: this-is-a-32-plus-character-dev-secret
+# LiveKit POSTs participant lifecycle events to the plugin's webhook receiver,
+# signed with the secret for `api_key` below. This must be the key the plugin
+# verifies with — devkey_for_livekit_e2e_ci_tests (MM_CALLS_LIVE_KIT_API_KEY in
+# .github/workflows/e2e.yml) — NOT the bridge's `devkey`. `mm-server` is the
+# haproxy alias for the Mattermost nodes in the compose network (nginx.conf);
+# the webhook carries no auth cookie, but the handler is DB/cluster-lock backed
+# so consistent-hash routing to either node handles it correctly.
+webhook:
+  api_key: devkey_for_livekit_e2e_ci_tests
+  urls:
+    - http://mm-server:8065/plugins/com.mattermost.calls/livekit-webhook
 logging:
   level: info

--- a/livekit-sip.yaml
+++ b/livekit-sip.yaml
@@ -16,5 +16,12 @@ redis:
   address: redis:6379
 keys:
   devkey: this-is-a-32-plus-character-dev-secret
+# See livekit.yaml for how this drives the plugin's webhook receiver and why the
+# URL uses host.docker.internal. participant_left is what ends an outbound-SIP
+# call on phone-hangup / last-human-leave, so the SIP dev path needs it.
+webhook:
+  api_key: devkey
+  urls:
+    - http://host.docker.internal:8065/plugins/com.mattermost.calls/livekit-webhook
 logging:
   level: info

--- a/livekit.yaml
+++ b/livekit.yaml
@@ -7,5 +7,16 @@ rtc:
   use_ice_lite: true
 keys:
   devkey: this-is-a-32-plus-character-dev-secret
+# LiveKit POSTs participant/room lifecycle events to the plugin's webhook
+# receiver (server/api.go handleLiveKitWebhook), signed with the secret for
+# `api_key` below — which must name a key in `keys:` (the plugin verifies with
+# the same key/secret). `host.docker.internal` resolves from inside the
+# container to the host running `make run-server` (Docker Desktop on macOS); on
+# plain Linux Docker add `extra_hosts: ["host.docker.internal:host-gateway"]`
+# or use the host LAN IP (the same one passed as LIVEKIT_NODE_IP).
+webhook:
+  api_key: devkey
+  urls:
+    - http://host.docker.internal:8065/plugins/com.mattermost.calls/livekit-webhook
 logging:
   level: info


### PR DESCRIPTION
## Summary

The plugin has a working LiveKit webhook receiver — `handleLiveKitWebhook` (`server/api.go`), routed at `POST /plugins/com.mattermost.calls/livekit-webhook` — that verifies the signature with `LiveKitAPIKey`/`LiveKitAPISecret` and handles `participant_joined`/`participant_left` (these drive SIP session tracking and outbound-SIP teardown). But none of the LiveKit configs had a `webhook:` block, so in local dev and CI LiveKit never emitted those events — the SIP join/leave and teardown paths couldn't be exercised end to end.

This adds a `webhook:` block to each config, pointing at the plugin endpoint and signed with a key the plugin verifies:

| Config | URL | `api_key` |
|---|---|---|
| `livekit.yaml` (local dev) | `http://host.docker.internal:8065/...` | `devkey` |
| `livekit-sip.yaml` (local SIP dev) | `http://host.docker.internal:8065/...` | `devkey` |
| `e2e/docker/livekit.yaml` (CI) | `http://mm-server:8065/...` | `devkey_for_livekit_e2e_ci_tests` |

The CI key must be the one the plugin verifies with (`MM_CALLS_LIVE_KIT_API_KEY` in `.github/workflows/e2e.yml`), **not** the SIP bridge's `devkey` — called out in an inline comment. URL resolution (container → Mattermost host) is documented inline in each file: `host.docker.internal` for local dev (with the Linux `host-gateway`/LAN-IP fallback noted), and the `mm-server` haproxy alias for the CI compose network.

## Testing

Verified locally with an isolated LiveKit v1.13.1 container running the edited `livekit.yaml` and a listener on `:8065` that replicates the plugin's signature check (HS256 over the JWT with `devkey`'s secret, `iss` match, body-sha256 match):

- LiveKit boots cleanly with the new `webhook:` block.
- A joined/left participant produces `participant_joined` and `participant_left` POSTs to `host.docker.internal:8065/plugins/com.mattermost.calls/livekit-webhook`, both signature-verified — i.e. the plugin would accept them (200, not 403).

The CI config uses the same webhook schema; the definitive check is the SIP e2e (`e2e/tests/sip_smoke.spec.ts`) on this branch.

## Ticket

https://mattermost.atlassian.net/browse/MM-69552