### PR TITLE
[MM-69584] Fix SIP-teardown unit tests broken by MM-69195 getBotID change

### DIFF
--- a/server/api_livekit_webhook_test.go
+++ b/server/api_livekit_webhook_test.go
@@ -412,6 +412,7 @@ func TestHandleLiveKitSIPParticipant(t *testing.T) {
 
 		botID := model.NewId()
 		p.botSession = &model.Session{UserId: botID}
+		p.botID = botID // getBotID reads p.botID, not botSession
 
 		channelID := model.NewId()
 		postID := model.NewId()
@@ -463,6 +464,7 @@ func TestHandleLiveKitSIPParticipant(t *testing.T) {
 
 		botID := model.NewId()
 		p.botSession = &model.Session{UserId: botID}
+		p.botID = botID // getBotID reads p.botID, not botSession
 
 		channelID := model.NewId()
 		postID := model.NewId()

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -182,6 +182,7 @@ func TestRemoveUserSessionPhoneCall(t *testing.T) {
 		metrics:           mockMetrics,
 		configuration:     &configuration{}, // no LiveKitURL: livekitDeleteRoom is a no-op
 		botSession:        &model.Session{UserId: botID},
+		botID:             botID, // getBotID reads p.botID, not botSession
 		sessions:          map[string]*session{},
 	}
 	p.licenseChecker = enterprise.NewLicenseChecker(p.API)


### PR DESCRIPTION
## Summary

`plugin-ci / test` and `code-coverage` are red on every PR based on current `v2`. Three server tests fail:

- `TestRemoveUserSessionPhoneCall`
- `TestHandleLiveKitSIPParticipant` / `…/last_SIP_participant_left_in_bot_DM_ends_the_phone_call`

Bisected on `v2`: the tests were added by MM-69251 (`b884d58a`, #1230) and pass there; they first fail at MM-69195 (`c4b49ddd`, #1233).

## Root cause

MM-69195 changed `getBotID()` (`server/bot_api.go`) from `return p.botSession.UserId` to `return p.botID`. These tests set up the bot via `p.botSession = &model.Session{UserId: botID}` but never set `p.botID`, so post-#1233 `getBotID()` returns `""` in the tests. The bot channel-member is no longer recognized, so the "last human/SIP participant left → end phone call → drop SIP" teardown never fires: `state.sessions` stays non-empty and `Call.EndAt` stays 0.

**Production is unaffected** — `p.botID` is set at activation (`createBotSession`). This is a stale-test fixture only. It slipped through because #1233 was authored before #1230's tests existed and merged with stale green checks, so its CI never ran the new SIP-teardown tests against the `getBotID()` change.

## Fix

Set `p.botID = botID` alongside the existing `botSession` in the three test setups (`session_test.go`, two subtests in `api_livekit_webhook_test.go`). Verified: `go test -run 'TestRemoveUserSessionPhoneCall|TestHandleLiveKitSIPParticipant'` passes at `v2` HEAD.

## Ticket

https://mattermost.atlassian.net/browse/MM-69584