### PR TITLE
[MM-69581] Calls v1: don't force-disconnect on transient GetSession error

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -598,7 +598,15 @@ func (p *Plugin) wsReader(us *session, authSessionID, handlerID string) {
 			}
 
 			s, appErr := p.API.GetSession(authSessionID)
-			if appErr != nil || s == nil || (s.ExpiresAt != 0 && time.Now().UnixMilli() >= s.ExpiresAt) {
+			if appErr != nil {
+				// A lookup error (e.g. transient DB failure during a pod roll) is not
+				// the same as a definitively revoked or expired session. Skip this tick
+				// and retry on the next interval rather than force-disconnecting.
+				p.LogWarn("failed to get session, will retry", "channelID", us.channelID, "userID", us.userID, "connID", us.connID, "err", appErr.Error())
+				continue
+			}
+
+			if s == nil || (s.ExpiresAt != 0 && time.Now().UnixMilli() >= s.ExpiresAt) {
 				fields := []any{
 					"channelID",
 					us.channelID,
@@ -608,10 +616,8 @@ func (p *Plugin) wsReader(us *session, authSessionID, handlerID string) {
 					us.connID,
 				}
 
-				if appErr == nil && s == nil {
-					p.LogWarn("no appErr and no session found", fields...)
-				} else if appErr != nil {
-					fields = append(fields, "err", appErr.Error())
+				if s == nil {
+					p.LogWarn("no session found", fields...)
 				} else {
 					fields = append(fields, "sessionID", s.Id, "expiresAt", fmt.Sprintf("%d", s.ExpiresAt))
 				}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -348,7 +348,9 @@ func TestWSReader(t *testing.T) {
 			wg.Wait()
 		})
 
-		t.Run("revoked session", func(_ *testing.T) {
+		// A transient GetSession error (e.g. DB blip during a pod roll) must not
+		// force-disconnect the session; the check is retried on the next tick.
+		t.Run("transient session lookup error", func(_ *testing.T) {
 			defer mockAPI.AssertExpectations(t)
 
 			us := newUserSession("userID", "channelID", "connID", "callID", false)
@@ -356,14 +358,10 @@ func TestWSReader(t *testing.T) {
 			mockAPI.On("GetSession", "authSessionID").Return(nil,
 				model.NewAppError("GetSessionById", "We encountered an error finding the session.", nil, "", http.StatusUnauthorized)).Once()
 
-			mockAPI.On("LogInfo", "invalid or expired session, closing RTC session",
+			mockAPI.On("LogWarn", "failed to get session, will retry",
 				"origin", mock.AnythingOfType("string"),
 				"channelID", us.channelID, "userID", us.userID, "connID", us.connID,
 				"err", "GetSessionById: We encountered an error finding the session.").Once()
-
-			mockAPI.On("LogDebug", "closeRTCSession",
-				"origin", mock.AnythingOfType("string"),
-				"userID", us.userID, "connID", us.connID, "channelID", us.channelID).Once()
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -372,7 +370,9 @@ func TestWSReader(t *testing.T) {
 				p.wsReader(us, "authSessionID", "handlerID")
 			}()
 
-			time.Sleep(time.Second * 2)
+			// Sleep long enough for one tick to fire (1s interval), then close
+			// before the second tick so no second GetSession call is made.
+			time.Sleep(1200 * time.Millisecond)
 			close(us.wsCloseCh)
 
 			wg.Wait()
@@ -386,7 +386,7 @@ func TestWSReader(t *testing.T) {
 
 			mockAPI.On("GetSession", "authSessionID").Return(nil, nil).Once()
 
-			mockAPI.On("LogWarn", "no appErr and no session found",
+			mockAPI.On("LogWarn", "no session found",
 				"origin", mock.AnythingOfType("string"),
 				"channelID", us.channelID, "userID", us.userID, "connID", us.connID)
 

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -355,6 +355,7 @@ func TestWSReader(t *testing.T) {
 
 			us := newUserSession("userID", "channelID", "connID", "callID", false)
 
+			// First tick: transient error — must not disconnect.
 			mockAPI.On("GetSession", "authSessionID").Return(nil,
 				model.NewAppError("GetSessionById", "We encountered an error finding the session.", nil, "", http.StatusUnauthorized)).Once()
 
@@ -363,6 +364,12 @@ func TestWSReader(t *testing.T) {
 				"channelID", us.channelID, "userID", us.userID, "connID", us.connID,
 				"err", "GetSessionById: We encountered an error finding the session.").Once()
 
+			// Second tick: succeeds — confirms wsReader retried rather than exiting.
+			secondCalled := make(chan struct{})
+			mockAPI.On("GetSession", "authSessionID").
+				Return(&model.Session{Id: "authSessionID"}, nil).
+				Run(func(_ mock.Arguments) { close(secondCalled) }).Once()
+
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
@@ -370,9 +377,8 @@ func TestWSReader(t *testing.T) {
 				p.wsReader(us, "authSessionID", "handlerID")
 			}()
 
-			// Sleep long enough for one tick to fire (1s interval), then close
-			// before the second tick so no second GetSession call is made.
-			time.Sleep(1200 * time.Millisecond)
+			// Wait until the second GetSession call fires, then tear down cleanly.
+			<-secondCalled
 			close(us.wsCloseCh)
 
 			wg.Wait()


### PR DESCRIPTION
## Summary

During a K8s rolling update, a transient DB error on the periodic bot-session auth check (`wsReader`) was misclassified as a revoked/expired session. The bot was force-disconnected, `handleLeave` fired, and the recording was torn down mid-call.

Root cause: `GetSession` reads from the replica DB by default, and any `appErr != nil` — including transient connection failures during pod drain — was handled identically to a definitively revoked or expired session.

- Split the auth check condition: `appErr != nil` now logs a warning and `continue`s to the next 10-second tick rather than force-closing the RTC session. Only a confirmed `nil` session (not-found) or an elapsed `ExpiresAt` triggers disconnection.
- Updated the corresponding test: renamed "revoked session" → "transient session lookup error" and verified that no `closeRTCSession` is called on a lookup error.

Fixes MM-69581.

## Test plan

- [ ] `go test -run TestWSReader ./server/` passes (all 6 sub-tests green)
- [ ] Roll MM pods during an active recorded call; recording continues uninterrupted
- [ ] A transient `GetSession` error produces a `LogWarn` and the session stays connected