### PR TITLE
[MM-69745] Parallelize host mute-all; drop redundant plugin WS events

### DIFF
--- a/server/host_controls.go
+++ b/server/host_controls.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -99,15 +100,15 @@ func (p *Plugin) hostMuteParticipant(requesterID, channelID, sessionID string) e
 	// vestigial (never updated post-migration, see MM-69116) and would always
 	// read false here. livekitMuteParticipant is idempotent — it no-ops if the
 	// participant has no unmuted mic track.
+	//
+	// No plugin WebSocket event is needed: MutePublishedTrack causes LiveKit to
+	// send a RemoteMute signal over the participant's own signaling connection,
+	// which the livekit-client SDK handles by calling pub.mute() locally — the
+	// same effect as the WS-driven path, without the extra round-trip.
 	if err := p.livekitMuteParticipant(channelID, composeLivekitIdentity(ust.UserID, sessionID)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
 		p.LogError("hostMuteParticipant: failed to mute participant via LiveKit",
 			"channelID", channelID, "sessionID", sessionID, "err", err.Error())
 	}
-
-	p.publishWebSocketEvent(wsEventHostMute, map[string]interface{}{
-		"channel_id": channelID,
-		"session_id": sessionID,
-	}, &WebSocketBroadcast{UserID: ust.UserID, ReliableClusterSend: true})
 
 	return nil
 }
@@ -134,21 +135,28 @@ func (p *Plugin) hostMuteAllParticipants(requesterID, channelID string) error {
 	// post-migration, see MM-69116) — it would read false for everyone and skip
 	// the whole loop. livekitMuteParticipant is idempotent, so muting an
 	// already-muted participant is a harmless no-op.
+	//
+	// Calls are issued concurrently: each livekitMuteParticipant makes two
+	// blocking RPCs (GetParticipant + MutePublishedTrack), so sequential
+	// execution scales linearly with participant count (~400ms/participant).
+	// No plugin WebSocket event is needed: MutePublishedTrack causes LiveKit to
+	// deliver a RemoteMute signal to each participant's own signaling connection,
+	// which the livekit-client SDK handles by muting the local track directly.
+	var wg sync.WaitGroup
 	for id, s := range state.sessions {
 		if s.UserID == requesterID {
 			continue
 		}
-
-		if err := p.livekitMuteParticipant(channelID, composeLivekitIdentity(s.UserID, id)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
-			p.LogError("hostMuteAllParticipants: failed to mute participant via LiveKit",
-				"channelID", channelID, "sessionID", id, "err", err.Error())
-		}
-
-		p.publishWebSocketEvent(wsEventHostMute, map[string]interface{}{
-			"channel_id": channelID,
-			"session_id": id,
-		}, &WebSocketBroadcast{UserID: s.UserID, ReliableClusterSend: true})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := p.livekitMuteParticipant(channelID, composeLivekitIdentity(s.UserID, id)); err != nil && !errors.Is(err, errLiveKitNotConfigured) {
+				p.LogError("hostMuteAllParticipants: failed to mute participant via LiveKit",
+					"channelID", channelID, "sessionID", id, "err", err.Error())
+			}
+		}()
 	}
+	wg.Wait()
 
 	return nil
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -42,7 +42,6 @@ const (
 	wsEventUserDismissedNotification = "user_dismissed_notification"
 	wsEventJobStop                   = "job_stop"
 	wsEventCaption                   = "caption"
-	wsEventHostMute                  = "host_mute"
 	wsEventHostScreenOff             = "host_screen_off"
 	wsEventHostLowerHand             = "host_lower_hand"
 	wsEventHostRemoved               = "host_removed"

--- a/standalone/src/index.ts
+++ b/standalone/src/index.ts
@@ -58,7 +58,6 @@ import {
     handleCallStart,
     handleCallState,
     handleHostLowerHand,
-    handleHostMute,
     handleHostRemoved,
     handleHostScreenOff,
     handleUserDismissedNotification,
@@ -325,9 +324,6 @@ export default async function initialiseEmbedApp(cfg: InitConfig) {
             break;
         case `custom_${pluginId}_call_state`:
             handleCallState(store, ev as WebSocketMessage<CallStateData>);
-            break;
-        case `custom_${pluginId}_host_mute`:
-            handleHostMute(store, ev as WebSocketMessage<HostControlMsg>);
             break;
         case `custom_${pluginId}_host_screen_off`:
             handleHostScreenOff(store, ev as WebSocketMessage<HostControlMsg>);

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -173,7 +173,6 @@ import {
     handleCallState,
     handleCaption,
     handleHostLowerHand,
-    handleHostMute,
     handleHostRemoved,
     handleHostScreenOff,
     handleUserDismissedNotification,
@@ -279,10 +278,6 @@ export default class Plugin {
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_caption`, (ev) => {
             handleCaption(store, ev);
-        });
-
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_host_mute`, (ev) => {
-            handleHostMute(store, ev);
         });
 
         registry.registerWebSocketEventHandler(`custom_${pluginId}_host_screen_off`, (ev) => {

--- a/webapp/src/websocket_handlers.ts
+++ b/webapp/src/websocket_handlers.ts
@@ -402,21 +402,6 @@ export function handleCaption(store: Store, ev: WebSocketMessage<LiveCaptionData
     }, LIVE_CAPTION_TIMEOUT);
 }
 
-export function handleHostMute(store: Store, ev: WebSocketMessage<HostControlMsg>) {
-    const channelID = ev.data.channel_id;
-    const client = getCallsClient();
-    if (!client || client?.channelID !== channelID) {
-        return;
-    }
-
-    const sessionID = client.getSessionID();
-    if (ev.data.session_id !== sessionID) {
-        return;
-    }
-
-    client.mute();
-}
-
 export function handleHostScreenOff(store: Store, ev: WebSocketMessage<HostControlMsg>) {
     const channelID = ev.data.channel_id;
     const client = getCallsClient();


### PR DESCRIPTION
## Summary

- `hostMuteAllParticipants` was a sequential loop making two blocking LiveKit Cloud RPCs per participant (`GetParticipant` + `MutePublishedTrack`), causing ~400ms/participant latency — 5+ seconds for a 13-person call observed at the July 8 dev meeting.
- Replaces the sequential loop with a concurrent fan-out (`sync.WaitGroup`), collapsing latency to roughly one RTT pair regardless of participant count.
- Removes the `wsEventHostMute` plugin WebSocket event from both `hostMuteParticipant` and `hostMuteAllParticipants`. `MutePublishedTrack` causes LiveKit to deliver a `RemoteMute` signal over each participant's own signaling connection; the livekit-client SDK handles it by calling `pub.mute()` on the local track — the same effect as the WS-driven path, making it redundant.
- Removes the dead `handleHostMute` handler from `webapp` and `standalone`.

## Test plan

- [ ] Host mute-all in a call with several participants — all participants mute simultaneously rather than sequentially
- [ ] Host mute individual participant — participant is muted
- [ ] Muted participant can still self-unmute afterward (matching v1 semantics)

I tested this feature locally with host and two users and it worked fine.