### PR TITLE
[MM-69753] Add 30s no-answer timer for DM calls

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -242,6 +242,12 @@ func (p *Plugin) OnDeactivate() error {
 		p.LogError(err.Error())
 	}
 
+	p.dmNoAnswerTimersMut.Lock()
+	for _, t := range p.dmNoAnswerTimers {
+		t.Stop()
+	}
+	p.dmNoAnswerTimersMut.Unlock()
+
 	if p.rtcdManager != nil {
 		if err := p.rtcdManager.Close(); err != nil {
 			p.LogError(err.Error())

--- a/server/dm_timer.go
+++ b/server/dm_timer.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"time"
+)
+
+type callEndReason int
+
+const (
+	callEndReasonNormal           callEndReason = iota
+	callEndReasonCanceledByCaller callEndReason = iota
+	callEndReasonNoAnswer         callEndReason = iota
+)
+
+const (
+	callStatusCalling          = "calling"
+	callStatusEnded            = "ended"
+	callStatusNoAnswer         = "no_answer"
+	callStatusCanceledByCaller = "canceled_by_caller"
+)
+
+const dmNoAnswerTimeout = 30 * time.Second
+
+func (p *Plugin) startDMNoAnswerTimer(channelID, callID string) {
+	p.dmNoAnswerTimersMut.Lock()
+	defer p.dmNoAnswerTimersMut.Unlock()
+
+	if _, ok := p.dmNoAnswerTimers[channelID]; ok {
+		return
+	}
+
+	p.dmNoAnswerTimers[channelID] = time.AfterFunc(dmNoAnswerTimeout, func() {
+		p.handleDMNoAnswer(channelID, callID)
+	})
+}
+
+func (p *Plugin) cancelDMNoAnswerTimer(channelID string) bool {
+	p.dmNoAnswerTimersMut.Lock()
+	defer p.dmNoAnswerTimersMut.Unlock()
+
+	t, ok := p.dmNoAnswerTimers[channelID]
+	if !ok {
+		return false
+	}
+
+	t.Stop()
+	delete(p.dmNoAnswerTimers, channelID)
+
+	return true
+}
+
+func (p *Plugin) handleDMNoAnswer(channelID, callID string) {
+	p.dmNoAnswerTimersMut.Lock()
+	delete(p.dmNoAnswerTimers, channelID)
+	p.dmNoAnswerTimersMut.Unlock()
+
+	state, err := p.lockCallReturnState(channelID)
+	if err != nil {
+		p.LogError("handleDMNoAnswer: failed to lock call", "channelID", channelID, "err", err.Error())
+		return
+	}
+
+	if state == nil || state.Call.ID != callID || len(state.sessions) != 1 {
+		p.unlockCall(channelID)
+		return
+	}
+
+	postID := state.Call.PostID
+	participants := mapKeys(state.Call.Props.Participants)
+	nodeID := state.Call.Props.NodeID
+
+	type sessionInfo struct {
+		userID, connID string
+	}
+	sessionInfos := make([]sessionInfo, 0, len(state.sessions))
+	for connID, sess := range state.sessions {
+		sessionInfos = append(sessionInfos, sessionInfo{sess.UserID, connID})
+	}
+
+	setCallEnded(&state.Call)
+	if err := p.store.UpdateCall(&state.Call); err != nil {
+		p.LogError("handleDMNoAnswer: failed to update call", "channelID", channelID, "err", err.Error())
+	}
+	if err := p.store.DeleteCallsSessions(state.Call.ID); err != nil {
+		p.LogError("handleDMNoAnswer: failed to delete call sessions", "channelID", channelID, "err", err.Error())
+	}
+
+	p.unlockCall(channelID)
+
+	if _, err := p.updateCallPostEnded(postID, participants, callEndReasonNoAnswer); err != nil {
+		p.LogError("handleDMNoAnswer: failed to update call post", "channelID", channelID, "err", err.Error())
+	}
+
+	p.publishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
+
+	for _, si := range sessionInfos {
+		if err := p.closeRTCSession(si.userID, si.connID, channelID, nodeID, callID); err != nil {
+			p.LogError("handleDMNoAnswer: failed to close RTC session", "err", err.Error())
+		}
+	}
+}

--- a/server/dm_timer_test.go
+++ b/server/dm_timer_test.go
@@ -1,0 +1,283 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-calls/server/cluster"
+	"github.com/mattermost/mattermost-plugin-calls/server/db"
+	"github.com/mattermost/mattermost-plugin-calls/server/public"
+
+	serverMocks "github.com/mattermost/mattermost-plugin-calls/server/mocks/github.com/mattermost/mattermost-plugin-calls/server/interfaces"
+	pluginMocks "github.com/mattermost/mattermost-plugin-calls/server/mocks/github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newDMTimerTestPlugin(t *testing.T) (*Plugin, *pluginMocks.MockAPI, *serverMocks.MockMetrics) {
+	t.Helper()
+
+	mockAPI := &pluginMocks.MockAPI{}
+	mockMetrics := &serverMocks.MockMetrics{}
+
+	p := &Plugin{
+		MattermostPlugin: plugin.MattermostPlugin{API: mockAPI},
+		callsClusterLocks: map[string]*cluster.Mutex{},
+		metrics:           mockMetrics,
+		dmNoAnswerTimers:  map[string]*time.Timer{},
+	}
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+	p.store = store
+
+	mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
+	mockMetrics.On("ObserveClusterMutexGrabTime", "mutex_call", mock.AnythingOfType("float64")).Maybe()
+	mockMetrics.On("ObserveClusterMutexLockedTime", "mutex_call", mock.AnythingOfType("float64")).Maybe()
+	mockMetrics.On("ObserveAppHandlersTime", mock.AnythingOfType("string"), mock.AnythingOfType("float64")).Maybe()
+	mockAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+	return p, mockAPI, mockMetrics
+}
+
+func TestStartCancelDMNoAnswerTimer(t *testing.T) {
+	p := &Plugin{
+		dmNoAnswerTimers: map[string]*time.Timer{},
+	}
+
+	channelID := model.NewId()
+	callID := model.NewId()
+
+	t.Run("start creates timer", func(t *testing.T) {
+		p.startDMNoAnswerTimer(channelID, callID)
+
+		p.dmNoAnswerTimersMut.Lock()
+		_, ok := p.dmNoAnswerTimers[channelID]
+		p.dmNoAnswerTimersMut.Unlock()
+
+		assert.True(t, ok)
+	})
+
+	t.Run("start is idempotent", func(t *testing.T) {
+		p.startDMNoAnswerTimer(channelID, callID)
+
+		p.dmNoAnswerTimersMut.Lock()
+		count := len(p.dmNoAnswerTimers)
+		p.dmNoAnswerTimersMut.Unlock()
+
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("cancel removes timer and returns true", func(t *testing.T) {
+		canceled := p.cancelDMNoAnswerTimer(channelID)
+		assert.True(t, canceled)
+
+		p.dmNoAnswerTimersMut.Lock()
+		_, ok := p.dmNoAnswerTimers[channelID]
+		p.dmNoAnswerTimersMut.Unlock()
+
+		assert.False(t, ok)
+	})
+
+	t.Run("cancel on missing timer returns false", func(t *testing.T) {
+		canceled := p.cancelDMNoAnswerTimer(channelID)
+		assert.False(t, canceled)
+	})
+}
+
+func TestHandleDMNoAnswer(t *testing.T) {
+	t.Run("no call ongoing", func(t *testing.T) {
+		p, mockAPI, _ := newDMTimerTestPlugin(t)
+		defer mockAPI.AssertExpectations(t)
+
+		channelID := model.NewId()
+
+		// lockCallReturnState returns nil state → bail without touching post or WS
+		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil).Once()
+
+		p.handleDMNoAnswer(channelID, model.NewId())
+	})
+
+	t.Run("stale call ID", func(t *testing.T) {
+		p, mockAPI, _ := newDMTimerTestPlugin(t)
+		defer mockAPI.AssertExpectations(t)
+		defer ResetTestStore(t, p.store)
+
+		channelID := model.NewId()
+		userID := model.NewId()
+
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			ChannelID: channelID,
+			StartAt:   time.Now().UnixMilli(),
+			PostID:    model.NewId(),
+			ThreadID:  model.NewId(),
+			OwnerID:   userID,
+		}
+		require.NoError(t, p.store.CreateCall(call))
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:     model.NewId(),
+			CallID: call.ID,
+			UserID: userID,
+			JoinAt: time.Now().UnixMilli(),
+		}))
+
+		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil).Once()
+
+		// A different callID than what's in the DB → state.Call.ID != callID → bail
+		p.handleDMNoAnswer(channelID, model.NewId())
+	})
+
+	t.Run("second participant already joined", func(t *testing.T) {
+		p, mockAPI, _ := newDMTimerTestPlugin(t)
+		defer mockAPI.AssertExpectations(t)
+		defer ResetTestStore(t, p.store)
+
+		channelID := model.NewId()
+		userID := model.NewId()
+
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			ChannelID: channelID,
+			StartAt:   time.Now().UnixMilli(),
+			PostID:    model.NewId(),
+			ThreadID:  model.NewId(),
+			OwnerID:   userID,
+		}
+		require.NoError(t, p.store.CreateCall(call))
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:     model.NewId(),
+			CallID: call.ID,
+			UserID: userID,
+			JoinAt: time.Now().UnixMilli(),
+		}))
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:     model.NewId(),
+			CallID: call.ID,
+			UserID: model.NewId(),
+			JoinAt: time.Now().UnixMilli(),
+		}))
+
+		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil).Once()
+
+		// 2 active sessions → len(state.sessions) != 1 → bail
+		p.handleDMNoAnswer(channelID, call.ID)
+	})
+
+	t.Run("no answer — call ended, post updated, WS event published", func(t *testing.T) {
+		p, mockAPI, mockMetrics := newDMTimerTestPlugin(t)
+		defer mockAPI.AssertExpectations(t)
+		defer mockMetrics.AssertExpectations(t)
+		defer ResetTestStore(t, p.store)
+
+		channelID := model.NewId()
+		userID := model.NewId()
+		postID := model.NewId()
+
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			ChannelID: channelID,
+			StartAt:   time.Now().UnixMilli(),
+			PostID:    postID,
+			ThreadID:  model.NewId(),
+			OwnerID:   userID,
+		}
+		require.NoError(t, p.store.CreateCall(call))
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:     model.NewId(),
+			CallID: call.ID,
+			UserID: userID,
+			JoinAt: time.Now().UnixMilli(),
+		}))
+		createPost(t, p.store, postID, userID, channelID)
+
+		mockAPI.On("KVDelete", "mutex_call_"+channelID).Return(nil).Once()
+		mockAPI.On("GetConfig").Return(&model.Config{}, nil).Once()
+
+		var capturedPost *model.Post
+		mockAPI.On("UpdatePost", mock.AnythingOfType("*model.Post")).Run(func(args mock.Arguments) {
+			capturedPost = args.Get(0).(*model.Post)
+		}).Return(&model.Post{}, nil).Once()
+
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, map[string]interface{}{},
+			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
+
+		p.handleDMNoAnswer(channelID, call.ID)
+
+		require.NotNil(t, capturedPost)
+		assert.Equal(t, callStatusNoAnswer, capturedPost.GetProp("call_status"))
+		assert.NotNil(t, capturedPost.GetProp("end_at"))
+
+		updatedCall, err := p.store.GetCall(call.ID, db.GetCallOpts{FromWriter: true})
+		require.NoError(t, err)
+		assert.Greater(t, updatedCall.EndAt, int64(0))
+
+		sessions, err := p.store.GetCallSessions(call.ID, db.GetCallSessionOpts{FromWriter: true})
+		require.NoError(t, err)
+		assert.Empty(t, sessions)
+	})
+}
+
+func TestUpdateCallPostEnded(t *testing.T) {
+	tests := []struct {
+		name       string
+		reason     callEndReason
+		wantStatus string
+	}{
+		{
+			name:       "normal end",
+			reason:     callEndReasonNormal,
+			wantStatus: callStatusEnded,
+		},
+		{
+			name:       "no answer",
+			reason:     callEndReasonNoAnswer,
+			wantStatus: callStatusNoAnswer,
+		},
+		{
+			name:       "canceled by caller",
+			reason:     callEndReasonCanceledByCaller,
+			wantStatus: callStatusCanceledByCaller,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, mockAPI, _ := newDMTimerTestPlugin(t)
+			defer mockAPI.AssertExpectations(t)
+
+			userID := model.NewId()
+			channelID := model.NewId()
+			postID := model.NewId()
+			createPost(t, p.store, postID, userID, channelID)
+
+			mockAPI.On("GetConfig").Return(&model.Config{}, nil).Once()
+
+			var capturedPost *model.Post
+			mockAPI.On("UpdatePost", mock.AnythingOfType("*model.Post")).Run(func(args mock.Arguments) {
+				capturedPost = args.Get(0).(*model.Post)
+			}).Return(&model.Post{}, nil).Once()
+
+			_, err := p.updateCallPostEnded(postID, []string{userID}, tc.reason)
+			require.NoError(t, err)
+
+			require.NotNil(t, capturedPost)
+			assert.Equal(t, tc.wantStatus, capturedPost.GetProp("call_status"))
+			assert.NotNil(t, capturedPost.GetProp("end_at"))
+		})
+	}
+}

--- a/server/dm_timer_test.go
+++ b/server/dm_timer_test.go
@@ -29,7 +29,7 @@ func newDMTimerTestPlugin(t *testing.T) (*Plugin, *pluginMocks.MockAPI, *serverM
 	mockMetrics := &serverMocks.MockMetrics{}
 
 	p := &Plugin{
-		MattermostPlugin: plugin.MattermostPlugin{API: mockAPI},
+		MattermostPlugin:  plugin.MattermostPlugin{API: mockAPI},
 		callsClusterLocks: map[string]*cluster.Mutex{},
 		metrics:           mockMetrics,
 		dmNoAnswerTimers:  map[string]*time.Timer{},

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -20,8 +20,16 @@
     "translation": "We highly recommend switching to [Mattermost Enterprise Edition](https://mattermost.com/pl/install-enterprise-install-upgrade) and [deploying the RTCD service](https://mattermost.com/pl/calls-deployment-the-rtcd-service) to offload calls processing to a separate instance in order to maintain the performance, scalability, and reliability of your main Mattermost server."
   },
   {
+    "id": "app.call.canceled_by_caller_message",
+    "translation": "Call cancelled"
+  },
+  {
     "id": "app.call.ended_message",
     "translation": "Call ended"
+  },
+  {
+    "id": "app.call.no_answer_message",
+    "translation": "No answer"
   },
   {
     "id": "app.call.new_recording_and_transcription_message",

--- a/server/main.go
+++ b/server/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"time"
+
 	"golang.org/x/time/rate"
 
 	"github.com/mattermost/mattermost-plugin-calls/server/batching"
@@ -34,6 +36,7 @@ func main() {
 		callsClusterLocks:      map[string]*cluster.Mutex{},
 		addSessionsBatchers:    map[string]*batching.Batcher{},
 		removeSessionsBatchers: map[string]*batching.Batcher{},
+		dmNoAnswerTimers:       map[string]*time.Timer{},
 	}
 	p.apiRouter = p.newAPIRouter()
 	plugin.ClientMain(p)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -73,6 +73,9 @@ type Plugin struct {
 	callsClusterLocks    map[string]*cluster.Mutex
 	callsClusterLocksMut sync.RWMutex
 
+	dmNoAnswerTimers    map[string]*time.Timer
+	dmNoAnswerTimersMut sync.Mutex
+
 	// Database
 	store *db.Store
 
@@ -301,7 +304,7 @@ func (p *Plugin) clusterEventsHandler() {
 	}
 }
 
-func (p *Plugin) createCallStartedPost(state *callState, userID, channelID, title, threadID string) (string, string, error) {
+func (p *Plugin) createCallStartedPost(state *callState, userID, channelID, title, threadID string, channelType model.ChannelType) (string, string, error) {
 	user, appErr := p.API.GetUser(userID)
 	if appErr != nil {
 		return "", "", appErr
@@ -329,17 +332,22 @@ func (p *Plugin) createCallStartedPost(state *callState, userID, channelID, titl
 		Text:     postMsg,
 	}
 
+	props := map[string]interface{}{
+		"attachments": []*model.MessageAttachment{&msgAttachment},
+		"start_at":    state.Call.StartAt,
+		"title":       title,
+	}
+	if channelType == model.ChannelTypeDirect {
+		props["call_status"] = callStatusCalling
+	}
+
 	post := &model.Post{
 		UserId:    userID,
 		ChannelId: channelID,
 		RootId:    threadID,
 		Message:   postMsg,
 		Type:      callStartPostType,
-		Props: map[string]interface{}{
-			"attachments": []*model.MessageAttachment{&msgAttachment},
-			"start_at":    state.Call.StartAt,
-			"title":       title,
-		},
+		Props:     props,
 	}
 
 	createdPost, appErr := p.API.CreatePost(post)
@@ -355,7 +363,7 @@ func (p *Plugin) createCallStartedPost(state *callState, userID, channelID, titl
 	return createdPost.Id, threadID, nil
 }
 
-func (p *Plugin) updateCallPostEnded(postID string, participants []string) (float64, error) {
+func (p *Plugin) updateCallPostEnded(postID string, participants []string, reason callEndReason) (float64, error) {
 	if postID == "" {
 		return 0, fmt.Errorf("postID should not be empty")
 	}
@@ -367,7 +375,19 @@ func (p *Plugin) updateCallPostEnded(postID string, participants []string) (floa
 
 	T := p.getTranslationFunc("")
 
-	postMsg := T("app.call.ended_message")
+	var postMsg, callStatus string
+	switch reason {
+	case callEndReasonNoAnswer:
+		postMsg = T("app.call.no_answer_message")
+		callStatus = callStatusNoAnswer
+	case callEndReasonCanceledByCaller:
+		postMsg = T("app.call.canceled_by_caller_message")
+		callStatus = callStatusCanceledByCaller
+	default:
+		postMsg = T("app.call.ended_message")
+		callStatus = callStatusEnded
+	}
+
 	msgAttachment := model.MessageAttachment{
 		Fallback: postMsg,
 		Title:    postMsg,
@@ -378,6 +398,7 @@ func (p *Plugin) updateCallPostEnded(postID string, participants []string) (floa
 	post.DelProp("attachments")
 	post.AddProp("attachments", []*model.MessageAttachment{&msgAttachment})
 	post.AddProp("end_at", time.Now().UnixMilli())
+	post.AddProp("call_status", callStatus)
 	post.AddProp("participants", participants)
 
 	if _, appErr := p.API.UpdatePost(post); appErr != nil {

--- a/server/session.go
+++ b/server/session.go
@@ -475,8 +475,17 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		}
 		setCallEnded(&state.Call)
 
+		p.cancelDMNoAnswerTimer(channelID)
+
+		reason := callEndReasonNormal
+		if len(state.Call.Props.Participants) == 1 {
+			if channel, appErr := p.API.GetChannel(channelID); appErr == nil && channel.Type == model.ChannelTypeDirect {
+				reason = callEndReasonCanceledByCaller
+			}
+		}
+
 		defer func() {
-			_, err := p.updateCallPostEnded(state.Call.PostID, mapKeys(state.Call.Props.Participants))
+			_, err := p.updateCallPostEnded(state.Call.PostID, mapKeys(state.Call.Props.Participants), reason)
 			if err != nil {
 				p.LogError("failed to update call post ended", "err", err.Error(), "channelID", channelID)
 			}

--- a/server/state.go
+++ b/server/state.go
@@ -359,7 +359,7 @@ func (p *Plugin) cleanCallState(call *public.Call) error {
 		return nil
 	}
 
-	if _, err := p.updateCallPostEnded(call.PostID, mapKeys(call.Props.Participants)); err != nil {
+	if _, err := p.updateCallPostEnded(call.PostID, mapKeys(call.Props.Participants), callEndReasonNormal); err != nil {
 		p.LogError("failed to update call post", "err", err.Error())
 	}
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -833,8 +833,16 @@ func (p *Plugin) handleJoin(userID, connID, authSessionID string, joinData calls
 			}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
 		}
 
-		if len(state.sessions) == 2 && !p.isBot(userID) && channel.Type == model.ChannelTypeDirect {
-			p.cancelDMNoAnswerTimer(channelID)
+		if !p.isBot(userID) && channel.Type == model.ChannelTypeDirect {
+			humanUsers := make(map[string]struct{})
+			for _, s := range state.sessions {
+				if !p.isBot(s.UserID) {
+					humanUsers[s.UserID] = struct{}{}
+				}
+			}
+			if len(humanUsers) == 2 {
+				p.cancelDMNoAnswerTimer(channelID)
+			}
 		}
 
 		p.LogDebug("session has joined call",

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -806,7 +806,7 @@ func (p *Plugin) handleJoin(userID, connID, authSessionID string, joinData calls
 				)
 			}
 
-			postID, threadID, err := p.createCallStartedPost(state, userID, channelID, joinData.Title, joinData.ThreadID)
+			postID, threadID, err := p.createCallStartedPost(state, userID, channelID, joinData.Title, joinData.ThreadID, channel.Type)
 			if err != nil {
 				p.LogError(err.Error())
 			}
@@ -815,6 +815,10 @@ func (p *Plugin) handleJoin(userID, connID, authSessionID string, joinData calls
 			state.Call.ThreadID = threadID
 			if err := p.store.UpdateCall(&state.Call); err != nil {
 				p.LogError(err.Error())
+			}
+
+			if channel.Type == model.ChannelTypeDirect {
+				p.startDMNoAnswerTimer(channelID, state.Call.ID)
 			}
 
 			// TODO: send all the info attached to a call.
@@ -827,6 +831,10 @@ func (p *Plugin) handleJoin(userID, connID, authSessionID string, joinData calls
 				"owner_id":  state.Call.OwnerID,
 				"host_id":   state.Call.GetHostID(),
 			}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
+		}
+
+		if len(state.sessions) == 2 && !p.isBot(userID) && channel.Type == model.ChannelTypeDirect {
+			p.cancelDMNoAnswerTimer(channelID)
 		}
 
 		p.LogDebug("session has joined call",

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -786,6 +786,7 @@ func TestHandleJoin(t *testing.T) {
 		sessions:               map[string]*session{},
 		addSessionsBatchers:    map[string]*batching.Batcher{},
 		removeSessionsBatchers: map[string]*batching.Batcher{},
+		dmNoAnswerTimers:       map[string]*time.Timer{},
 	}
 
 	p.licenseChecker = enterprise.NewLicenseChecker(p.API)


### PR DESCRIPTION
## Summary

- Adds a 30-second no-answer timer that fires when the caller is still the only participant in a DM call
- On timeout, the call is force-ended under the channel lock (guards against stale callID and concurrent joins on any cluster node) and the call post is updated with `call_status: "no_answer"`
- Cancels the timer early if a second participant joins (`call_status` remains as normal ended) or the caller hangs up first (`call_status: "canceled_by_caller"`)
- Adds `callEndReason` enum and `call_status` post prop for DM/GM call state (calling → ended/no_answer/canceled_by_caller)
- Stops all pending timers on plugin deactivation

## Implementation notes

Timer state lives in `Plugin.dmNoAnswerTimers` (map + mutex). Correctness in a cluster is guaranteed by the `callsClusterLocks` guard in `handleDMNoAnswer`: it re-checks that the callID matches and sessions count is still 1 before proceeding, so a late-firing timer on one node can't end a call that was already answered (or ended) on another node.

## Test plan

- [x] `TestStartCancelDMNoAnswerTimer` — timer lifecycle (start, idempotent start, cancel, cancel-on-missing)
- [x] `TestHandleDMNoAnswer` — guard conditions (no active call, stale call ID, second participant already joined) + happy path (post updated, DB call ended, sessions deleted, WS event published)
- [x] `TestUpdateCallPostEnded` — per-reason `call_status` prop assertions for all three reasons
- [ ] Manual: start a DM call, let it ring for 30s with no answer → post shows "No answer"
- [ ] Manual: start a DM call, cancel before answer → post shows "Call cancelled"
- [ ] Manual: start a DM call, second party joins → normal call flow, no timer fires