### PR TITLE
[MM-70219] Use short-lived job sessions for recording and transcription

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -21,6 +21,9 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/i18n"
 )
 
+// jobSessionTTL matches the transcriber's own MaxDurationSec ceiling (2 × maxRecDurationMinutes).
+const jobSessionTTL = time.Duration(maxRecDurationMinutes) * time.Minute * 2
+
 func (p *Plugin) createBotSession() (*model.Session, error) {
 	m, err := cluster.NewMutex(p.API, p.metrics, "ensure_bot", cluster.MutexConfig{})
 	if err != nil {
@@ -51,6 +54,17 @@ func (p *Plugin) createBotSession() (*model.Session, error) {
 		return nil, appErr
 	}
 
+	return session, nil
+}
+
+func (p *Plugin) createJobSession() (*model.Session, error) {
+	session, appErr := p.API.CreateSession(&model.Session{
+		UserId:    p.botSession.UserId,
+		ExpiresAt: time.Now().Add(jobSessionTTL).UnixMilli(),
+	})
+	if appErr != nil {
+		return nil, appErr
+	}
 	return session, nil
 }
 

--- a/server/recording_api.go
+++ b/server/recording_api.go
@@ -117,11 +117,16 @@ func (p *Plugin) startRecordingJob(state *callState, callID, userID string) (rst
 		UserIDs:             getUserIDsFromSessions(state.sessions),
 	})
 
+	jobSession, err := p.createJobSession()
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create job session: %w", err)
+	}
+
 	// We don't want to keep the lock while making the API call to the service since it
 	// could take a while to return. We lock again as soon as this returns.
 	p.unlockCall(callID)
-	recJobID, jobErr := p.getJobService().RunJob(job.TypeRecording, callID, state.Call.PostID, recState.ID, p.botSession.Token)
-	state, err := p.lockCallReturnState(callID)
+	recJobID, jobErr := p.getJobService().RunJob(job.TypeRecording, callID, state.Call.PostID, recState.ID, jobSession.Token)
+	state, err = p.lockCallReturnState(callID)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to lock call: %w", err)
 	}

--- a/server/transcription_api.go
+++ b/server/transcription_api.go
@@ -164,11 +164,16 @@ func (p *Plugin) startTranscribingJob(state *callState, callID, userID, trID str
 	// Note: We don't need to send the live captions event until we get the StartAt in the
 	// bot_api handleBotPostJobsStatus
 
+	jobSession, err := p.createJobSession()
+	if err != nil {
+		return fmt.Errorf("failed to create job session: %w", err)
+	}
+
 	// We don't want to keep the lock while making the API call to the service since it
 	// could take a while to return. We lock again as soon as this returns.
 	p.unlockCall(callID)
-	trJobID, jobErr := p.getJobService().RunJob(job.TypeTranscribing, callID, state.Call.PostID, trState.ID, p.botSession.Token)
-	state, err := p.lockCallReturnState(callID)
+	trJobID, jobErr := p.getJobService().RunJob(job.TypeTranscribing, callID, state.Call.PostID, trState.ID, jobSession.Token)
+	state, err = p.lockCallReturnState(callID)
 	if err != nil {
 		return fmt.Errorf("failed to lock call: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Recording and transcription jobs were launched with the pod's main bot session token (`ExpiresAt=0`). That session is revoked on pod deactivation, so any rolling deploy during transcription post-processing would cause 401s when the transcriber tried to publish its results — silently discarding the transcript.
- Fix: `createJobSession()` creates a separate `model.Session` for each job with `ExpiresAt = now + jobSessionTTL` (6 h = 2 × the maximum configurable recording duration). Both recording and transcription jobs receive this per-job token instead of the main bot session token.
- The main bot session is unchanged and continues to be revoked normally on `OnDeactivate`.
- Job sessions expire automatically via Mattermost's periodic session `Cleanup` job (`WHERE ExpiresAt != 0 AND now > ExpiresAt`), so nothing accumulates in the Sessions table.

## Test plan

- [ ] Start a recording + transcription, then disable/re-enable the plugin while transcription is still processing — transcript should post successfully
- [ ] Verify job sessions appear in the Sessions table for the calls bot user with a non-zero `ExpiresAt`
- [ ] Verify the main bot session still has `ExpiresAt=0` and is unaffected

Fixes: MM-70219