### PR TITLE
[MM-69672] Send leave when LiveKit join fails during WS reconnect

### DIFF
--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -135,6 +135,7 @@ type MockWebSocketClient = {
     sendJoin: jest.Mock;
     sendReconnect: jest.Mock;
     sendLeave: jest.Mock;
+    sendLeaveAndClose: jest.Mock;
     sendScreenOn: jest.Mock;
     sendScreenOff: jest.Mock;
     close: jest.Mock;
@@ -154,6 +155,7 @@ function createMockWebSocketClient(): MockWebSocketClient {
         sendJoin: jest.fn(),
         sendReconnect: jest.fn(),
         sendLeave: jest.fn(),
+        sendLeaveAndClose: jest.fn(),
         sendScreenOn: jest.fn(),
         sendScreenOff: jest.fn(),
         close: jest.fn(),
@@ -342,7 +344,7 @@ describe('CallClient', () => {
             // Teardown is driven by the resulting RoomEvent.Disconnected, not synchronously here.
             mockRoom.fire(RoomEvent.Disconnected);
             expect(client.isDisconnected).toBe(true);
-            expect(mockWebSocketClient.sendLeave).toHaveBeenCalled();
+            expect(mockWebSocketClient.sendLeaveAndClose).toHaveBeenCalled();
             expect(disconnectedListener).toHaveBeenCalled();
         });
 
@@ -506,8 +508,7 @@ describe('CallClient', () => {
 
             expect(mockRoom.disconnect).not.toHaveBeenCalled();
             expect(client.isDisconnected).toBe(true);
-            expect(mockWebSocketClient.sendLeave).toHaveBeenCalled();
-            expect(mockWebSocketClient.close).toHaveBeenCalled();
+            expect(mockWebSocketClient.sendLeaveAndClose).toHaveBeenCalled();
             expect(disconnectedListener).toHaveBeenCalled();
         });
 

--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -134,7 +134,6 @@ type MockWebSocketClient = {
     ready: jest.Mock;
     sendJoin: jest.Mock;
     sendReconnect: jest.Mock;
-    sendLeave: jest.Mock;
     sendLeaveAndClose: jest.Mock;
     sendScreenOn: jest.Mock;
     sendScreenOff: jest.Mock;
@@ -154,7 +153,6 @@ function createMockWebSocketClient(): MockWebSocketClient {
         ready: jest.fn().mockResolvedValue('orig-conn-id'),
         sendJoin: jest.fn(),
         sendReconnect: jest.fn(),
-        sendLeave: jest.fn(),
         sendLeaveAndClose: jest.fn(),
         sendScreenOn: jest.fn(),
         sendScreenOff: jest.fn(),

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -302,8 +302,7 @@ export default class CallClient extends EventEmitter {
 
             // The plugin WS is already open and the join was sent, so tell the server we're
             // leaving before closing — otherwise it keeps the session until its own timeout.
-            this.websocketClient?.sendLeave();
-            this.websocketClient?.close();
+            this.websocketClient?.sendLeaveAndClose();
             this.websocketClient = null;
 
             this.emit(CALL_EVENT.ERROR, err);
@@ -341,8 +340,7 @@ export default class CallClient extends EventEmitter {
 
             // The plugin WS is already open and the join was sent, so tell the server we're
             // leaving before closing — otherwise it keeps the session until its own timeout.
-            this.websocketClient?.sendLeave();
-            this.websocketClient?.close();
+            this.websocketClient?.sendLeaveAndClose();
             this.websocketClient = null;
 
             this.emit(CALL_EVENT.ERROR, err);
@@ -798,7 +796,6 @@ export default class CallClient extends EventEmitter {
         }
         case WebSocketErrorType.ReconnectTimeout: {
             logErr('CallClient: pluginWS reconnect timed out, disconnecting', err);
-            this.websocketClient = null;
             this.emit(CALL_EVENT.ERROR, err);
             this.disconnect();
             break;
@@ -972,8 +969,7 @@ export default class CallClient extends EventEmitter {
 
         if (this.websocketClient) {
             try {
-                this.websocketClient.sendLeave();
-                this.websocketClient.close();
+                this.websocketClient.sendLeaveAndClose();
             } catch (error) {
                 logErr('CallClient: pluginWS teardown error', error);
             } finally {

--- a/webapp/src/clients/websocket/websocket_client.test.ts
+++ b/webapp/src/clients/websocket/websocket_client.test.ts
@@ -509,4 +509,66 @@ describe('WebSocketClient', () => {
             expect(client.getOriginalConnID()).toBe('test-conn-id');
         });
     });
+
+    describe('sendLeaveAndClose', () => {
+        it('sends leave immediately and closes when WS is OPEN', () => {
+            mockWebSocket.readyState = WebSocket.OPEN;
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+            const closeSpy = jest.spyOn(mockWebSocket, 'close');
+
+            client.sendLeaveAndClose();
+
+            expect(sendSpy).toHaveBeenCalledWith(
+                expect.stringContaining('"action":"custom_com.mattermost.calls_leave"'),
+            );
+            expect(closeSpy).toHaveBeenCalled();
+            expect((client as any).closed).toBe(true);
+        });
+
+        it('defers leave until the pending reconnect opens when WS is CONNECTING', () => {
+            // Establish initial connection so originalConnID is set (needed for reconnect path).
+            mockWebSocket.readyState = WebSocket.OPEN;
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify({event: 'hello', data: {connection_id: 'conn-1'}, seq: 1}),
+            }));
+
+            // Simulate WS drop → reconnect in progress: close WS1, which triggers
+            // closeHandler → reconnect(). A new WS (WS2) is now CONNECTING.
+            (client as any).ws.onclose = null; // prevent default close handler
+            mockWebSocket.readyState = WebSocket.CLOSED;
+            (client as any).lastDisconnect = 0;
+            (client as any).connect(true); // starts WS2 in CONNECTING state
+            const ws2 = (client as any).ws as typeof mockWebSocket;
+            expect(ws2.readyState).toBe(WebSocket.CONNECTING);
+
+            const sendSpy = jest.spyOn(ws2, 'send');
+            const closeSpy = jest.spyOn(ws2, 'close');
+
+            client.sendLeaveAndClose();
+
+            // Nothing sent yet — WS2 hasn't opened.
+            expect(sendSpy).not.toHaveBeenCalled();
+            expect(closeSpy).not.toHaveBeenCalled();
+
+            // `closed` is set immediately to stop further reconnect attempts.
+            expect((client as any).closed).toBe(true);
+
+            // Simulate WS2 opening (reconnect succeeds). The isReconnect path emits
+            // 'open' directly from ws.onopen, which fires our once('open') listener.
+            ws2.readyState = WebSocket.OPEN;
+            ws2.onopen!(new Event('open'));
+
+            // Leave sent and WS closed synchronously within the open handler.
+            expect(sendSpy).toHaveBeenCalledWith(
+                expect.stringContaining('"action":"custom_com.mattermost.calls_leave"'),
+            );
+            expect(closeSpy).toHaveBeenCalled();
+        });
+
+        it('calls close for cleanup without throwing when already closed', () => {
+            client.close();
+
+            expect(() => client.sendLeaveAndClose()).not.toThrow();
+        });
+    });
 });

--- a/webapp/src/clients/websocket/websocket_client.ts
+++ b/webapp/src/clients/websocket/websocket_client.ts
@@ -196,6 +196,34 @@ export class WebSocketClient extends EventEmitter {
         this.send('leave');
     }
 
+    /**
+     * Sends a leave message and closes the connection. When the WS is
+     * reconnecting (CONNECTING state), queues the leave to fire as soon as
+     * the pending connection opens before closing. This prevents a ~100s
+     * server-side session orphan when LiveKit fails while the plugin WS is
+     * mid-reconnect and sendLeave() would otherwise be silently dropped.
+     */
+    public sendLeaveAndClose() {
+        if (this.ws?.readyState === WebSocket.OPEN) {
+            this.send('leave');
+            this.close();
+            return;
+        }
+        if (this.closed) {
+            this.close();
+            return;
+        }
+
+        // WS is reconnecting. Stop further reconnect attempts, then queue
+        // leave+cleanup for when the current connection attempt opens.
+        this.closed = true;
+        this.once('open', () => {
+            this.send('leave');
+            this.ws?.close();
+            this.ws = null;
+        });
+    }
+
     public sendScreenOn(payload: {screenStreamID: string}) {
         this.send('screen_on', {data: JSON.stringify(payload)});
     }

--- a/webapp/src/clients/websocket/websocket_client.ts
+++ b/webapp/src/clients/websocket/websocket_client.ts
@@ -192,16 +192,12 @@ export class WebSocketClient extends EventEmitter {
         this.send('reconnect', payload);
     }
 
-    public sendLeave() {
-        this.send('leave');
-    }
-
     /**
      * Sends a leave message and closes the connection. When the WS is
      * reconnecting (CONNECTING state), queues the leave to fire as soon as
      * the pending connection opens before closing. This prevents a ~100s
      * server-side session orphan when LiveKit fails while the plugin WS is
-     * mid-reconnect and sendLeave() would otherwise be silently dropped.
+     * mid-reconnect.
      */
     public sendLeaveAndClose() {
         if (this.ws?.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
## Summary

- Adds `sendLeaveAndClose()` to `WebSocketClient`: sends leave immediately when the WS is OPEN; when the WS is CONNECTING (mid-reconnect), queues the leave via `once('open')` so it fires as soon as the pending connection opens and then closes — closing off the ~87s server-side session orphan that occurs when LiveKit fails while the plugin WS is reconnecting
- Replaces the three separate `sendLeave()` + `close()` call pairs in `CallClient` with `sendLeaveAndClose()`
- Fixes a bug in `handleWebsocketErrored` where `ReconnectTimeout` nulled `websocketClient` before calling `disconnect()`, preventing `sendLeaveAndClose()` from running cleanup

## Root cause

When LiveKit returns `JOIN_FAILURE` while the plugin WS is in CONNECTING state (e.g. a 5-second ping timeout triggered a reconnect), `sendLeave()` calls through to `send()` which checks `ws.readyState === WebSocket.OPEN` and silently drops the message. No leave ever reaches the server, so the `CallSession` row is only reaped when the server's own WS pong timeout fires (~87s).

Note: if the underlying TCP connection is dead (not just a transient blip), no client-side fix can help — the server pong timeout remains the reaper in that case. This fix closes the gap for the more common case where TCP is healthy but the application-level ping interval triggered a reconnect.

## Test plan

- [ ] Unit tests: `sendLeaveAndClose` describe block in `websocket_client.test.ts` (3 new tests covering OPEN, CONNECTING, and already-closed cases)
- [ ] Existing disconnect tests updated to assert `sendLeaveAndClose` instead of separate `sendLeave` + `close`
- [ ] All 423 webapp tests pass