### PR TITLE
[MM-69803] Add POST /calls/{channel_id}/decline endpoint for DM calls

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -318,6 +318,10 @@ func (p *Plugin) handleDismissNotification(w http.ResponseWriter, r *http.Reques
 // and updating the call post to reflect the declined state.
 // Callers must ensure channelID belongs to a DM channel before calling.
 func (p *Plugin) declineCall(channelID, userID string) (int, error) {
+	if !p.API.HasPermissionToChannel(userID, channelID, model.PermissionCreatePost) {
+		return http.StatusForbidden, fmt.Errorf("forbidden")
+	}
+
 	state, err := p.lockCallReturnState(channelID)
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to lock call: %w", err)

--- a/server/api.go
+++ b/server/api.go
@@ -257,28 +257,6 @@ func (p *Plugin) handleDismissNotification(w http.ResponseWriter, r *http.Reques
 	userID := r.Header.Get("Mattermost-User-Id")
 	channelID := mux.Vars(r)["channel_id"]
 
-	channel, appErr := p.API.GetChannel(channelID)
-	if appErr != nil {
-		res.Err = fmt.Errorf("failed to get channel: %w", appErr).Error()
-		res.Code = http.StatusInternalServerError
-		return
-	}
-
-	// For DM calls, dismiss acts as decline: end the call immediately so the
-	// caller is not left hanging. Legacy mobile clients that lack the /decline
-	// endpoint will use this path. See MM-69803.
-	if channel.Type == model.ChannelTypeDirect {
-		code, err := p.declineCall(channelID, userID)
-		if err != nil {
-			res.Err = err.Error()
-			res.Code = code
-			return
-		}
-		res.Code = http.StatusOK
-		res.Msg = "success"
-		return
-	}
-
 	state, err := p.lockCallReturnState(channelID)
 	if err != nil {
 		res.Err = fmt.Errorf("failed to lock call: %w", err).Error()

--- a/server/api.go
+++ b/server/api.go
@@ -257,6 +257,28 @@ func (p *Plugin) handleDismissNotification(w http.ResponseWriter, r *http.Reques
 	userID := r.Header.Get("Mattermost-User-Id")
 	channelID := mux.Vars(r)["channel_id"]
 
+	channel, appErr := p.API.GetChannel(channelID)
+	if appErr != nil {
+		res.Err = fmt.Errorf("failed to get channel: %w", appErr).Error()
+		res.Code = http.StatusInternalServerError
+		return
+	}
+
+	// For DM calls, dismiss acts as decline: end the call immediately so the
+	// caller is not left hanging. Legacy mobile clients that lack the /decline
+	// endpoint will use this path. See MM-69803.
+	if channel.Type == model.ChannelTypeDirect {
+		code, err := p.declineCall(channelID, userID)
+		if err != nil {
+			res.Err = err.Error()
+			res.Code = code
+			return
+		}
+		res.Code = http.StatusOK
+		res.Msg = "success"
+		return
+	}
+
 	state, err := p.lockCallReturnState(channelID)
 	if err != nil {
 		res.Err = fmt.Errorf("failed to lock call: %w", err).Error()
@@ -287,6 +309,116 @@ func (p *Plugin) handleDismissNotification(w http.ResponseWriter, r *http.Reques
 		"userID": userID,
 		"callID": state.Call.ID,
 	}, &WebSocketBroadcast{UserID: userID, ReliableClusterSend: true})
+
+	res.Code = http.StatusOK
+	res.Msg = "success"
+}
+
+// declineCall ends a DM call on behalf of the callee, disconnecting the caller
+// and updating the call post to reflect the declined state.
+// Callers must ensure channelID belongs to a DM channel before calling.
+func (p *Plugin) declineCall(channelID, userID string) (int, error) {
+	state, err := p.lockCallReturnState(channelID)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to lock call: %w", err)
+	}
+
+	if state == nil {
+		p.unlockCall(channelID)
+		return http.StatusBadRequest, fmt.Errorf("no call ongoing")
+	}
+
+	// The callee has no active session; the caller does. Reject if the requester
+	// owns a session (they would be the caller, not the callee).
+	for _, sess := range state.sessions {
+		if sess.UserID == userID {
+			p.unlockCall(channelID)
+			return http.StatusForbidden, fmt.Errorf("caller cannot decline their own call")
+		}
+	}
+
+	// If not exactly one session, the callee may have already joined (race). Bail silently.
+	if len(state.sessions) != 1 {
+		p.unlockCall(channelID)
+		return http.StatusOK, nil
+	}
+
+	// Capture caller session data before we destroy the state.
+	var callerUserID, callerConnID string
+	for connID, sess := range state.sessions {
+		callerConnID = connID
+		callerUserID = sess.UserID
+	}
+	nodeID := state.Call.Props.NodeID
+	callID := state.Call.ID
+	postID := state.Call.PostID
+	participants := mapKeys(state.Call.Props.Participants)
+
+	if state.Call.Props.DismissedNotification == nil {
+		state.Call.Props.DismissedNotification = make(map[string]bool)
+	}
+	state.Call.Props.DismissedNotification[userID] = true
+
+	setCallEnded(&state.Call)
+
+	if err := p.store.UpdateCall(&state.Call); err != nil {
+		p.unlockCall(channelID)
+		return http.StatusInternalServerError, fmt.Errorf("failed to update call: %w", err)
+	}
+	if err := p.store.DeleteCallsSessions(callID); err != nil {
+		p.unlockCall(channelID)
+		return http.StatusInternalServerError, fmt.Errorf("failed to delete call sessions: %w", err)
+	}
+
+	p.cancelDMNoAnswerTimer(channelID)
+	p.unlockCall(channelID)
+
+	if _, err := p.updateCallPostEnded(postID, participants, callEndReasonDeclined); err != nil {
+		p.LogError("declineCall: failed to update call post", "channelID", channelID, "err", err.Error())
+	}
+
+	p.publishWebSocketEvent(wsEventCallEnd, map[string]interface{}{}, &WebSocketBroadcast{
+		ChannelID:           channelID,
+		ReliableClusterSend: true,
+	})
+
+	if err := p.closeRTCSession(callerUserID, callerConnID, channelID, nodeID, callID); err != nil {
+		p.LogError("declineCall: failed to close RTC session", "channelID", channelID, "err", err.Error())
+	}
+
+	p.publishWebSocketEvent(wsEventUserDismissedNotification, map[string]interface{}{
+		"userID": userID,
+		"callID": callID,
+	}, &WebSocketBroadcast{UserID: userID, ReliableClusterSend: true})
+
+	return http.StatusOK, nil
+}
+
+func (p *Plugin) handleDeclineCall(w http.ResponseWriter, r *http.Request) {
+	var res httpResponse
+	defer p.httpAudit("handleDeclineCall", &res, w, r)
+
+	userID := r.Header.Get("Mattermost-User-Id")
+	channelID := mux.Vars(r)["channel_id"]
+
+	channel, appErr := p.API.GetChannel(channelID)
+	if appErr != nil {
+		res.Err = fmt.Errorf("failed to get channel: %w", appErr).Error()
+		res.Code = http.StatusInternalServerError
+		return
+	}
+	if channel.Type != model.ChannelTypeDirect {
+		res.Err = "decline is only supported for DM calls"
+		res.Code = http.StatusBadRequest
+		return
+	}
+
+	code, err := p.declineCall(channelID, userID)
+	if err != nil {
+		res.Err = err.Error()
+		res.Code = code
+		return
+	}
 
 	res.Code = http.StatusOK
 	res.Msg = "success"

--- a/server/api.go
+++ b/server/api.go
@@ -366,12 +366,10 @@ func (p *Plugin) declineCall(channelID, userID string) (int, error) {
 	setCallEnded(&state.Call)
 
 	if err := p.store.UpdateCall(&state.Call); err != nil {
-		p.unlockCall(channelID)
-		return http.StatusInternalServerError, fmt.Errorf("failed to update call: %w", err)
+		p.LogError("declineCall: failed to update call", "channelID", channelID, "err", err.Error())
 	}
 	if err := p.store.DeleteCallsSessions(callID); err != nil {
-		p.unlockCall(channelID)
-		return http.StatusInternalServerError, fmt.Errorf("failed to delete call sessions: %w", err)
+		p.LogError("declineCall: failed to delete call sessions", "channelID", channelID, "err", err.Error())
 	}
 
 	p.cancelDMNoAnswerTimer(channelID)

--- a/server/api_router.go
+++ b/server/api_router.go
@@ -103,6 +103,7 @@ func (p *Plugin) newAPIRouter() *mux.Router {
 	// router.HandleFunc("/channels/{channel_id:[a-z0-9]{26}}", p.handlePostCallsChannel).Methods("POST")
 
 	// Calls
+	router.HandleFunc("/calls/{channel_id:[a-z0-9]{26}}/decline", p.handleDeclineCall).Methods("POST")
 	router.HandleFunc("/calls/{channel_id:[a-z0-9]{26}}/dismiss-notification", p.handleDismissNotification).Methods("POST")
 	router.HandleFunc("/calls/{call_id:[a-z0-9]{26}}/recording/{action}", p.handleRecordingAction).Methods("POST")
 	router.HandleFunc("/calls/{channel_id:[a-z0-9]{26}}/active", p.handleGetCallActive).Methods("GET")

--- a/server/dm_timer.go
+++ b/server/dm_timer.go
@@ -13,6 +13,7 @@ const (
 	callEndReasonNormal           callEndReason = iota
 	callEndReasonCanceledByCaller callEndReason = iota
 	callEndReasonNoAnswer         callEndReason = iota
+	callEndReasonDeclined         callEndReason = iota
 )
 
 const (
@@ -20,6 +21,7 @@ const (
 	callStatusEnded            = "ended"
 	callStatusNoAnswer         = "no_answer"
 	callStatusCanceledByCaller = "canceled_by_caller"
+	callStatusDeclined         = "declined"
 )
 
 const dmNoAnswerTimeout = 30 * time.Second

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -24,6 +24,10 @@
     "translation": "Call cancelled"
   },
   {
+    "id": "app.call.declined_message",
+    "translation": "Call declined"
+  },
+  {
     "id": "app.call.ended_message",
     "translation": "Call ended"
   },

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -383,6 +383,9 @@ func (p *Plugin) updateCallPostEnded(postID string, participants []string, reaso
 	case callEndReasonCanceledByCaller:
 		postMsg = T("app.call.canceled_by_caller_message")
 		callStatus = callStatusCanceledByCaller
+	case callEndReasonDeclined:
+		postMsg = T("app.call.declined_message")
+		callStatus = callStatusDeclined
 	default:
 		postMsg = T("app.call.ended_message")
 		callStatus = callStatusEnded


### PR DESCRIPTION
## Summary

- Adds `POST /calls/{channel_id}/decline` so the callee of a DM call can end it immediately; disconnects the caller and sets the call card to **Call declined**
- Adds `callEndReasonDeclined` / `callStatusDeclined` to the enums introduced by MM-69753, and the corresponding i18n string ("Call declined")
- `POST /calls/{channel_id}/dismiss-notification` retains its original Ignore semantics on all channel types — it does **not** route to decline logic

Depends on MM-69753-dm-timer.

## Design notes

**Why dismiss-notification is unchanged:** The webapp sends `dismiss-notification` as part of the join flow — it is dispatched *before* `connectCall` when the callee clicks Join (`incoming_calls/hooks.ts`). Routing DM dismiss-notification to `declineCall` ended the call before the joining callee could connect, causing other callee clients to keep ringing indefinitely (since `user_joined` never fired). Ignore semantics on dismiss-notification are correct for all channel types; explicit decline is only triggered via `/decline`.

**Ring cancellation on other callee clients** is handled by the `user_joined` WebSocket event: when any session of the callee joins, all their other sessions receive `user_joined`, detect it as a self-join, and call `notificationsStopRinging()`.

**Legacy mobile clients** that tap Ignore on a DM call get true Ignore behavior — the 30s no-answer timer (MM-69753) fires rather than an immediate "Call declined." Modern clients use `/decline` for the explicit declined experience.

**Race guard:** Ending the call sets `EndAt` in the DB before the lock is released. `GetActiveCallByChannelID` filters on `EndAt = 0`, so any subsequent `lockCallReturnState` call (e.g. from the caller's WebSocket disconnect) returns nil state and exits before reaching `updateCallPostEnded` — no explicit guard needed.

**IDOR fix:** `declineCall` calls `HasPermissionToChannel(..., PermissionCreatePost)` before taking the lock, consistent with the existing pattern in `handleJoin` and other mutating handlers.

**Persistence errors** in `UpdateCall`/`DeleteCallsSessions` are logged and continued (best-effort), matching the pattern in `handleDMNoAnswer` — a transient DB error should not leave the caller ringing.

## Test plan

- [ ] Callee calls `POST /calls/{channel_id}/decline` on a DM call → call ends, caller is disconnected, card shows "Call declined"
- [ ] Declining suppresses the incoming-call popup on the callee's other sessions
- [ ] Caller calling `/decline` on their own call returns 403
- [ ] `/decline` on a non-DM channel returns 400
- [ ] `dismiss-notification` on a DM call retains Ignore behavior (call continues, no-answer timer fires)
- [ ] `dismiss-notification` on a GM/channel call retains existing Ignore behavior
- [ ] Callee joining from one client correctly cancels ringing on other callee clients
- [ ] No-answer timer is cancelled on decline