### PR TITLE
[MM-69714] Calls v1: fix stale Join button after websocket reconnect

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1137,7 +1137,7 @@ export default class Plugin {
                 // eslint-disable-next-line max-nested-callbacks
                 this.registerReconnectHandler(registry, store, () => {
                     logDebug('websocket reconnect handler');
-                    if (!getCallsClient()) {
+                    if (!getCallsClient() && !channelIDForCurrentCall(store.getState())) {
                         logDebug('resetting state');
                         store.dispatch({
                             type: UNINIT,


### PR DESCRIPTION
## Summary

Backport of MM-69655 to v1 (RTCD).

On Desktop, the channel call-post flips from "Leave" to "Join" while the user is still connected, after the Mattermost app websocket reconnects. The reconnect handler's `!getCallsClient()` guard is always true in the Desktop main-window renderer (callsClient lives in the widget renderer), so `unInitialized()` was dispatched on every reconnect, wiping `clientStateReducer`.

One-line fix: also guard on `channelIDForCurrentCall` so the uninit dispatch is skipped when the Redux store knows a call is active.

```diff
- if (!getCallsClient()) {
+ if (!getCallsClient() && !channelIDForCurrentCall(store.getState())) {
```

Tested locally on Desktop by the author.

## Jira

https://mattermost.atlassian.net/browse/MM-69714