### PR TITLE
[MM-70234] Calls v2: Revert call_ended event name back to call_end

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -31,7 +31,7 @@ const (
 	wsEventUserVideoOff              = "user_video_off"
 	wsEventCallStart                 = "call_start"
 	wsEventCallState                 = "call_state"
-	wsEventCallEnd                   = "call_ended"
+	wsEventCallEnd                   = "call_end"
 	wsEventUserRaiseHand             = "user_raise_hand"
 	wsEventUserUnraiseHand           = "user_unraise_hand"
 	wsEventUserReacted               = "user_reacted"

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -903,7 +903,7 @@ func TestHandleJoin(t *testing.T) {
 		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, map[string]any{"session_id": connID, "user_id": userID},
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
 
-		// Last participant leaving triggers the call_ended broadcast.
+		// Last participant leaving triggers the call_end broadcast.
 		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Once()
 		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, map[string]any{},
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
@@ -1042,7 +1042,7 @@ func TestHandleJoin(t *testing.T) {
 		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, mock.Anything,
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Times(10)
 
-		// Last participant leaving triggers the call_ended broadcast.
+		// Last participant leaving triggers the call_end broadcast.
 		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Once()
 		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, map[string]any{},
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
@@ -1388,7 +1388,7 @@ func TestHandleJoin(t *testing.T) {
 		mockAPI.On("PublishWebSocketEvent", wsEventUserLeft, map[string]any{"session_id": connID, "user_id": userID},
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()
 
-		// Last participant leaving triggers the call_ended broadcast.
+		// Last participant leaving triggers the call_end broadcast.
 		mockMetrics.On("IncWebSocketEvent", "out", wsEventCallEnd).Once()
 		mockAPI.On("PublishWebSocketEvent", wsEventCallEnd, map[string]any{},
 			&model.WebsocketBroadcast{ChannelId: channelID, ReliableClusterSend: true}).Once()

--- a/standalone/src/index.ts
+++ b/standalone/src/index.ts
@@ -298,7 +298,7 @@ export default async function initialiseEmbedApp(cfg: InitConfig) {
         case `custom_${pluginId}_call_start`:
             handleCallStart(store, ev as WebSocketMessage<CallStartData>);
             break;
-        case `custom_${pluginId}_call_ended`:
+        case `custom_${pluginId}_call_end`:
             handleCallEnd(store, ev as WebSocketMessage<EmptyData>);
             break;
         case `custom_${pluginId}_user_joined`:

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -221,7 +221,7 @@ export default class Plugin {
             handleCallStart(store, ev);
         });
 
-        registry.registerWebSocketEventHandler(`custom_${pluginId}_call_ended`, (ev) => {
+        registry.registerWebSocketEventHandler(`custom_${pluginId}_call_end`, (ev) => {
             handleCallEnd(store, ev);
         });
 

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -8,7 +8,7 @@ import {combineReducers} from 'redux';
 import {MAX_NUM_REACTIONS_IN_REACTION_STREAM} from 'src/constants';
 import {reducer as screenSharingIDs} from 'src/state/screen_sharing_ids/reducer';
 import {
-    CALL_ENDED,
+    CALL_END,
     UN_INITIALIZED,
     USER_JOINED,
     USER_LEFT,
@@ -129,7 +129,7 @@ const clientStateReducer = (state: clientState = null, action: clientStateAction
         }
         return state;
     }
-    case CALL_ENDED: {
+    case CALL_END: {
         const data = action.data as callEndData;
         if (data.channelID === state?.channelID) {
             return null;
@@ -400,7 +400,7 @@ const calls = (state: callsState = {}, action: callStateAction) => {
                 ...action.data,
             },
         };
-    case CALL_ENDED: {
+    case CALL_END: {
         const nextState = {...state};
         delete nextState[action.data.channelID];
         return nextState;
@@ -440,7 +440,7 @@ const hosts = (state: hostsState = {}, action: hostsStateAction) => {
             },
         };
     }
-    case CALL_ENDED: {
+    case CALL_END: {
         const nextState = {...state};
         delete nextState[action.data.channelID];
         return nextState;
@@ -585,7 +585,7 @@ const recentlyJoinedUsers = (state: recentlyJoinedUsersState = {}, action: recen
             ...state,
             [action.data.channelID]: state[action.data.channelID]?.filter((val) => val !== action.data.userID),
         };
-    case CALL_ENDED:
+    case CALL_END:
         return {
             ...state,
             [action.data.channelID]: [],
@@ -663,7 +663,7 @@ const didRingForCalls = (state: { [callID: string]: boolean } = {}, action: Ring
             [action.data.callID]: true,
         };
     }
-    case CALL_ENDED: {
+    case CALL_END: {
         const nextState = {...state};
         delete nextState[action.data.callID];
         return nextState;

--- a/webapp/src/state/screen_sharing_ids/reducer.ts
+++ b/webapp/src/state/screen_sharing_ids/reducer.ts
@@ -3,7 +3,7 @@
 
 import {UserSessionState} from '@mattermost/calls-common/lib/types';
 import {Reducer} from 'redux';
-import {CALL_ENDED, UN_INITIALIZED, USER_LEFT} from 'src/state/session/action_types';
+import {CALL_END, UN_INITIALIZED, USER_LEFT} from 'src/state/session/action_types';
 
 import {USER_SCREEN_OFF, USER_SCREEN_ON} from './action_types';
 import {Actions} from './actions';
@@ -59,7 +59,7 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
         return nextState;
     }
 
-    case CALL_ENDED: {
+    case CALL_END: {
         const nextState = {...initialState};
         delete nextState[action.data.channelID];
 

--- a/webapp/src/state/session/action_types.ts
+++ b/webapp/src/state/session/action_types.ts
@@ -14,5 +14,5 @@ export const USER_HAND_LOWERED = `${pluginId}_user_hand_lowered` as const;
 export const USER_REACTED = `${pluginId}_user_reacted` as const;
 export const USER_REACTED_TIMEOUT = `${pluginId}_user_reacted_timeout` as const;
 export const USER_LEFT = `${pluginId}_user_left` as const;
-export const CALL_ENDED = `${pluginId}_call_ended` as const;
+export const CALL_END = `${pluginId}_call_end` as const;
 

--- a/webapp/src/state/session/actions.ts
+++ b/webapp/src/state/session/actions.ts
@@ -6,7 +6,7 @@ import {Channel} from '@mattermost/types/channels';
 import {UserProfile} from '@mattermost/types/users';
 
 import {
-    CALL_ENDED,
+    CALL_END,
     SESSIONS_RECEIVED,
     UN_INITIALIZED,
     USER_HAND_LOWERED,
@@ -130,7 +130,7 @@ export const userLeft = (channelID: Channel['id'], sessionID: string, userID: Us
 export type ActionUserLeft = ReturnType<typeof userLeft>
 
 export const callEnded = (channelID: Channel['id'], callID: string) => ({
-    type: CALL_ENDED,
+    type: CALL_END,
     data: {
         channelID,
         callID,

--- a/webapp/src/state/session/reducer.ts
+++ b/webapp/src/state/session/reducer.ts
@@ -6,7 +6,7 @@ import {Channel} from '@mattermost/types/channels';
 import {Reducer} from 'redux';
 
 import {
-    CALL_ENDED,
+    CALL_END,
     SESSIONS_RECEIVED,
     UN_INITIALIZED,
     USER_HAND_LOWERED,
@@ -233,7 +233,7 @@ export const reducer: Reducer<State, Actions> = (initialState = emptyState, acti
         };
     }
 
-    case CALL_ENDED: {
+    case CALL_END: {
         const nextState = {...initialState};
         delete nextState[action.data.channelID];
 


### PR DESCRIPTION
## Summary

- Reverts `wsEventCallEnd = "call_ended"` back to `"call_end"` in `server/websocket.go`
- Updates the `custom_<pluginId>_call_ended` handler registration in `webapp/src/index.tsx` and `standalone/src/index.ts` to `call_end`
- Renames the internal Redux constant `CALL_ENDED` → `CALL_END` and its wire value in `webapp/src/state/session/action_types.ts`, propagated to all consumers (`reducers.ts`, `session/reducer.ts`, `session/actions.ts`, `screen_sharing_ids/reducer.ts`)
- Updates three test comments in `server/websocket_test.go`

The rename from `call_end` to `call_ended` that landed in PR #1199 was a gratuitous wire-protocol break. Mobile subscribes to `call_end` today (`app/constants/websocket.ts: CALLS_CALL_END`) and has to support both v1 and v2 servers — keeping `call_ended` would force two handlers for one event indefinitely. It was also the only renamed event; every other `wsEvent*` constant is byte-identical between `main` and `v2`. Reverting now while v2 is unreleased is cheap; the cost only goes up after release.

## Test plan

- [ ] `grep` for `call_ended` / `CALL_ENDED` in `.go`/`.ts`/`.tsx` returns nothing
- [ ] End a call (host-end and natural last-participant-leave paths) — call tears down in webapp and standalone
- [ ] Existing `websocket_test.go` tests pass (`go test ./server/... -run TestWebSocket`)