### PR TITLE
[MM-69793] Port blob reporter to v2 branch

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -71,7 +71,7 @@ const config: PlaywrightTestConfig = {
         },
     ],
     reporter: process.env.CI ? [
-        ['html', {open: 'never'}],
+        ['blob'],
         ['json', {outputFile: 'pw-results.json'}],
         ['list'],
     ] : 'list',

--- a/e2e/scripts/run.sh
+++ b/e2e/scripts/run.sh
@@ -101,7 +101,7 @@ docker run -d --name playwright-e2e \
 docker logs -f playwright-e2e
 
 docker cp playwright-e2e:/usr/src/calls-e2e/test-results results/test-results-${CI_NODE_INDEX}
-docker cp playwright-e2e:/usr/src/calls-e2e/playwright-report results/playwright-report-${CI_NODE_INDEX}
+docker cp playwright-e2e:/usr/src/calls-e2e/blob-report results/blob-report-${CI_NODE_INDEX}
 docker cp playwright-e2e:/usr/src/calls-e2e/pw-results.json results/pw-results-${CI_NODE_INDEX}.json
 
 ## Dumping services logs to be uploaded as artifacts in case of failures.


### PR DESCRIPTION
## Summary

- Switch CI Playwright reporter from `html` to `blob` in `e2e/playwright.config.ts`
- Copy `blob-report` (instead of `playwright-report`) out of the E2E container in `e2e/scripts/run.sh`

This is the v2 follow-up to PR #1244, which fixed the broken `E2E Report Generation` workflow on `main`. The `generate-e2e-report.yml` workflow always runs from `main` (GitHub `workflow_run` semantics) and now expects blob-report artifacts; v2-based feature branches were still producing the old HTML-format artifacts, causing the report generation step to fail with `Error: No report files found in .../all-blob-reports`.

No changes needed to `generate-e2e-report.yml` or `e2e.yml` — the report workflow was already fixed on `main`, and the artifact upload step picks up `results/blob-report-*` automatically.

Jira: MM-69793