### PR TITLE
fix: don't send VoIP/CallKit push when ringing is disabled (MM-69924)

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -624,6 +624,12 @@ func TestCreateCallStartedPost(t *testing.T) {
 			p, mockAPI, _ := newAPITestPlugin(t)
 			defer mockAPI.AssertExpectations(t)
 
+			// Enable ringing so sendPushNotifications proceeds past the EnableRinging guard.
+			ringCfg := &configuration{}
+			ringCfg.SetDefaults()
+			*ringCfg.EnableRinging = true
+			p.configuration = ringCfg
+
 			channelID := model.NewId()
 			userID := model.NewId()
 

--- a/server/push_notifications.go
+++ b/server/push_notifications.go
@@ -67,6 +67,10 @@ func (p *Plugin) NotificationWillBePushed(notification *model.PushNotification, 
 }
 
 func (p *Plugin) sendPushNotifications(channelID, createdPostID, threadID string, sender *model.User, config *model.Config) {
+	if !*p.getConfiguration().EnableRinging {
+		return
+	}
+
 	if err := p.canSendPushNotifications(config, p.API.GetLicense()); err != nil {
 		return
 	}

--- a/server/push_notifications.go
+++ b/server/push_notifications.go
@@ -67,7 +67,8 @@ func (p *Plugin) NotificationWillBePushed(notification *model.PushNotification, 
 }
 
 func (p *Plugin) sendPushNotifications(channelID, createdPostID, threadID string, sender *model.User, config *model.Config) {
-	if !*p.getConfiguration().EnableRinging {
+	cfg := p.getConfiguration()
+	if cfg.EnableRinging == nil || !*cfg.EnableRinging {
 		return
 	}
 

--- a/server/push_notifications.go
+++ b/server/push_notifications.go
@@ -33,7 +33,11 @@ func (p *Plugin) NotificationWillBePushed(notification *model.PushNotification, 
 	// 1. This is a call start post
 	// 2. We have enabled ringing
 	// 3. The channel is a DM or GM
-	if notification.PostType != callEventPostType || !*p.getConfiguration().EnableRinging {
+	if notification.PostType != callEventPostType {
+		return nil, ""
+	}
+	cfg := p.getConfiguration()
+	if cfg.EnableRinging == nil || !*cfg.EnableRinging {
 		return nil, ""
 	}
 

--- a/server/push_notifications_test.go
+++ b/server/push_notifications_test.go
@@ -18,6 +18,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSendPushNotificationsRingingDisabled(t *testing.T) {
+	mockAPI := &pluginMocks.MockAPI{}
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+
+	p := Plugin{
+		MattermostPlugin: plugin.MattermostPlugin{
+			API: mockAPI,
+		},
+		store: store,
+	}
+
+	mockAPI.On("GetLicense").Return(&model.License{}, nil).Times(2)
+
+	var cfg configuration
+	cfg.SetDefaults()
+	*cfg.EnableRinging = false
+	err := p.setConfiguration(cfg.Clone())
+	require.NoError(t, err)
+
+	var serverConfig model.Config
+	serverConfig.SetDefaults()
+
+	// SendPushNotification must never be called when ringing is disabled.
+	// If the guard is missing, the VoIP/CallKit push would be sent regardless.
+	p.sendPushNotifications(model.NewId(), model.NewId(), model.NewId(), &model.User{Id: model.NewId()}, &serverConfig)
+
+	mockAPI.AssertNotCalled(t, "SendPushNotification")
+}
+
 func TestNotificationWillBePushed(t *testing.T) {
 	mockAPI := &pluginMocks.MockAPI{}
 

--- a/server/push_notifications_test.go
+++ b/server/push_notifications_test.go
@@ -49,6 +49,53 @@ func TestSendPushNotificationsRingingDisabled(t *testing.T) {
 	mockAPI.AssertNotCalled(t, "SendPushNotification")
 }
 
+func TestSendPushNotificationsRingingEnabled(t *testing.T) {
+	mockAPI := &pluginMocks.MockAPI{}
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+
+	p := Plugin{
+		MattermostPlugin: plugin.MattermostPlugin{
+			API: mockAPI,
+		},
+		store: store,
+	}
+
+	// 2 calls inside setOverrides + 1 eager arg to canSendPushNotifications
+	mockAPI.On("GetLicense").Return(&model.License{}, nil).Times(3)
+
+	var cfg configuration
+	cfg.SetDefaults()
+	*cfg.EnableRinging = true
+	err := p.setConfiguration(cfg.Clone())
+	require.NoError(t, err)
+
+	senderID := model.NewId()
+	receiverID := model.NewId()
+	channelID := model.NewId()
+	postID := model.NewId()
+	threadID := model.NewId()
+
+	sender := &model.User{Id: senderID, Username: "sender"}
+	receiver := &model.User{Id: receiverID, Username: "receiver"}
+	channel := &model.Channel{Id: channelID, Type: model.ChannelTypeDirect}
+
+	var serverConfig model.Config
+	serverConfig.SetDefaults()
+
+	mockAPI.On("GetChannel", channelID).Return(channel, nil).Once()
+	mockAPI.On("GetUsersInChannel", channelID, model.ChannelSortByUsername, 0, 8).Return([]*model.User{sender, receiver}, nil).Once()
+	mockAPI.On("GetUser", receiverID).Return(receiver, nil).Once()
+	mockAPI.On("GetConfig").Return(&serverConfig).Once()
+	mockAPI.On("GetPreferencesForUser", receiverID).Return([]model.Preference{}, nil).Once()
+	mockAPI.On("SendPushNotification", mock.Anything, receiverID).Return(nil).Once()
+
+	p.sendPushNotifications(channelID, postID, threadID, sender, &serverConfig)
+
+	mockAPI.AssertExpectations(t)
+}
+
 func TestNotificationWillBePushed(t *testing.T) {
 	mockAPI := &pluginMocks.MockAPI{}
 

--- a/server/push_notifications_test.go
+++ b/server/push_notifications_test.go
@@ -49,6 +49,36 @@ func TestSendPushNotificationsRingingDisabled(t *testing.T) {
 	mockAPI.AssertNotCalled(t, "SendPushNotification")
 }
 
+func TestSendPushNotificationsRingingNil(t *testing.T) {
+	mockAPI := &pluginMocks.MockAPI{}
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+
+	p := Plugin{
+		MattermostPlugin: plugin.MattermostPlugin{
+			API: mockAPI,
+		},
+		store: store,
+	}
+
+	mockAPI.On("GetLicense").Return(&model.License{}, nil).Times(2)
+
+	var cfg configuration
+	cfg.SetDefaults()
+	cfg.EnableRinging = nil
+	err := p.setConfiguration(cfg.Clone())
+	require.NoError(t, err)
+
+	var serverConfig model.Config
+	serverConfig.SetDefaults()
+
+	// SendPushNotification must not be called when EnableRinging is unset (nil).
+	p.sendPushNotifications(model.NewId(), model.NewId(), model.NewId(), &model.User{Id: model.NewId()}, &serverConfig)
+
+	mockAPI.AssertNotCalled(t, "SendPushNotification")
+}
+
 func TestSendPushNotificationsRingingEnabled(t *testing.T) {
 	mockAPI := &pluginMocks.MockAPI{}
 

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1040,10 +1040,6 @@ func TestHandleJoin(t *testing.T) {
 			SkuShortName: "enterprise",
 		}, nil).Unset()
 
-		mockAPI.On("GetChannel", channelID).Return(&model.Channel{
-			Id:   channelID,
-			Type: model.ChannelTypeOpen,
-		}, nil).Once()
 		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallStart).Once()
 		mockAPI.On("PublishWebSocketEvent", wsEventCallStart, mock.Anything,
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
@@ -1184,11 +1180,6 @@ func TestHandleJoin(t *testing.T) {
 				mockMetrics.On("IncWebSocketEvent", "out", wsEventCallStart).Once()
 				mockAPI.On("PublishWebSocketEvent", wsEventCallStart, mock.Anything,
 					&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
-
-				mockAPI.On("GetChannel", channelID).Return(&model.Channel{
-					Id:   channelID,
-					Type: model.ChannelTypeOpen,
-				}, nil).Once()
 			}
 
 			mockAPI.On("GetLicense").Return(&model.License{
@@ -1339,10 +1330,6 @@ func TestHandleJoin(t *testing.T) {
 		defer mockMetrics.On("IncWebSocketEvent", "out", wsEventCallStart).Unset()
 		mockAPI.On("PublishWebSocketEvent", wsEventCallStart, mock.Anything,
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true})
-		mockAPI.On("GetChannel", channelID).Return(&model.Channel{
-			Id:   channelID,
-			Type: model.ChannelTypeOpen,
-		}, nil)
 		mockAPI.On("GetLicense").Return(&model.License{
 			SkuShortName: "enterprise",
 		}, nil)
@@ -1517,13 +1504,11 @@ func TestHandleJoin(t *testing.T) {
 		mockAPI.On("GetChannel", channelID).Return(&model.Channel{
 			Id:   channelID,
 			Type: model.ChannelTypeDirect,
-		}, nil).Twice()
+		}, nil).Once()
 
 		mockAPI.On("GetChannelStats", channelID).Return(&model.ChannelStats{
 			MemberCount: 1,
 		}, nil).Once()
-
-		mockAPI.On("GetUsersInChannel", channelID, "username", 0, 8).Return(nil, nil)
 
 		// Call lock
 		mockAPI.On("KVSetWithOptions", "mutex_call_"+channelID, []byte{0x1}, mock.Anything).Return(true, nil)

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -415,7 +415,10 @@ func TestWSReader(t *testing.T) {
 			case <-doneCh:
 			case <-time.After(5 * time.Second):
 				close(us.wsCloseCh)
-				<-doneCh
+				select {
+				case <-doneCh:
+				case <-time.After(time.Second):
+				}
 				t.Fatal("wsReader did not return within timeout")
 			}
 		})

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -386,7 +386,7 @@ func TestWSReader(t *testing.T) {
 		})
 
 		// MM-64737 bug, which shouldn't happen but somehow did.
-		t.Run("nil session but nil error, revoke session, don't crash", func(_ *testing.T) {
+		t.Run("nil session but nil error, revoke session, don't crash", func(t *testing.T) {
 			defer mockAPI.AssertExpectations(t)
 
 			us := newUserSession("userID", "channelID", "connID", "callID", false)
@@ -405,17 +405,19 @@ func TestWSReader(t *testing.T) {
 				"origin", mock.AnythingOfType("string"),
 				"userID", us.userID, "connID", us.connID, "channelID", us.channelID).Once()
 
-			var wg sync.WaitGroup
-			wg.Add(1)
+			doneCh := make(chan struct{})
 			go func() {
-				defer wg.Done()
+				defer close(doneCh)
 				p.wsReader(us, "authSessionID", "handlerID")
 			}()
 
-			time.Sleep(1500 * time.Millisecond)
-			close(us.wsCloseCh)
-
-			wg.Wait()
+			select {
+			case <-doneCh:
+			case <-time.After(5 * time.Second):
+				close(us.wsCloseCh)
+				<-doneCh
+				t.Fatal("wsReader did not return within timeout")
+			}
 		})
 	})
 }


### PR DESCRIPTION
## Summary
- When `EnableRinging` is `false`, `sendPushNotifications` was still sending a VoIP push notification to iOS devices
- iOS CallKit notifications are OS-level and cannot be ignored by the app — they unconditionally present the native incoming-call UI
- Added an early-return guard in `sendPushNotifications` so no VoIP push is sent when ringing is disabled
- Added a test to assert `SendPushNotification` is never called when `EnableRinging=false`

## Test plan
- [ ] Set `EnableRinging` to `false` in plugin config
- [ ] Have a user call another user in a DM from a web client
- [ ] Verify iOS recipient gets a standard push notification only — no native CallKit ringing UI
- [ ] Verify that with `EnableRinging=true` the CallKit ringing still works normally

Fixes [MM-69924](https://mattermost.atlassian.net/browse/MM-69924)