### PR TITLE
[MM-69687] Fix orphaned session when peer fails during WS reconnect (v1)

### DIFF
--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -494,7 +494,6 @@ export default class CallsClient extends EventEmitter {
             case WebSocketErrorType.Native:
                 break;
             case WebSocketErrorType.ReconnectTimeout:
-                this.ws = null;
                 this.disconnect(err);
                 break;
             case WebSocketErrorType.Join:
@@ -866,8 +865,7 @@ export default class CallsClient extends EventEmitter {
         this.cleanup();
 
         if (this.ws) {
-            this.ws.send('leave');
-            this.ws.close();
+            this.ws.sendLeaveAndClose();
             this.ws = null;
         }
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -522,6 +522,9 @@ export default class CallsClient extends EventEmitter {
         });
 
         ws.on('join', async () => {
+            if (this.closed) {
+                return;
+            }
             logDebug('join ack received, initializing connection');
 
             const peer = new RTCPeer({

--- a/webapp/src/websocket.test.ts
+++ b/webapp/src/websocket.test.ts
@@ -513,7 +513,6 @@ describe('WebSocketClient', () => {
         });
 
         it('should queue leave for when WS opens if CONNECTING, then close', () => {
-            // WS starts CONNECTING (default for MockWebSocket)
             expect(mockWebSocket.readyState).toBe(WebSocket.CONNECTING);
 
             const sendSpy = jest.spyOn(mockWebSocket, 'send');
@@ -526,7 +525,7 @@ describe('WebSocketClient', () => {
             // leave not yet sent (WS still connecting)
             expect(sendSpy).not.toHaveBeenCalled();
 
-            // Simulate WS opening (reconnect path emits 'open' on onopen)
+            // Simulate WS opening
             mockWebSocket.readyState = WebSocket.OPEN;
 
             // Simulate hello message to trigger the 'open' event
@@ -560,6 +559,7 @@ describe('WebSocketClient', () => {
 
         it('should call close without sending leave when WS is already CLOSED', () => {
             mockWebSocket.readyState = WebSocket.CLOSED;
+
             // Prevent the close() → ws.close() → onclose loop from causing issues
             mockWebSocket.onclose = null;
 

--- a/webapp/src/websocket.test.ts
+++ b/webapp/src/websocket.test.ts
@@ -491,6 +491,99 @@ describe('WebSocketClient', () => {
         });
     });
 
+    describe('sendLeaveAndClose', () => {
+        it('should send leave and close when WS is OPEN', () => {
+            mockWebSocket.readyState = WebSocket.OPEN;
+
+            // Establish connection state
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify({event: 'hello', data: {connection_id: 'conn-1'}, seq: 1}),
+            }));
+
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+            const closeSpy = jest.spyOn(mockWebSocket, 'close');
+
+            client.sendLeaveAndClose();
+
+            expect(sendSpy).toHaveBeenCalledWith(
+                expect.stringContaining('"action":"custom_com.mattermost.calls_leave"'),
+            );
+            expect(closeSpy).toHaveBeenCalled();
+            expect((client as any).closed).toBe(true);
+        });
+
+        it('should queue leave for when WS opens if CONNECTING, then close', () => {
+            // WS starts CONNECTING (default for MockWebSocket)
+            expect(mockWebSocket.readyState).toBe(WebSocket.CONNECTING);
+
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+
+            client.sendLeaveAndClose();
+
+            // closed flag set immediately to prevent further reconnects
+            expect((client as any).closed).toBe(true);
+
+            // leave not yet sent (WS still connecting)
+            expect(sendSpy).not.toHaveBeenCalled();
+
+            // Simulate WS opening (reconnect path emits 'open' on onopen)
+            mockWebSocket.readyState = WebSocket.OPEN;
+
+            // Simulate hello message to trigger the 'open' event
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify({event: 'hello', data: {connection_id: 'conn-2'}, seq: 1}),
+            }));
+
+            // leave should now have been sent
+            expect(sendSpy).toHaveBeenCalledWith(
+                expect.stringContaining('"action":"custom_com.mattermost.calls_leave"'),
+            );
+
+            // client should be fully closed
+            expect((client as any).ws).toBeNull();
+        });
+
+        it('should not start a zombie ping interval when closing from CONNECTING state', () => {
+            expect(mockWebSocket.readyState).toBe(WebSocket.CONNECTING);
+
+            client.sendLeaveAndClose();
+
+            // Simulate hello arriving (open event fires, once handler runs, close() is called)
+            mockWebSocket.readyState = WebSocket.OPEN;
+            mockWebSocket.onmessage!(new MessageEvent('message', {
+                data: JSON.stringify({event: 'hello', data: {connection_id: 'conn-3'}, seq: 1}),
+            }));
+
+            // After close(), pingInterval must not be running
+            expect((client as any).pingInterval).toBeNull();
+        });
+
+        it('should call close without sending leave when WS is already CLOSED', () => {
+            mockWebSocket.readyState = WebSocket.CLOSED;
+            // Prevent the close() → ws.close() → onclose loop from causing issues
+            mockWebSocket.onclose = null;
+
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+
+            client.sendLeaveAndClose();
+
+            expect(sendSpy).not.toHaveBeenCalled();
+            expect((client as any).closed).toBe(true);
+        });
+
+        it('should call close without sending leave when WS is CLOSING', () => {
+            mockWebSocket.readyState = WebSocket.CLOSING;
+            mockWebSocket.onclose = null;
+
+            const sendSpy = jest.spyOn(mockWebSocket, 'send');
+
+            client.sendLeaveAndClose();
+
+            expect(sendSpy).not.toHaveBeenCalled();
+            expect((client as any).closed).toBe(true);
+        });
+    });
+
     describe('getOriginalConnID', () => {
         it('should return the original connection ID', () => {
             // Set up connection

--- a/webapp/src/websocket.ts
+++ b/webapp/src/websocket.ts
@@ -185,6 +185,32 @@ export class WebSocketClient extends EventEmitter {
         }
     }
 
+    // sendLeaveAndClose sends a 'leave' message and closes the connection.
+    // If the WS is mid-reconnect (CONNECTING), it marks the client as closed
+    // (preventing further reconnects) and queues the leave for when the
+    // connection opens, so the server receives it instead of waiting for the
+    // pong timeout (~87s) to reap the session.
+    sendLeaveAndClose() {
+        if (!this.ws || this.ws.readyState === WebSocket.CLOSING || this.ws.readyState === WebSocket.CLOSED) {
+            this.close();
+            return;
+        }
+
+        if (this.ws.readyState === WebSocket.OPEN) {
+            this.send('leave');
+            this.close();
+            return;
+        }
+
+        // WS is CONNECTING (mid-reconnect): mark closed to stop further
+        // reconnects, then send leave as soon as the connection opens.
+        this.closed = true;
+        this.once('open', () => {
+            this.send('leave');
+            this.close();
+        });
+    }
+
     close() {
         this.closed = true;
         this.stopPingInterval();
@@ -231,6 +257,10 @@ export class WebSocketClient extends EventEmitter {
     }
 
     private startPingInterval() {
+        if (this.closed) {
+            return;
+        }
+
         if (this.pingInterval) {
             this.stopPingInterval();
         }


### PR DESCRIPTION
## Summary

- Adds `sendLeaveAndClose()` to `WebSocketClient` that correctly handles all three readyState cases: OPEN (send leave + close immediately), CONNECTING/mid-reconnect (mark closed to stop further reconnects, queue `once('open', …)` to send leave as soon as the socket opens), CLOSING/CLOSED (just cleanup).
- Fixes a premature `this.ws = null` in the `ReconnectTimeout` error handler in `client.ts` that caused `disconnect()` to silently skip the leave message.
- Guards `startPingInterval()` against `this.closed` to prevent a zombie interval when `close()` is called synchronously from inside the `once('open', …)` callback.

Worst case without this fix: leave is never delivered and the server reaps the `CallSession` row via pong timeout (~87s). With the fix, teardown is near-immediate.

This is the v1/RTCD backport of the fix made in the v2/LiveKit codebase via PR #1250 (MM-69672).

## Test plan

- [ ] All existing `WebSocketClient` tests pass
- [ ] 5 new `sendLeaveAndClose` unit tests covering OPEN, CONNECTING (queued leave delivered on open), CONNECTING (no zombie ping interval), CLOSED, CLOSING
- [ ] Manual: start a call, trigger a network blip while connected, verify session is cleaned up promptly rather than after ~87s