### PR TITLE
[MM-69754] Server: DM auto-end when the other party leaves

### DIFF
--- a/server/host_controls.go
+++ b/server/host_controls.go
@@ -293,7 +293,11 @@ func (p *Plugin) hostEnd(requesterID, channelID string) error {
 	go func() {
 		// We wait a few seconds for the call to end cleanly. If this doesn't
 		// happen we force end it.
-		time.Sleep(5 * time.Second)
+		select {
+		case <-time.After(5 * time.Second):
+		case <-p.stopCh:
+			return
+		}
 
 		call, err := p.store.GetCall(callID, db.GetCallOpts{})
 		if err != nil {

--- a/server/session.go
+++ b/server/session.go
@@ -483,6 +483,46 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		}()
 	}
 
+	// DM auto-end: end the call when a real user leaves and another real user is still connected.
+	if len(state.sessions) > 0 && !state.onlyUserLeft(p.getBotID()) {
+		ch, appErr := p.API.GetChannel(channelID)
+		if appErr != nil {
+			p.LogError("failed to get channel for DM auto-end check", "err", appErr.Error(), "channelID", channelID)
+		} else if ch.Type == model.ChannelTypeDirect {
+			p.LogDebug("DM auto-end: participant left, ending call", "channelID", channelID, "userID", userID)
+			p.publishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &WebSocketBroadcast{
+				ChannelID: channelID, ReliableClusterSend: true,
+			})
+
+			callID := state.Call.ID
+			nodeID := state.Call.Props.NodeID
+
+			go func() {
+				time.Sleep(5 * time.Second)
+
+				call, err := p.store.GetCall(callID, db.GetCallOpts{})
+				if err != nil {
+					p.LogError("DM auto-end: failed to get call", "err", err.Error())
+				}
+
+				sessions, err := p.store.GetCallSessions(callID, db.GetCallSessionOpts{})
+				if err != nil {
+					p.LogError("DM auto-end: failed to get call sessions", "err", err.Error())
+				}
+
+				for _, s := range sessions {
+					if err := p.closeRTCSession(s.UserID, s.ID, channelID, nodeID, callID); err != nil {
+						p.LogError("DM auto-end: failed to close RTC session", "err", err.Error())
+					}
+				}
+
+				if err := p.cleanCallState(call); err != nil {
+					p.LogError("DM auto-end: failed to clean call state", "err", err.Error())
+				}
+			}()
+		}
+	}
+
 	if err := p.store.UpdateCall(&state.Call); err != nil {
 		return fmt.Errorf("failed to update call: %w", err)
 	}

--- a/server/session.go
+++ b/server/session.go
@@ -498,7 +498,11 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 			nodeID := state.Call.Props.NodeID
 
 			go func() {
-				time.Sleep(5 * time.Second)
+				select {
+				case <-time.After(5 * time.Second):
+				case <-p.stopCh:
+					return
+				}
 
 				call, err := p.store.GetCall(callID, db.GetCallOpts{})
 				if err != nil {

--- a/server/session.go
+++ b/server/session.go
@@ -484,7 +484,7 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 	}
 
 	// DM auto-end: end the call when a real user leaves and another real user is still connected.
-	if len(state.sessions) > 0 && !state.onlyUserLeft(p.getBotID()) {
+	if userID != p.getBotID() && len(state.sessions) > 0 && !state.onlyUserLeft(p.getBotID()) {
 		ch, appErr := p.API.GetChannel(channelID)
 		if appErr != nil {
 			p.LogError("failed to get channel for DM auto-end check", "err", appErr.Error(), "channelID", channelID)

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -21,6 +21,135 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRemoveUserSessionDMAutoEnd(t *testing.T) {
+	mockAPI := &pluginMocks.MockAPI{}
+	mockMetrics := &serverMocks.MockMetrics{}
+
+	p := Plugin{
+		MattermostPlugin: plugin.MattermostPlugin{
+			API: mockAPI,
+		},
+		callsClusterLocks: map[string]*cluster.Mutex{},
+		metrics:           mockMetrics,
+		sessions:          map[string]*session{},
+	}
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+	p.store = store
+
+	mockMetrics.On("ObserveAppHandlersTime", mock.AnythingOfType("string"), mock.AnythingOfType("float64"))
+	mockAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+	mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+	buildDMCallState := func(t *testing.T, channelID string) *callState {
+		t.Helper()
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			ChannelID: channelID,
+			StartAt:   time.Now().UnixMilli(),
+			PostID:    model.NewId(),
+			ThreadID:  model.NewId(),
+			OwnerID:   "userA",
+			Props: public.CallProps{
+				Participants: map[string]struct{}{
+					"userA": {},
+					"userB": {},
+				},
+			},
+		}
+		err := p.store.CreateCall(call)
+		require.NoError(t, err)
+
+		err = p.store.CreateCallSession(&public.CallSession{
+			ID:     "connA",
+			CallID: call.ID,
+			UserID: "userA",
+			JoinAt: time.Now().UnixMilli(),
+		})
+		require.NoError(t, err)
+
+		err = p.store.CreateCallSession(&public.CallSession{
+			ID:     "connB",
+			CallID: call.ID,
+			UserID: "userB",
+			JoinAt: time.Now().UnixMilli(),
+		})
+		require.NoError(t, err)
+
+		state, err := p.getCallState(channelID, true)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		require.Len(t, state.sessions, 2)
+
+		return state
+	}
+
+	t.Run("DM: publishes call_end when a real user leaves with another user still connected", func(t *testing.T) {
+		defer mockAPI.AssertExpectations(t)
+		defer mockMetrics.AssertExpectations(t)
+		defer ResetTestStore(t, p.store)
+
+		channelID := model.NewId()
+		state := buildDMCallState(t, channelID)
+
+		mockAPI.On("GetChannel", channelID).Return(&model.Channel{
+			Id:   channelID,
+			Type: model.ChannelTypeDirect,
+		}, nil).Once()
+
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventUserLeft).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, map[string]any{
+			"session_id": "connA",
+			"user_id":    "userA",
+		}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
+
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, map[string]any{},
+			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
+
+		err := p.removeUserSession(state, "userA", "connA", "connA", channelID)
+		require.NoError(t, err)
+
+		// Call should NOT be marked as ended in state (userB is still connected).
+		require.Zero(t, state.Call.EndAt)
+
+		// One session (userB) should remain.
+		require.Len(t, state.sessions, 1)
+	})
+
+	t.Run("non-DM: does not publish call_end when a user leaves with another user still connected", func(t *testing.T) {
+		defer mockAPI.AssertExpectations(t)
+		defer mockMetrics.AssertExpectations(t)
+		defer ResetTestStore(t, p.store)
+
+		channelID := model.NewId()
+		state := buildDMCallState(t, channelID)
+
+		mockAPI.On("GetChannel", channelID).Return(&model.Channel{
+			Id:   channelID,
+			Type: model.ChannelTypeOpen,
+		}, nil).Once()
+
+		mockMetrics.On("IncWebSocketEvent", "out", wsEventUserLeft).Once()
+		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, map[string]any{
+			"session_id": "connA",
+			"user_id":    "userA",
+		}, &model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
+
+		err := p.removeUserSession(state, "userA", "connA", "connA", channelID)
+		require.NoError(t, err)
+
+		require.Zero(t, state.Call.EndAt)
+		require.Len(t, state.sessions, 1)
+	})
+}
+
 func TestAddUserSession(t *testing.T) {
 	mockAPI := &pluginMocks.MockAPI{}
 	mockMetrics := &serverMocks.MockMetrics{}

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -123,6 +123,42 @@ func TestRemoveUserSessionDMAutoEnd(t *testing.T) {
 		require.Len(t, state.sessions, 1)
 	})
 
+	t.Run("DM: does not publish call_end when the bot leaves with a real user still connected", func(t *testing.T) {
+		defer mockAPI.AssertExpectations(t)
+		defer mockMetrics.AssertExpectations(t)
+		defer ResetTestStore(t, p.store)
+
+		botID := model.NewId()
+		p.botSession = &model.Session{UserId: botID}
+		defer func() { p.botSession = nil }()
+
+		channelID := model.NewId()
+		state := buildDMCallState(t, channelID)
+
+		// Add a bot session alongside the two real users.
+		botConnID := model.NewId()
+		err := p.store.CreateCallSession(&public.CallSession{
+			ID:     botConnID,
+			CallID: state.Call.ID,
+			UserID: botID,
+			JoinAt: time.Now().UnixMilli(),
+		})
+		require.NoError(t, err)
+		state.sessions[botConnID] = &public.CallSession{
+			ID:     botConnID,
+			CallID: state.Call.ID,
+			UserID: botID,
+		}
+
+		err = p.removeUserSession(state, botID, botConnID, botConnID, channelID)
+		require.NoError(t, err)
+
+		// wsEventUserLeft and wsEventCallEnd must NOT be published: publishWebSocketEvent
+		// suppresses wsEventUserLeft for the bot, and the DM auto-end block skips bot departures.
+		require.Zero(t, state.Call.EndAt)
+		require.Len(t, state.sessions, 2)
+	})
+
 	t.Run("non-DM: does not publish call_end when a user leaves with another user still connected", func(t *testing.T) {
 		defer mockAPI.AssertExpectations(t)
 		defer mockMetrics.AssertExpectations(t)

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1069,6 +1069,13 @@ func TestHandleJoin(t *testing.T) {
 
 		// Session leaving call path
 
+		// removeUserSession calls GetChannel for DM auto-end check when sessions remain.
+		// Channel is open (not DM), so auto-end won't fire, but the call must be handled.
+		mockAPI.On("GetChannel", channelID).Return(&model.Channel{
+			Id:   channelID,
+			Type: model.ChannelTypeOpen,
+		}, nil)
+
 		mockMetrics.On("DecWebSocketConn").Times(10)
 		mockRTCMetrics.On("DecRTCSessions", "default").Times(10)
 		mockRTCMetrics.On("IncRTCConnState", "closed").Times(10)


### PR DESCRIPTION
## Summary

- In `removeUserSession`, after a participant leaves a 1:1 DM call, publishes `wsEventCallEnd` to the remaining participant so they disconnect immediately.
- A 5-second safety-net goroutine (same pattern as `hostEnd`) force-closes any lingering RTC sessions and runs `cleanCallState` if the client doesn't disconnect cleanly on its own.
- Non-DM channels (group messages, open/private) are unaffected — the logic is gated on `model.ChannelTypeDirect`.
- Two unit tests added: one verifying `wsEventCallEnd` is published for DM channels, one verifying it is not published for non-DM channels.

Fixes: https://mattermost.atlassian.net/browse/MM-69754
Part of: https://mattermost.atlassian.net/browse/MM-69735

## Test plan

- [ ] Start a DM call with two users; have one leave — confirm the call ends for both immediately.
- [ ] Start a group message call with 3+ users; have one leave — confirm remaining users stay in the call.
- [ ] `go test ./server -run TestRemoveUserSessionDMAutoEnd` passes.

I tested locally with DM/GM/channel calls and all works as expected.