### PR TITLE
[MM-69717] Guard join button against concurrent join attempts

### DIFF
--- a/webapp/src/components/channel_header_button.tsx
+++ b/webapp/src/components/channel_header_button.tsx
@@ -71,7 +71,7 @@ const ChannelHeaderButton = () => {
         <CallButton
             id='calls-join-button'
             className={'style--none call-button ' + (inCall || restricted ? 'disabled' : '')}
-            disabled={isChannelArchived || isDeactivatedDM}
+            disabled={isChannelArchived || isDeactivatedDM || isClientConnecting}
             $restricted={restricted}
             $isCloudPaid={isCloudPaid}
             $isClientConnecting={isClientConnecting}

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -148,6 +148,7 @@ import {
     callsVersionInfo,
     channelHasCall,
     channelIDForCurrentCall,
+    clientConnecting,
     defaultEnabled,
     hasPermissionsToEnableCalls,
     iceServers,
@@ -430,6 +431,10 @@ export default class Plugin {
         });
 
         const connectToCall = async (channelId: string, teamId?: string, title?: string, rootId?: string) => {
+            if (clientConnecting(store.getState())) {
+                return;
+            }
+
             // Prefer the live window.callsClient over Redux state: the client
             // is the concrete "I am literally in a call right now" signal,
             // while Redux can be transiently stale during reload reconnect.

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -443,7 +443,11 @@ export default class Plugin {
             const effectiveCurrentChannel = window.callsClient?.channelID ?? channelIDForCurrentCall(store.getState());
 
             if (!effectiveCurrentChannel) {
-                // Not in any call - join the new one
+                // Not in any call - join the new one.
+                // Set connecting state synchronously before the first await in
+                // connectCall so the re-entrancy guard above is effective even
+                // on rapid subsequent clicks.
+                store.dispatch(setClientConnecting(true));
                 connectCall(channelId, title, rootId);
 
                 // following the thread only on join. On call start


### PR DESCRIPTION
## Summary

Ports the join re-entrancy guard from MM-69670 (v2) to `main` (v1/RTCD).

- Early-returns from `connectToCall` when `clientConnecting` is already `true`, so rapid or slow-connection clicks cannot start multiple join flows in parallel.
- Adds `isClientConnecting` to the `disabled` prop on the channel header button, so the button is natively disabled (not just visually styled) during the in-flight window.

## Jira

https://mattermost.atlassian.net/browse/MM-69717

## Test plan

- [ ] Click "Join call" rapidly while on a slow/throttled connection — only one join attempt fires.
- [ ] Button is visually and functionally disabled while a join is in progress (spinner showing).
- [ ] Normal join and start-call flows still work.