### PR TITLE
[MM-69777] Fix join re-entrancy guard race: dispatch setClientConnecting before connectCall

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -416,6 +416,7 @@ export default class Plugin {
                 return;
             }
             if (!channelIDForCurrentCall(store.getState())) {
+                store.dispatch(setClientConnecting(true));
                 connectCall(channelId, title, rootId);
 
                 // following the thread only on join. On call start


### PR DESCRIPTION
## Summary

Fixes a race window in the `clientConnecting` guard introduced in MM-69670.

The guard checks `clientConnecting` at the top of `connectToCall`, but `setClientConnecting(true)` was not dispatched until deep inside `connectCall` — after any async work (e.g. `await disconnect()` on switch-call, or the desktop API await). A second call to `connectToCall` could pass the guard before the flag was ever set.

Fix: dispatch `setClientConnecting(true)` synchronously in the join branch of `connectToCall`, right before `connectCall` is invoked. The existing dispatches inside `connectCall` are retained for the other call sites (window event handler, reconnect path) that bypass `connectToCall`.

This is the same issue CodeRabbit flagged on the v1 backport (MM-69717).

## Test plan

The race window is too narrow to reproduce reliably by clicking — it requires an async suspension inside `connectCall` to happen between the guard check and the flag set. Manual double-click testing is unlikely to hit the window consistently.

- [ ] Verify normal join flow works (widget appears, audio connects)
- [ ] Verify switch-call flow works (switch modal appears when already in a different call)
- [ ] Unit tests cover the guard behaviour
- [ ] TypeScript check: `npx tsc --noEmit` passes
- [ ] Lint: `make check-style` passes