### PR TITLE
Calls v2: Fix double mic track publish on permission grant

### DIFF
--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -1313,6 +1313,54 @@ describe('CallClient', () => {
         });
     });
 
+    describe('ensureMicrophoneTrack', () => {
+        it('mutex prevents double publishTrack when Connected and MediaDevicesChanged race concurrently (Safari)', async () => {
+            // Safari does not expose mic devices via enumerateDevices() until permission is
+            // granted, so the initial input count is 0. When the user clicks Allow, Safari
+            // fires mediadeviceschange — which triggers a second ensureMicrophoneTrack() call
+            // while the first (from handleConnected) is still suspended inside getUserMedia().
+            // Both calls would otherwise race past the !getTrackPublication guard and publish
+            // two tracks. The micTrackEnsureInProgress mutex must block the second call.
+
+            let resolveGetUserMedia!: (stream: any) => void;
+
+            // First getUserMedia call (from handleConnected) is deferred until we manually
+            // resolve it. Second call (if the mutex fails) would resolve immediately with a
+            // track, proving a second publishTrack was attempted.
+            (navigator.mediaDevices.getUserMedia as jest.Mock)
+                .mockReturnValueOnce(new Promise((resolve) => { resolveGetUserMedia = resolve; }))
+                .mockResolvedValueOnce({getTracks: () => [{stop: jest.fn()}]});
+
+            // Simulate Safari: no inputs visible before permission.
+            (navigator.mediaDevices.enumerateDevices as jest.Mock).mockResolvedValue([]);
+
+            await client.connect({channelID: 'test-channel'});
+
+            // RoomEvent.Connected triggers the first ensureMicrophoneTrack(), which suspends
+            // at the deferred getUserMedia and sets micTrackEnsureInProgress = true.
+            mockRoom.fire(RoomEvent.Connected);
+
+            // Permission is granted — Safari fires mediadeviceschange with the new input.
+            // handleMediaDevicesChanged sees prevInputCount=0 → newCount=1 → no published
+            // track → calls ensureMicrophoneTrack() again. The mutex must block it.
+            const safariInputDevice: MediaDeviceInfo = {
+                deviceId: 'mic-1', kind: 'audioinput', label: 'Built-in Mic', groupId: 'g1', toJSON: () => ({}),
+            } as MediaDeviceInfo;
+            (navigator.mediaDevices.enumerateDevices as jest.Mock).mockResolvedValue([safariInputDevice]);
+            mockRoom.fire(RoomEvent.MediaDevicesChanged);
+
+            // Let handleMediaDevicesChanged's enumerateDevices await settle.
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            // Resolve getUserMedia — the first ensureMicrophoneTrack() completes and
+            // publishes exactly one track.
+            resolveGetUserMedia({getTracks: () => [{stop: jest.fn()}]});
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(mockRoom.localParticipant.publishTrack).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('screen share', () => {
         // Models LiveKit's behavior: by the time LocalTrackPublished / TrackSubscribed
         // fires, the participant's getTrackPublication already returns the publication.

--- a/webapp/src/clients/call/call_client.test.ts
+++ b/webapp/src/clients/call/call_client.test.ts
@@ -1328,7 +1328,9 @@ describe('CallClient', () => {
             // resolve it. Second call (if the mutex fails) would resolve immediately with a
             // track, proving a second publishTrack was attempted.
             (navigator.mediaDevices.getUserMedia as jest.Mock)
-                .mockReturnValueOnce(new Promise((resolve) => { resolveGetUserMedia = resolve; }))
+                .mockReturnValueOnce(new Promise((resolve) => {
+                    resolveGetUserMedia = resolve;
+                }))
                 .mockResolvedValueOnce({getTracks: () => [{stop: jest.fn()}]});
 
             // Simulate Safari: no inputs visible before permission.

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -110,6 +110,9 @@ export default class CallClient extends EventEmitter {
     // best stats we can log for forensics. See startStatsPolling().
     private lastStats: CallsClientStats | null = null;
     private statsPollTimer: ReturnType<typeof setInterval> | null = null;
+
+    // Mutex for ensureMicrophoneTrack — set synchronously before the first await so
+    // concurrent callers are blocked immediately.
     private micTrackEnsureInProgress = false;
 
     // Cached enumerated audio devices so we can call getAudioDevices() synchronously
@@ -967,6 +970,7 @@ export default class CallClient extends EventEmitter {
             return;
         }
         this.micTrackEnsureInProgress = true;
+        let notFound = false;
         try {
             logDebug('CallClient: ensuring microphone track');
             const mediaStream = await navigator.mediaDevices.getUserMedia({audio: true});
@@ -1022,14 +1026,21 @@ export default class CallClient extends EventEmitter {
                 this.emit(CALL_EVENT.ERROR, AudioInputPermissionsErr);
             } else if (MediaDeviceFailure.getFailure(err) === MediaDeviceFailure.NotFound) {
                 logDebug('CallClient: no audio input device found');
-                await this.enumerateDevices();
-                this.emit(CALL_EVENT.DEVICE_CHANGE, this.audioDevices);
+                notFound = true;
             } else {
                 logErr('CallClient: failed to request microphone permission', err);
                 this.emit(CALL_EVENT.ERROR, err);
             }
         } finally {
             this.micTrackEnsureInProgress = false;
+        }
+
+        if (notFound) {
+            // Enumerate and emit outside the micTrackEnsureInProgress mutex so a concurrent
+            // MediaDevicesChanged (e.g. user plugs in a mic immediately after joining) is not blocked.
+            // DEVICE_CHANGE triggers the missing-audio-input alert in the UI.
+            await this.enumerateDevices();
+            this.emit(CALL_EVENT.DEVICE_CHANGE, this.audioDevices);
         }
     }
 

--- a/webapp/src/clients/call/call_client.ts
+++ b/webapp/src/clients/call/call_client.ts
@@ -110,6 +110,7 @@ export default class CallClient extends EventEmitter {
     // best stats we can log for forensics. See startStatsPolling().
     private lastStats: CallsClientStats | null = null;
     private statsPollTimer: ReturnType<typeof setInterval> | null = null;
+    private micTrackEnsureInProgress = false;
 
     // Cached enumerated audio devices so we can call getAudioDevices() synchronously
     private audioDevices: MediaDevices = {inputs: [], outputs: []};
@@ -961,6 +962,11 @@ export default class CallClient extends EventEmitter {
     // the popout. The main window is always focused at join time, so capture is safe here.
     // Idempotent: skips publication if a mic track is already published (e.g. on hot-plug).
     private async ensureMicrophoneTrack() {
+        if (this.micTrackEnsureInProgress) {
+            logDebug('CallClient: ensureMicrophoneTrack already in progress, skipping');
+            return;
+        }
+        this.micTrackEnsureInProgress = true;
         try {
             logDebug('CallClient: ensuring microphone track');
             const mediaStream = await navigator.mediaDevices.getUserMedia({audio: true});
@@ -1022,6 +1028,8 @@ export default class CallClient extends EventEmitter {
                 logErr('CallClient: failed to request microphone permission', err);
                 this.emit(CALL_EVENT.ERROR, err);
             }
+        } finally {
+            this.micTrackEnsureInProgress = false;
         }
     }
 


### PR DESCRIPTION
## Summary

On Safari (and probably other browsers), `enumerateDevices()` returns no devices before mic permission is granted. When the user clicks Allow, the browser fires `mediadeviceschange` with the new input — while the first `ensureMicrophoneTrack()` call (from `handleConnected`) is still suspended inside `getUserMedia()`. Both calls race through the `!getTrackPublication(Mic)` guard simultaneously and publish two tracks. The second track's subsequent `mute()` silently no-ops against the already-muted first publication, leaving the second track live and unmuted.

**Fix:** add a `micTrackEnsureInProgress` boolean mutex to `ensureMicrophoneTrack()` so concurrent calls return early. The `finally` block clears the flag so the Firefox popout retry path (first call fails with `NotFound`, second call from `MediaDevicesChanged` succeeds) is not affected.

**Test:** new unit test in `call_client.test.ts` reproduces the race by deferring the first `getUserMedia` promise, firing both `RoomEvent.Connected` and `RoomEvent.MediaDevicesChanged` concurrently, then asserting `publishTrack` is called exactly once. The test fails if the mutex is removed.

## Observed impact

A participant using Chrome joined unmuted during a team meeting (2026-07-15), causing an echo heard by all participants. Client logs showed two mic track SIDs, one `muted:false`.

## Test plan

- [x] Unit test: `ensureMicrophoneTrack > mutex prevents double publishTrack when Connected and MediaDevicesChanged race concurrently (Safari)`
- [ ] Manual: join a v2 call on Safari with mic permission cleared; verify you are muted on join