### PR TITLE
[MM-69670] Guard join flow against concurrent re-entry

### DIFF
--- a/webapp/src/components/channel_header_button.tsx
+++ b/webapp/src/components/channel_header_button.tsx
@@ -71,7 +71,7 @@ const ChannelHeaderButton = () => {
         <CallButton
             id='calls-join-button'
             className={'style--none call-button ' + (inCall || restricted ? 'disabled' : '')}
-            disabled={isChannelArchived || isDeactivatedDM}
+            disabled={isChannelArchived || isDeactivatedDM || isClientConnecting}
             $restricted={restricted}
             $isCloudPaid={isCloudPaid}
             $isClientConnecting={isClientConnecting}

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -139,6 +139,7 @@ import {
     callStartAtForCallInChannel,
     channelHasCall,
     channelIDForCurrentCall,
+    clientConnecting,
     defaultEnabled,
     hasPermissionsToEnableCalls,
     hostIDForCallInChannel,
@@ -411,6 +412,9 @@ export default class Plugin {
         });
 
         const connectToCall = async (channelId: string, teamId?: string, title?: string, rootId?: string) => {
+            if (clientConnecting(store.getState())) {
+                return;
+            }
             if (!channelIDForCurrentCall(store.getState())) {
                 connectCall(channelId, title, rootId);
 


### PR DESCRIPTION
## Summary

Clicking \"Join call\" while a previous join is still in flight (slow/flaky connection) starts another join flow — there's no re-entrancy guard. The guard that exists keys off `channelIDForCurrentCall`, which isn't set until a join completes, so during the in-flight window repeated clicks all pass and can produce orphaned server sessions.

- Add an early-return to `connectToCall` when `clientConnecting(state)` is true. The connecting flag is already set by `connectCall` at the start of each join attempt, but nothing was using it to gate re-entry.
- Also make the channel header button HTML-`disabled` (not just visually styled with a spinner) while `isClientConnecting`, so click events are blocked at the source.

The two changes form a defense-in-depth: the button can't dispatch a click while connecting, and if a click does get through (slash command or another entry point), `connectToCall` drops it immediately.

## Test plan

- [ ] Rapid-click the Join button on a slow connection — second click is suppressed, button is disabled
- [ ] Button shows "Joining call…" spinner and is unclickable during the in-flight window
- [ ] Normal join flow (single click) still works
- [ ] Slash command `/call join` still works