### PR TITLE
Calls v1: Fix screen share not rendering due to MediaMap race [MM-68318]

### DIFF
--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@mattermost/calls-common": "github:mattermost/calls-common#af309ceb0571ce43cc47ccc754fdb7bbeaf3da83",
+        "@mattermost/calls-common": "github:mattermost/calls-common#59e41e8f8f2211490a36fed3a9f8e7b7d2140e20",
         "@mattermost/compass-icons": "0.1.31",
         "@msgpack/msgpack": "2.7.1",
         "bootstrap": "3.4.1",
@@ -2834,8 +2834,8 @@
     },
     "node_modules/@mattermost/calls-common": {
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#af309ceb0571ce43cc47ccc754fdb7bbeaf3da83",
-      "integrity": "sha512-4gQ7jbc8Lq2PzLn0CczNW1Q54D5pW4C9fcOV3pI8GMQNucDYiVqkxcztSQ3sTtkpbKGzi+Ho++J95/rI2GXDfA==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#59e41e8f8f2211490a36fed3a9f8e7b7d2140e20",
+      "integrity": "sha512-kD6ZglMqOAnT0A/QbM599rZUiJh2rHrPhLljM7BwYIugSin3ANKzCXT36k11KEAOXeF53iK52n4ty2li7OTijg==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
         "fflate": "0.8.2",

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -18,7 +18,7 @@
     "extract": "formatjs extract 'src/**/*.{ts,tsx}' --ignore 'src/**/*.d.ts' --out-file i18n/temp.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' && formatjs compile 'i18n/temp.json' --out-file i18n/en.json && rm i18n/temp.json"
   },
   "dependencies": {
-    "@mattermost/calls-common": "github:mattermost/calls-common#af309ceb0571ce43cc47ccc754fdb7bbeaf3da83",
+    "@mattermost/calls-common": "github:mattermost/calls-common#59e41e8f8f2211490a36fed3a9f8e7b7d2140e20",
     "@mattermost/compass-icons": "0.1.31",
     "@msgpack/msgpack": "2.7.1",
     "bootstrap": "3.4.1",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -7,7 +7,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "0.26.12",
-        "@mattermost/calls-common": "github:mattermost/calls-common#af309ceb0571ce43cc47ccc754fdb7bbeaf3da83",
+        "@mattermost/calls-common": "github:mattermost/calls-common#59e41e8f8f2211490a36fed3a9f8e7b7d2140e20",
         "@mediapipe/tasks-vision": "0.10.22-rc.20250304",
         "@msgpack/msgpack": "2.7.1",
         "@redux-devtools/extension": "3.2.3",
@@ -7928,8 +7928,8 @@
     },
     "node_modules/@mattermost/calls-common": {
       "version": "0.27.2",
-      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#af309ceb0571ce43cc47ccc754fdb7bbeaf3da83",
-      "integrity": "sha512-4gQ7jbc8Lq2PzLn0CczNW1Q54D5pW4C9fcOV3pI8GMQNucDYiVqkxcztSQ3sTtkpbKGzi+Ho++J95/rI2GXDfA==",
+      "resolved": "git+ssh://git@github.com/mattermost/calls-common.git#59e41e8f8f2211490a36fed3a9f8e7b7d2140e20",
+      "integrity": "sha512-kD6ZglMqOAnT0A/QbM599rZUiJh2rHrPhLljM7BwYIugSin3ANKzCXT36k11KEAOXeF53iK52n4ty2li7OTijg==",
       "dependencies": {
         "@msgpack/msgpack": "3.0.0-beta2",
         "fflate": "0.8.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "0.26.12",
-    "@mattermost/calls-common": "github:mattermost/calls-common#af309ceb0571ce43cc47ccc754fdb7bbeaf3da83",
+    "@mattermost/calls-common": "github:mattermost/calls-common#59e41e8f8f2211490a36fed3a9f8e7b7d2140e20",
     "@mediapipe/tasks-vision": "0.10.22-rc.20250304",
     "@msgpack/msgpack": "2.7.1",
     "@redux-devtools/extension": "3.2.3",


### PR DESCRIPTION
## Summary

Bumps `@mattermost/calls-common` to pick up the MediaMap race fix (mattermost/calls-common#56).

- When `dcSignaling:false`, SDP travels via WebSocket and MediaMap via datachannel — two unsynchronized transports
- If `onTrack` fires before the MediaMap DC message arrives, `trackInfo` is `undefined` and the stream event is silently dropped in `client.ts`, so the screen share never renders
- The fix buffers tracks in `RTCPeer.onTrack()` when the MID isn't in the MediaMap yet, then flushes them when the MediaMap DC message arrives

The regression was introduced by the video 1:1 feature (`af309ce` in calls-common).

Note: this PR shouldn't be merged until the fix lands on calls-common, then update PR to point to the squash merge commit.

Fixes: [MM-68318](https://mattermost.atlassian.net/browse/MM-68318)

## Test plan

- [ ] User A shares screen, stops; User B shares screen — User A should see it (requires `dcSignaling:false`, e.g. Firefox client)
- [ ] calls-common CI green: mattermost/calls-common#56