### PR TITLE
[MM-69727] Surface deprecated MM_CALLS_RTCD_URL override in /env endpoint

### DIFF
--- a/server/configuration.go
+++ b/server/configuration.go
@@ -716,6 +716,16 @@ func (p *Plugin) setOverrides(cfg *configuration) {
 		}
 	}
 
+	// v1.8.0 (MM-62732) MM_CALLS_RTCD_URL is DEPRECATED in favor of MM_CALLS_RTCD_SERVICE_URL.
+	// If the canonical env var didn't win, check the deprecated one and surface it so /env reflects reality.
+	if _, alreadySet := p.configEnvOverrides["RTCDServiceURL"]; !alreadySet {
+		if url := os.Getenv("MM_CALLS_RTCD_URL"); url != "" {
+			p.LogWarn("MM_CALLS_RTCD_URL is deprecated and will be removed in a future release, please use MM_CALLS_RTCD_SERVICE_URL instead")
+			cfg.RTCDServiceURL = url
+			p.configEnvOverrides["RTCDServiceURL"] = url
+		}
+	}
+
 	cfg.ICEHostOverride = strings.TrimSpace(cfg.ICEHostOverride)
 	cfg.UDPServerAddress = strings.TrimSpace(cfg.UDPServerAddress)
 	cfg.TCPServerAddress = strings.TrimSpace(cfg.TCPServerAddress)

--- a/server/environment_test.go
+++ b/server/environment_test.go
@@ -197,6 +197,82 @@ func getField(obj interface{}, fieldName string) reflect.Value {
 	return val.FieldByName(fieldName)
 }
 
+func TestSetOverridesDeprecatedRTCDURL(t *testing.T) {
+	originalEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, e := range originalEnv {
+			pair := splitEnvPair(e)
+			os.Setenv(pair[0], pair[1])
+		}
+	}()
+
+	setup := func(t *testing.T) (*Plugin, *pluginMocks.MockAPI) {
+		t.Helper()
+		mockAPI := &pluginMocks.MockAPI{}
+		mockAPI.On("GetLicense").Return(nil)
+		// Allow LogError calls (e.g. from applyEnvOverrides on parse failures) without requiring them.
+		mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+		p := &Plugin{
+			MattermostPlugin: plugin.MattermostPlugin{
+				API: mockAPI,
+			},
+			configEnvOverrides: make(map[string]string),
+		}
+		return p, mockAPI
+	}
+
+	t.Run("deprecated MM_CALLS_RTCD_URL sets override and logs warning", func(t *testing.T) {
+		p, mockAPI := setup(t)
+		mockAPI.On("LogWarn", "MM_CALLS_RTCD_URL is deprecated and will be removed in a future release, please use MM_CALLS_RTCD_SERVICE_URL instead", "origin", mock.AnythingOfType("string")).Return()
+		defer mockAPI.AssertExpectations(t)
+
+		os.Clearenv()
+		os.Setenv("MM_CALLS_RTCD_URL", "http://rtcd.example.com:8045")
+
+		cfg := &configuration{}
+		cfg.SetDefaults()
+
+		p.setOverrides(cfg)
+
+		require.Equal(t, "http://rtcd.example.com:8045", cfg.RTCDServiceURL)
+		require.Equal(t, "http://rtcd.example.com:8045", p.configEnvOverrides["RTCDServiceURL"])
+	})
+
+	t.Run("canonical MM_CALLS_RTCD_SERVICE_URL wins over deprecated MM_CALLS_RTCD_URL", func(t *testing.T) {
+		p, mockAPI := setup(t)
+		defer mockAPI.AssertExpectations(t)
+
+		os.Clearenv()
+		os.Setenv("MM_CALLS_RTCD_SERVICE_URL", "http://canonical.example.com:8045")
+		os.Setenv("MM_CALLS_RTCD_URL", "http://deprecated.example.com:8045")
+
+		cfg := &configuration{}
+		cfg.SetDefaults()
+
+		p.setOverrides(cfg)
+
+		require.Equal(t, "http://canonical.example.com:8045", cfg.RTCDServiceURL)
+		require.Equal(t, "http://canonical.example.com:8045", p.configEnvOverrides["RTCDServiceURL"])
+	})
+
+	t.Run("no env var set leaves RTCDServiceURL from config", func(t *testing.T) {
+		p, mockAPI := setup(t)
+		defer mockAPI.AssertExpectations(t)
+
+		os.Clearenv()
+
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		cfg.RTCDServiceURL = "http://console.example.com:8045"
+
+		p.setOverrides(cfg)
+
+		require.Equal(t, "http://console.example.com:8045", cfg.RTCDServiceURL)
+		require.Empty(t, p.configEnvOverrides["RTCDServiceURL"])
+	})
+}
+
 // Helper function to split environment variable pairs
 func splitEnvPair(pair string) []string {
 	for i := 0; i < len(pair); i++ {


### PR DESCRIPTION
## Summary

- When `MM_CALLS_RTCD_URL` (deprecated since v1.8.0) is set, the plugin's `/env` endpoint previously reported no RTCD URL override, making this misconfiguration invisible to operators
- In `setOverrides`, after `applyEnvOverrides` runs, check if the deprecated var is active and the canonical `MM_CALLS_RTCD_SERVICE_URL` didn't already win: apply the value to `cfg.RTCDServiceURL`, add it to `configEnvOverrides["RTCDServiceURL"]` so `/env` surfaces it, and emit a deprecation warning
- The canonical `MM_CALLS_RTCD_SERVICE_URL` path is unchanged — `applyEnvOverrides` handles it via field-name reflection as before

## Test plan

- [ ] Three new unit test cases in `TestSetOverridesDeprecatedRTCDURL` covering: deprecated var set alone, canonical var wins when both are set, neither var set leaves console value intact
- [ ] `go test ./server -run TestSetOverridesDeprecatedRTCDURL` passes
- [ ] Full `go test ./server` passes

Fixes https://mattermost.atlassian.net/browse/MM-69727