### PR TITLE
[MM-69654] Fix /call logs from expanded-view popout

### DIFF
--- a/webapp/src/log.ts
+++ b/webapp/src/log.ts
@@ -17,6 +17,18 @@ let clientLogs = '';
 // usually more useful, entries. Strings and Error stacks are not capped.
 const maxObjectLogLength = 256;
 
+// Flush the in-memory buffer to storage once it exceeds this size. Keeps
+// memory bounded between calls and during plugin-inactive periods when the
+// window error/unhandledrejection listeners are still writing to the buffer.
+// String .length is O(1) in JS so this check is cheap on every write.
+const maxInMemoryLogSize = 50 * 1024;
+
+function maybeFlush() {
+    if (clientLogs.length > maxInMemoryLogSize) {
+        flushLogsToAccumulated();
+    }
+}
+
 function stringifyLogArg(arg: unknown): string {
     if (typeof arg === 'string') {
         return arg;
@@ -37,6 +49,7 @@ function stringifyLogArg(arg: unknown): string {
 // opener's buffer rather than persisting separately.
 function appendLogLine(line: string) {
     clientLogs += line;
+    maybeFlush();
 }
 
 function appendClientLog(level: string, ...args: unknown[]) {
@@ -64,6 +77,7 @@ function appendClientLog(level: string, ...args: unknown[]) {
     }
 
     clientLogs += line;
+    maybeFlush();
 }
 
 // Expose this realm's appender and flush+getter so an expanded-view popout can

--- a/webapp/src/log.ts
+++ b/webapp/src/log.ts
@@ -66,10 +66,29 @@ function appendClientLog(level: string, ...args: unknown[]) {
     clientLogs += line;
 }
 
-// Expose this realm's appender so an expanded-view popout can write its logs
-// through to this (the opener's) buffer via window.opener.
+// Expose this realm's appender and flush+getter so an expanded-view popout can
+// write logs through to (and read them back from) the opener's realm.
 if (typeof window !== 'undefined') {
     window.callsClientLogAppend = appendLogLine;
+    window.callsClientFlushAndGetLogs = flushAndGetLogs;
+
+    // Wire uncaught JS errors and unhandled promise rejections into the client-
+    // log buffer. Without this, exceptions that crash a handler go only to
+    // console.error and never appear in /call logs uploads.
+    window.addEventListener('error', (event: ErrorEvent) => {
+        const {message, filename, lineno, colno, error} = event;
+        const errStr = error instanceof Error ?
+            (error.stack || `${error.name}: ${error.message}`) :
+            String(error || message);
+        appendClientLog('error', `[uncaught] ${errStr} (${filename}:${lineno}:${colno})`);
+    });
+
+    window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+        const reason = event.reason instanceof Error ?
+            (event.reason.stack || `${event.reason.name}: ${event.reason.message}`) :
+            String(event.reason);
+        appendClientLog('error', `[unhandledrejection] ${reason}`);
+    });
 }
 
 export function flushLogsToAccumulated(stats?: CallsClientStats | null) {
@@ -131,6 +150,14 @@ export function persistClientLogs() {
 
 export function getClientLogs() {
     return getPersistentStorage().getItem(STORAGE_CALLS_CLIENT_LOGS_KEY) || '';
+}
+
+// Flushes this realm's in-memory buffer to storage and returns the full
+// accumulated log string. Exposed on `window` so a popout can delegate the
+// entire flush+read to its opener's realm in one call.
+export function flushAndGetLogs(): string {
+    flushLogsToAccumulated();
+    return getClientLogs();
 }
 
 export function logErr(...args: unknown[]) {

--- a/webapp/src/slash_commands.tsx
+++ b/webapp/src/slash_commands.tsx
@@ -23,7 +23,7 @@ import {
 } from 'src/constants';
 import {modals} from 'src/webapp_globals';
 
-import {flushLogsToAccumulated, getClientLogs, logDebug} from './log';
+import {flushAndGetLogs, logDebug} from './log';
 import {
     areGroupCallsAllowed,
     channelHasCall,
@@ -176,8 +176,24 @@ export default async function slashCommandsHandler(store: Store, joinCall: joinC
         return {message: `/call stats ${btoa(data)}`, args};
     }
     case 'logs': {
-        flushLogsToAccumulated();
-        const allLogs = getClientLogs();
+        // When running in the expanded-view popout, delegate flush+read to the
+        // opener's realm. The popout's own in-memory buffer is ~empty (every
+        // appended line is forwarded to opener.callsClientLogAppend), and on
+        // web sessionStorage is per-window so a local read would miss the
+        // opener's accumulated logs entirely.
+        let allLogs: string;
+        try {
+            const opener = window.opener as Window | null;
+            if (opener && opener !== window && typeof opener.callsClientFlushAndGetLogs === 'function') {
+                allLogs = opener.callsClientFlushAndGetLogs();
+            } else {
+                allLogs = flushAndGetLogs();
+            }
+        } catch {
+            // Cross-origin opener (SecurityError) or missing function — fall
+            // back to the local realm.
+            allLogs = flushAndGetLogs();
+        }
 
         if (!allLogs || allLogs.trim().length === 0) {
             return {error: {message: 'No call logs available'}};

--- a/webapp/src/types/global.d.ts
+++ b/webapp/src/types/global.d.ts
@@ -16,6 +16,11 @@ declare global {
         // buffer. Exposed so the expanded-view popout can write through to its
         // opener's buffer (single source of truth). See src/log.ts.
         callsClientLogAppend?: (line: string) => void,
+
+        // Flushes this realm's in-memory buffer to storage and returns the full
+        // accumulated log string. Exposed so a popout can delegate /call logs
+        // flush+read to the opener's realm in one call. See src/log.ts.
+        callsClientFlushAndGetLogs?: () => string,
         webkitAudioContext: AudioContext,
         basename: string,
         desktop?: {


### PR DESCRIPTION
## Summary

- Exposes `window.callsClientFlushAndGetLogs()` on the main window — combines flush + read in a single cross-window call, mirroring the existing `callsClientLogAppend` pattern.
- In the `/call logs` handler, detects when running in the popout and delegates the entire flush+read to `window.opener.callsClientFlushAndGetLogs()` instead of operating on the popout's own (nearly empty) buffer and isolated `sessionStorage`.
- Wires `window.addEventListener('error')` and `window.addEventListener('unhandledrejection')` into the calls log buffer in both realms, so uncaught exceptions and rejected promises appear in `/call logs` uploads.

## Root cause

`/call logs` called `flushLogsToAccumulated()` + `getClientLogs()` in the current realm. In the popout:
1. The popout's in-memory `clientLogs` is ~empty — every line is forwarded to `opener.callsClientLogAppend()` and the popout's own buffer is skipped.
2. On web, `getPersistentStorage()` returns `sessionStorage`, which is **not shared** between windows, so the popout's read sees a store that never received the opener's logs.

## Test plan

- [ ] Join a call on web (Firefox or Chrome), open the expanded view popout, run `/call logs` from the popout's chat panel — verify the uploaded file contains full session logs
- [ ] Run `/call logs` from the main window — verify output is identical (same accumulated logs)
- [ ] Trigger an uncaught JS error in the calls plugin (e.g. via devtools) — verify it appears in the next `/call logs` upload
- [ ] Verify no regression on Desktop: `/call logs` from main window still works, and running it from the popout also returns full logs

Note: I ran these tests locally with Safari and Desktop, "/call logs" works from popout channel (log post appears in main thread), and unhandled rejections and uncaught exceptions are both logged.
 
Fixes https://mattermost.atlassian.net/browse/MM-69654