### PR TITLE
[MM-69655] Fix Desktop call-post showing stale "Join" after websocket reconnect

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1066,6 +1066,7 @@ export default class Plugin {
                 // eslint-disable-next-line max-nested-callbacks
                 this.registerReconnectHandler(registry, store, () => {
                     logDebug('websocket reconnect handler');
+
                     // On Desktop, callsClient lives in the widget renderer so getCallsClient()
                     // is always falsy in the main-window renderer. Guard on channelIDForCurrentCall
                     // too so we don't wipe clientStateReducer while a call is active.

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1066,7 +1066,10 @@ export default class Plugin {
                 // eslint-disable-next-line max-nested-callbacks
                 this.registerReconnectHandler(registry, store, () => {
                     logDebug('websocket reconnect handler');
-                    if (!getCallsClient()) {
+                    // On Desktop, callsClient lives in the widget renderer so getCallsClient()
+                    // is always falsy in the main-window renderer. Guard on channelIDForCurrentCall
+                    // too so we don't wipe clientStateReducer while a call is active.
+                    if (!getCallsClient() && !channelIDForCurrentCall(store.getState())) {
                         logDebug('resetting state');
                         store.dispatch(unInitialized());
                     }


### PR DESCRIPTION
## Summary

On Desktop, `callsClient` lives in the widget renderer, so `getCallsClient()` is always falsy in the main-window renderer. The websocket reconnect handler's existing guard (`!getCallsClient()`) therefore always evaluated true and dispatched `unInitialized()`, wiping `clientStateReducer` and flipping the channel call-post card from "Leave" to "Join" while the call was still live.

The fix adds `channelIDForCurrentCall` to the guard so the reset is skipped when we believe we're connected. `onActivate` still runs and requests fresh call state via websocket as usual.

```js
// Before
if (!getCallsClient()) {

// After
if (!getCallsClient() && !channelIDForCurrentCall(store.getState())) {
```

Side effects beyond the stale label: after the wipe the "Join" button threw (`callID` undefined), the channel-header "Leave" control vanished (gated on `channelIDForCurrentCall`), and the host's "End call for everyone" became a no-op — only the widget's plain "Leave" survived.

## Test plan

- [ ] Desktop app: join a call in a channel, confirm post shows "Leave"
- [ ] Force a websocket reconnect via DevTools console (see [repro steps in MM-69655](https://mattermost.atlassian.net/browse/MM-69655))
- [ ] Confirm post still shows "Leave" after reconnect and audio is unaffected
- [ ] Confirm "Leave" and host "End call" still work post-reconnect
- [ ] Non-Desktop (browser): join a call, trigger reconnect, confirm no regression