### PR TITLE
[MM-68131] Limit decompressed SDP payload size to prevent zip-bomb DoS

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -27,6 +27,9 @@ import (
 
 const (
 	channelNameMaxLength = 24
+	// sdpDataMaxSize is the maximum allowed size of a decompressed SDP payload.
+	// Legitimate SDP offers/answers are a few KB; 64 KB is a generous upper bound.
+	sdpDataMaxSize = 64 * 1024
 )
 
 // filenameSanitizationRE matches any character NOT in the allowlist.
@@ -99,9 +102,12 @@ func unpackSDPData(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reader: %w", err)
 	}
-	unpacked, err := io.ReadAll(rd)
+	unpacked, err := io.ReadAll(io.LimitReader(rd, sdpDataMaxSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read data: %w", err)
+	}
+	if len(unpacked) > sdpDataMaxSize {
+		return nil, fmt.Errorf("decompressed SDP data exceeds maximum allowed size")
 	}
 	return unpacked, nil
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -4,7 +4,10 @@
 package main
 
 import (
+	"bytes"
+	"compress/zlib"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-plugin-calls/server/public"
@@ -14,6 +17,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func zlibCompress(data []byte) []byte {
+	var buf bytes.Buffer
+	w := zlib.NewWriter(&buf)
+	_, _ = w.Write(data)
+	_ = w.Close()
+	return buf.Bytes()
+}
 
 func TestCheckMinVersion(t *testing.T) {
 	tcs := []struct {
@@ -249,6 +260,40 @@ func TestPlugin_canSendPushNotifications(t *testing.T) {
 			assert.Equalf(t, tt.want, p.canSendPushNotifications(tt.config, tt.license), "test: %s", tt.name)
 		})
 	}
+}
+
+func TestUnpackSDPData(t *testing.T) {
+	t.Run("valid small payload", func(t *testing.T) {
+		payload := []byte("v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\n")
+		unpacked, err := unpackSDPData(zlibCompress(payload))
+		require.NoError(t, err)
+		require.Equal(t, payload, unpacked)
+	})
+
+	t.Run("invalid zlib data", func(t *testing.T) {
+		_, err := unpackSDPData([]byte("not zlib data"))
+		require.Error(t, err)
+	})
+
+	t.Run("payload at exact limit passes", func(t *testing.T) {
+		payload := []byte(strings.Repeat("a", sdpDataMaxSize))
+		unpacked, err := unpackSDPData(zlibCompress(payload))
+		require.NoError(t, err)
+		require.Equal(t, sdpDataMaxSize, len(unpacked))
+	})
+
+	t.Run("payload exceeding limit rejected", func(t *testing.T) {
+		payload := []byte(strings.Repeat("a", sdpDataMaxSize+1))
+		_, err := unpackSDPData(zlibCompress(payload))
+		require.ErrorContains(t, err, "exceeds maximum allowed size")
+	})
+
+	t.Run("bomb payload rejected", func(t *testing.T) {
+		// Highly compressible data simulating a zip-bomb style attack.
+		payload := []byte(strings.Repeat("A", 1024*1024))
+		_, err := unpackSDPData(zlibCompress(payload))
+		require.ErrorContains(t, err, "exceeds maximum allowed size")
+	})
 }
 
 func TestGetUserIDsFromSessions(t *testing.T) {


### PR DESCRIPTION
## Summary

- `unpackSDPData` in `server/utils.go` used `io.ReadAll` with no size bound, allowing an authenticated user to send a crafted zlib-compressed SDP message that decompresses to an arbitrarily large payload and exhausts server memory.
- Fix: wrap the zlib reader in `io.LimitReader(rd, 64KB+1)` and return an error if the decompressed size exceeds 64 KB. Legitimate SDP offers/answers are a few KB; 64 KB is a generous ceiling.
- Adds `TestUnpackSDPData` covering: valid payload, invalid zlib, exact-limit pass, limit+1 rejection, and a 1 MB compressible bomb.

## Test plan

- [ ] `go test ./server/ -run TestUnpackSDPData` passes (all 5 subtests)
- [ ] Verify normal calls (audio/video/screen share) are unaffected
- [ ] Verify the PoC from MM-68131 no longer crashes the server