### PR TITLE
[MM-69502] Publish call state over LiveKit

### DIFF
--- a/server/activate.go
+++ b/server/activate.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/mattermost/mattermost-plugin-calls/server/cluster"
 	"github.com/mattermost/mattermost-plugin-calls/server/enterprise"
@@ -54,6 +55,10 @@ func (p *Plugin) createBotSession() (*model.Session, error) {
 
 	return session, nil
 }
+
+// publisherShutdownTimeout bounds how long deactivation waits for the room
+// metadata publisher, which may be blocked acquiring a channel lock.
+const publisherShutdownTimeout = 2 * time.Second
 
 func (p *Plugin) OnActivate() (retErr error) {
 	p.LogDebug("activating")
@@ -158,6 +163,9 @@ func (p *Plugin) OnActivate() (retErr error) {
 
 	go p.clusterEventsHandler()
 
+	p.publisherWg.Add(1)
+	go p.roomMetadataPublisher()
+
 	p.LogDebug("activated", "ClusterID", status.ClusterId)
 
 	return nil
@@ -174,6 +182,9 @@ func (p *Plugin) OnDeactivate() error {
 	}
 	p.dmNoAnswerTimers = nil
 	p.dmNoAnswerTimersMut.Unlock()
+
+	// The publisher reads call state, so it has to be down before the store is.
+	p.waitForPublisher(publisherShutdownTimeout)
 
 	if err := p.store.Close(); err != nil {
 		p.LogError(err.Error())

--- a/server/activate.go
+++ b/server/activate.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/mattermost/mattermost-plugin-calls/server/cluster"
 	"github.com/mattermost/mattermost-plugin-calls/server/enterprise"
@@ -55,10 +54,6 @@ func (p *Plugin) createBotSession() (*model.Session, error) {
 
 	return session, nil
 }
-
-// publisherShutdownTimeout bounds how long deactivation waits for the room
-// metadata publisher, which may be blocked acquiring a channel lock.
-const publisherShutdownTimeout = 2 * time.Second
 
 func (p *Plugin) OnActivate() (retErr error) {
 	p.LogDebug("activating")
@@ -183,8 +178,13 @@ func (p *Plugin) OnDeactivate() error {
 	p.dmNoAnswerTimers = nil
 	p.dmNoAnswerTimersMut.Unlock()
 
-	// The publisher reads call state, so it has to be down before the store is.
-	p.waitForPublisher(publisherShutdownTimeout)
+	// The publisher reads call state, so it has to be fully down before the store
+	// closes. Closing stopCh cancels its cross-node lock wait and its LiveKit
+	// request, so this normally returns at once. It can still block on a lock
+	// held by another goroutine on this node, or on one in-flight query — both
+	// bounded, the first by handlers not holding the call lock across network
+	// calls and the second by the SQL settings' QueryTimeout.
+	p.publisherWg.Wait()
 
 	if err := p.store.Close(); err != nil {
 		p.LogError(err.Error())

--- a/server/api.go
+++ b/server/api.go
@@ -962,16 +962,6 @@ func (p *Plugin) handleLiveKitWebhook(w http.ResponseWriter, r *http.Request) {
 	case webhook.EventParticipantJoined:
 		p.handleLiveKitSIPParticipantJoined(event)
 		p.handleLiveKitParticipantJoined(event)
-		// Seed the room metadata. It is otherwise only published on change, so a
-		// call whose host was settled by the token endpoint and never changed
-		// again would have none.
-		//
-		// This is the earliest point it can be done: room_started is too early,
-		// since a room with no confirmed session has nothing to publish to, and
-		// the handlers above are what confirm the session. Marking on every join
-		// rather than just the first also means a dropped publish heals on the
-		// next one. Repeats coalesce in the dirty set.
-		p.markCallDirty(event.GetRoom().GetName())
 	case webhook.EventParticipantLeft:
 		p.handleLiveKitSIPParticipantLeft(event)
 		p.handleLiveKitParticipantLeft(event)
@@ -1047,6 +1037,8 @@ func (p *Plugin) handleLiveKitSIPParticipantJoined(event *livekit.WebhookEvent) 
 			UserIDs:             getUserIDsFromSessions(state.sessions),
 		})
 	}
+
+	p.markCallDirtyOnFirstParticipant(state, channelID)
 
 	if err := p.store.CreateCallSession(session); err != nil {
 		p.LogError("handleLiveKitSIPParticipantJoined: failed to create call session",

--- a/server/api.go
+++ b/server/api.go
@@ -962,14 +962,19 @@ func (p *Plugin) handleLiveKitWebhook(w http.ResponseWriter, r *http.Request) {
 	case webhook.EventParticipantJoined:
 		p.handleLiveKitSIPParticipantJoined(event)
 		p.handleLiveKitParticipantJoined(event)
+		// Seed the room metadata. It is otherwise only published on change, so a
+		// call whose host was settled by the token endpoint and never changed
+		// again would have none.
+		//
+		// This is the earliest point it can be done: room_started is too early,
+		// since a room with no confirmed session has nothing to publish to, and
+		// the handlers above are what confirm the session. Marking on every join
+		// rather than just the first also means a dropped publish heals on the
+		// next one. Repeats coalesce in the dirty set.
+		p.markCallDirty(event.GetRoom().GetName())
 	case webhook.EventParticipantLeft:
 		p.handleLiveKitSIPParticipantLeft(event)
 		p.handleLiveKitParticipantLeft(event)
-	case webhook.EventRoomStarted:
-		// Metadata is only published on change, so a call whose host was settled
-		// before anyone connected would have none. Seed it now that the room
-		// exists to be updated.
-		p.markCallDirty(event.GetRoom().GetName())
 	case webhook.EventRoomFinished:
 		p.handleLiveKitRoomFinished(event)
 	case webhook.EventTrackPublished:

--- a/server/api.go
+++ b/server/api.go
@@ -965,6 +965,11 @@ func (p *Plugin) handleLiveKitWebhook(w http.ResponseWriter, r *http.Request) {
 	case webhook.EventParticipantLeft:
 		p.handleLiveKitSIPParticipantLeft(event)
 		p.handleLiveKitParticipantLeft(event)
+	case webhook.EventRoomStarted:
+		// Metadata is only published on change, so a call whose host was settled
+		// before anyone connected would have none. Seed it now that the room
+		// exists to be updated.
+		p.markCallDirty(event.GetRoom().GetName())
 	case webhook.EventRoomFinished:
 		p.handleLiveKitRoomFinished(event)
 	case webhook.EventTrackPublished:
@@ -1021,12 +1026,13 @@ func (p *Plugin) handleLiveKitSIPParticipantJoined(event *livekit.WebhookEvent) 
 		CallID:           state.Call.ID,
 		UserID:           identity,
 		JoinAt:           time.Now().UnixMilli(),
+		ConfirmedAt:      time.Now().UnixMilli(),
 		IsSIPParticipant: true,
 	}
 	state.sessions[sid] = session
 
 	if newHostID := state.getHostID(p.getBotID()); newHostID != state.Call.GetHostID() {
-		state.Call.Props.Hosts = []string{newHostID}
+		p.setCallHost(state, channelID, newHostID)
 		p.publishWebSocketEvent(wsEventCallHostChanged, map[string]interface{}{
 			"hostID":  newHostID,
 			"call_id": state.Call.ID,
@@ -1124,11 +1130,7 @@ func (p *Plugin) handleLiveKitSIPParticipantLeft(event *livekit.WebhookEvent) {
 
 	if state.Call.GetHostID() == identity && len(state.sessions) > 0 {
 		if newHostID := state.getHostID(p.getBotID()); newHostID != identity {
-			if newHostID == "" {
-				state.Call.Props.Hosts = nil
-			} else {
-				state.Call.Props.Hosts = []string{newHostID}
-			}
+			p.setCallHost(state, channelID, newHostID)
 			p.publishWebSocketEvent(wsEventCallHostChanged, map[string]interface{}{
 				"hostID":  newHostID,
 				"call_id": state.Call.ID,

--- a/server/bot_api.go
+++ b/server/bot_api.go
@@ -509,7 +509,7 @@ func (p *Plugin) handleBotPostJobsStatus(w http.ResponseWriter, r *http.Request)
 			// then the live captioning has started. This can change in the future; if it does, we will
 			// only need to change the backend.
 			lcState.StartAt = time.Now().UnixMilli()
-			if err := p.store.UpdateCallJob(lcState); err != nil {
+			if err := p.updateCallJob(callID, lcState); err != nil {
 				res.Err = fmt.Errorf("failed to update call job: %w", err).Error()
 				res.Code = http.StatusInternalServerError
 				return
@@ -521,7 +521,7 @@ func (p *Plugin) handleBotPostJobsStatus(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err := p.store.UpdateCallJob(jb); err != nil {
+	if err := p.updateCallJob(callID, jb); err != nil {
 		res.Err = fmt.Errorf("failed to update call job: %w", err).Error()
 		res.Code = http.StatusInternalServerError
 		return

--- a/server/host_controls.go
+++ b/server/host_controls.go
@@ -55,7 +55,7 @@ func (p *Plugin) changeHost(requesterID, channelID, newHostID string) error {
 		return ErrNotInCall
 	}
 
-	state.Call.Props.Hosts = []string{newHostID}
+	p.setCallHost(state, channelID, newHostID)
 	state.Call.Props.HostLockedUserID = newHostID
 
 	if err := p.store.UpdateCall(&state.Call); err != nil {
@@ -190,6 +190,24 @@ func (p *Plugin) hostSwitchOffParticipantScreen(requesterID, channelID, sessionI
 		"channel_id": channelID,
 		"session_id": sessionID,
 	}, &WebSocketBroadcast{UserID: ust.UserID, ReliableClusterSend: true})
+
+	// Also ask over LiveKit, which is the only path standalone will have left
+	// once it drops the Calls WebSocket. Unlike the other host controls this
+	// cannot be enforced server-side: muting the track would leave the capture
+	// running and the browser's sharing indicator lit while nobody receives
+	// anything, so the client has to tear it down. Once it does, the
+	// track_unpublished webhook clears the call's screen-sharing state.
+	//
+	// A client that handles both stops sharing twice, which is a no-op. The
+	// failure is logged rather than returned because the WebSocket event above
+	// is still the working path for every client today; this must become the
+	// returned error when that event is removed (MM-69502 PR 7).
+	if err := p.livekitSendHostControl(channelID,
+		composeLivekitIdentity(ust.UserID, sessionID),
+		hostControlActionStopScreenshare); err != nil {
+		p.LogError("failed to send stop screenshare host control",
+			"channelID", channelID, "sessionID", sessionID, "err", err.Error())
+	}
 
 	return nil
 }

--- a/server/livekit_admin.go
+++ b/server/livekit_admin.go
@@ -184,13 +184,13 @@ func (p *Plugin) livekitDeleteRoom(room string) error {
 // client, including standalone bundles with no Mattermost WebSocket, receives it
 // through RoomEvent.RoomMetadataChanged, and newly connected clients get the
 // current value on connect — so this needs no companion resync path.
-func (p *Plugin) livekitUpdateRoomMetadata(room, metadata string) error {
+func (p *Plugin) livekitUpdateRoomMetadata(ctx context.Context, room, metadata string) error {
 	client, err := p.getLiveKitRoomClient()
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), livekitAPITimeout)
+	ctx, cancel := context.WithTimeout(ctx, livekitAPITimeout)
 	defer cancel()
 
 	if _, err := client.UpdateRoomMetadata(ctx, &livekit.UpdateRoomMetadataRequest{

--- a/server/livekit_admin.go
+++ b/server/livekit_admin.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,6 +30,24 @@ const livekitAttributeRaisedHand = "raised_hand"
 // is server-set on the bot's token grant so clients can filter the bot out of
 // the participant list independently of the plugin-WS bot filter.
 const livekitAttributeBot = "bot"
+
+// livekitTopicHostControl is the data-message topic for host commands the
+// server cannot enforce through the admin API. It mirrors
+// CALL_MESSAGE_TOPICS.HOST_CONTROL on the clients.
+//
+// One topic with an action field rather than a topic per command: any future
+// host action the admin API cannot carry out has this same shape — the server
+// has to ask the client. Requesting an unmute is the clearest case, since the
+// server can mute someone but can never unmute them.
+const livekitTopicHostControl = "host_control"
+
+// hostControlActionStopScreenshare asks the client to stop its screen share.
+const hostControlActionStopScreenshare = "stop_screenshare"
+
+// hostControlPayload is the host_control data-message body.
+type hostControlPayload struct {
+	Action string `json:"action"`
+}
 
 var errLiveKitNotConfigured = errors.New("LiveKit is not configured")
 
@@ -157,6 +176,67 @@ func (p *Plugin) livekitDeleteRoom(room string) error {
 		Room: room,
 	}); err != nil {
 		return fmt.Errorf("livekit DeleteRoom: %w", err)
+	}
+	return nil
+}
+
+// livekitUpdateRoomMetadata pushes call-level state to the room. Every connected
+// client, including standalone bundles with no Mattermost WebSocket, receives it
+// through RoomEvent.RoomMetadataChanged, and newly connected clients get the
+// current value on connect — so this needs no companion resync path.
+func (p *Plugin) livekitUpdateRoomMetadata(room, metadata string) error {
+	client, err := p.getLiveKitRoomClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), livekitAPITimeout)
+	defer cancel()
+
+	if _, err := client.UpdateRoomMetadata(ctx, &livekit.UpdateRoomMetadataRequest{
+		Room:     room,
+		Metadata: metadata,
+	}); err != nil {
+		return fmt.Errorf("livekit UpdateRoomMetadata: %w", err)
+	}
+	return nil
+}
+
+// livekitSendHostControl asks a single client to carry out a host action that
+// the server cannot enforce itself.
+//
+// Almost every host control is enforced through the admin API and needs no
+// message: mutes land as TrackMuted, a lowered hand as an attribute change, a
+// removal as a disconnect. The exception is stopping a screen share.
+// MutePublishedTrack does not stop the client publishing, so the capture stays
+// live and the browser's sharing indicator stays lit while nobody receives
+// anything. Only the client can tear the track down, so it has to be asked.
+//
+// Delivery is best-effort and fails safe: a lost message leaves the share
+// running and the host clicks again.
+func (p *Plugin) livekitSendHostControl(room, identity, action string) error {
+	client, err := p.getLiveKitRoomClient()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(hostControlPayload{Action: action})
+	if err != nil {
+		return fmt.Errorf("failed to marshal host control payload: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), livekitAPITimeout)
+	defer cancel()
+
+	topic := livekitTopicHostControl
+	if _, err := client.SendData(ctx, &livekit.SendDataRequest{
+		Room:                  room,
+		Data:                  data,
+		Kind:                  livekit.DataPacket_RELIABLE,
+		DestinationIdentities: []string{identity},
+		Topic:                 &topic,
+	}); err != nil {
+		return fmt.Errorf("livekit SendData: %w", err)
 	}
 	return nil
 }

--- a/server/livekit_state.go
+++ b/server/livekit_state.go
@@ -174,10 +174,10 @@ func (p *Plugin) publishCallRoomMetadata(channelID string) error {
 			return nil, nil
 		}
 
-		if !anyConfirmedSession(state.sessions) {
+		if confirmedSessionCount(state.sessions) == 0 {
 			// The call exists but nobody has connected, so neither has the room:
 			// the token endpoint settles the host before the first client dials
-			// in. The room_started webhook marks the call dirty again once
+			// in. The first participant_joined marks the call dirty again once
 			// LiveKit has a room to update.
 			return nil, nil
 		}

--- a/server/livekit_state.go
+++ b/server/livekit_state.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-calls/server/public"
+)
+
+// callRoomMetadata is the LiveKit room metadata payload. It carries the
+// call-level state that clients cannot derive from LiveKit itself: who the host
+// is and whether a job is running. Everything else (participants, mute, hand,
+// screen sharing) comes from LiveKit's own events.
+//
+// Metadata is delivered on connect and again on every change, so clients need
+// no separate resync path. Only mutable state belongs here: immutable fields
+// such as OwnerID and StartAt already arrive in the join response, and metadata
+// has a size limit worth respecting.
+type callRoomMetadata struct {
+	HostID        string          `json:"host_id"`
+	Recording     *JobStateClient `json:"recording,omitempty"`
+	Transcription *JobStateClient `json:"transcription,omitempty"`
+	LiveCaptions  *JobStateClient `json:"live_captions,omitempty"`
+}
+
+// newCallRoomMetadata derives the room metadata from a call state snapshot. Job
+// state reuses JobStateClient so clients see the same shape they already
+// consume from the call_job_state WebSocket event.
+func newCallRoomMetadata(state *callState) *callRoomMetadata {
+	if state == nil {
+		return nil
+	}
+
+	return &callRoomMetadata{
+		HostID:        state.Call.GetHostID(),
+		Recording:     getClientStateFromCallJob(state.Recording),
+		Transcription: getClientStateFromCallJob(state.Transcription),
+		LiveCaptions:  getClientStateFromCallJob(state.LiveCaptions),
+	}
+}
+
+// setCallHost assigns the call host in the given state and schedules a room
+// metadata publish. It does not persist: callers commit the call as part of
+// their own critical section, and the publisher reads under the channel lock so
+// it cannot observe a half-finished one.
+//
+// The caller must hold the channel lock.
+func (p *Plugin) setCallHost(state *callState, channelID, newHostID string) {
+	if newHostID == "" {
+		state.Call.Props.Hosts = nil
+	} else {
+		state.Call.Props.Hosts = []string{newHostID}
+	}
+
+	p.markCallDirty(channelID)
+}
+
+// createCallJob persists a new job and schedules a room metadata publish. It
+// wraps the store method so that job state cannot start without the room being
+// told, rather than relying on callers to remember a separate call.
+func (p *Plugin) createCallJob(channelID string, job *public.CallJob) error {
+	if err := p.store.CreateCallJob(job); err != nil {
+		return err
+	}
+
+	p.markCallDirty(channelID)
+
+	return nil
+}
+
+// updateCallJob persists a job change and schedules a room metadata publish.
+// See createCallJob for why this wraps the store method.
+func (p *Plugin) updateCallJob(channelID string, job *public.CallJob) error {
+	if err := p.store.UpdateCallJob(job); err != nil {
+		return err
+	}
+
+	p.markCallDirty(channelID)
+
+	return nil
+}
+
+// markCallDirty records that the given channel's room metadata needs
+// republishing and wakes the publisher. It never blocks on anything but a
+// nanosecond-scale in-process mutex, so it is safe to call while holding the
+// channel lock.
+//
+// The map deduplicates: several changes to the same call coalesce into one
+// publish, which matters because stopping a recording also stops transcription
+// and vice versa.
+func (p *Plugin) markCallDirty(channelID string) {
+	p.dirtyCallsMut.Lock()
+	if p.dirtyCalls == nil {
+		p.dirtyCalls = map[string]struct{}{}
+	}
+	p.dirtyCalls[channelID] = struct{}{}
+	p.dirtyCallsMut.Unlock()
+
+	// A pending wakeup covers any number of marks, so a full channel is success.
+	select {
+	case p.dirtyCallsCh <- struct{}{}:
+	default:
+	}
+}
+
+// roomMetadataPublisher publishes room metadata for calls marked dirty. It is
+// signal-driven rather than polled: a ticker would make its interval the
+// user-visible latency floor for host and recording changes.
+//
+// Publishing is best-effort. A failed publish is logged and dropped rather than
+// retried, which would spin while LiveKit is down; MM-69510's reconciliation
+// sweep is the retry, comparing metadata against the database and republishing
+// on divergence.
+func (p *Plugin) roomMetadataPublisher() {
+	defer p.publisherWg.Done()
+
+	for {
+		select {
+		case <-p.dirtyCallsCh:
+			p.publishDirtyCalls()
+		case <-p.stopCh:
+			return
+		}
+	}
+}
+
+// publishDirtyCalls takes the current dirty set and publishes each call's room
+// metadata. Marks arriving during a publish land in the fresh set with a wakeup
+// pending, so nothing is lost; at worst the same state is published twice.
+func (p *Plugin) publishDirtyCalls() {
+	p.dirtyCallsMut.Lock()
+	dirty := p.dirtyCalls
+	p.dirtyCalls = map[string]struct{}{}
+	p.dirtyCallsMut.Unlock()
+
+	for channelID := range dirty {
+		select {
+		case <-p.stopCh:
+			return
+		default:
+		}
+
+		if err := p.publishCallRoomMetadata(channelID); err != nil {
+			p.LogError("failed to publish call room metadata",
+				"channelID", channelID, "err", err.Error())
+		}
+	}
+}
+
+// publishCallRoomMetadata reads the call state and pushes it to the LiveKit
+// room.
+//
+// The read happens under the channel lock so that a mark made mid-critical
+// section cannot be serviced before that section commits — which is what lets
+// markCallDirty be called anywhere, including before the caller's own
+// UpdateCall. The LiveKit round trip happens after the lock is released: it is a
+// network call, and holding the lock across it would block every other
+// operation on that call.
+func (p *Plugin) publishCallRoomMetadata(channelID string) error {
+	data, err := func() ([]byte, error) {
+		state, err := p.lockCallReturnState(channelID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to lock call: %w", err)
+		}
+		defer p.unlockCall(channelID)
+
+		if state == nil {
+			// The call ended while the publish was queued. The room is gone with
+			// it, so there is nothing to update.
+			return nil, nil
+		}
+
+		if !anyConfirmedSession(state.sessions) {
+			// The call exists but nobody has connected, so neither has the room:
+			// the token endpoint settles the host before the first client dials
+			// in. The room_started webhook marks the call dirty again once
+			// LiveKit has a room to update.
+			return nil, nil
+		}
+
+		return json.Marshal(newCallRoomMetadata(state))
+	}()
+	if err != nil {
+		return err
+	}
+	if data == nil {
+		return nil
+	}
+
+	return p.livekitUpdateRoomMetadata(channelID, string(data))
+}
+
+// waitForPublisher gives the metadata publisher a bounded window to exit on
+// deactivation, so it is not left reading from a store that is about to close.
+// It can be mid-lock-acquisition, hence the timeout rather than an open-ended
+// wait.
+func (p *Plugin) waitForPublisher(timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		p.publisherWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		p.LogWarn("timed out waiting for room metadata publisher to exit")
+	}
+}

--- a/server/livekit_state.go
+++ b/server/livekit_state.go
@@ -4,9 +4,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/mattermost/mattermost-plugin-calls/server/public"
 )
@@ -118,10 +118,21 @@ func (p *Plugin) markCallDirty(channelID string) {
 func (p *Plugin) roomMetadataPublisher() {
 	defer p.publisherWg.Done()
 
+	// Cancelled on shutdown so an in-flight publish gives up its cross-node lock
+	// wait and its LiveKit request promptly. Without it, deactivation would
+	// either close the store from under a publish still in progress or wait out
+	// lockTimeout plus livekitAPITimeout.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-p.stopCh
+		cancel()
+	}()
+
 	for {
 		select {
 		case <-p.dirtyCallsCh:
-			p.publishDirtyCalls()
+			p.publishDirtyCalls(ctx)
 		case <-p.stopCh:
 			return
 		}
@@ -131,7 +142,7 @@ func (p *Plugin) roomMetadataPublisher() {
 // publishDirtyCalls takes the current dirty set and publishes each call's room
 // metadata. Marks arriving during a publish land in the fresh set with a wakeup
 // pending, so nothing is lost; at worst the same state is published twice.
-func (p *Plugin) publishDirtyCalls() {
+func (p *Plugin) publishDirtyCalls(ctx context.Context) {
 	p.dirtyCallsMut.Lock()
 	dirty := p.dirtyCalls
 	p.dirtyCalls = map[string]struct{}{}
@@ -144,7 +155,7 @@ func (p *Plugin) publishDirtyCalls() {
 		default:
 		}
 
-		if err := p.publishCallRoomMetadata(channelID); err != nil {
+		if err := p.publishCallRoomMetadata(ctx, channelID); err != nil {
 			p.LogError("failed to publish call room metadata",
 				"channelID", channelID, "err", err.Error())
 		}
@@ -160,9 +171,9 @@ func (p *Plugin) publishDirtyCalls() {
 // UpdateCall. The LiveKit round trip happens after the lock is released: it is a
 // network call, and holding the lock across it would block every other
 // operation on that call.
-func (p *Plugin) publishCallRoomMetadata(channelID string) error {
+func (p *Plugin) publishCallRoomMetadata(ctx context.Context, channelID string) error {
 	data, err := func() ([]byte, error) {
-		state, err := p.lockCallReturnState(channelID)
+		state, err := p.lockCallReturnStateCtx(ctx, channelID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lock call: %w", err)
 		}
@@ -191,23 +202,5 @@ func (p *Plugin) publishCallRoomMetadata(channelID string) error {
 		return nil
 	}
 
-	return p.livekitUpdateRoomMetadata(channelID, string(data))
-}
-
-// waitForPublisher gives the metadata publisher a bounded window to exit on
-// deactivation, so it is not left reading from a store that is about to close.
-// It can be mid-lock-acquisition, hence the timeout rather than an open-ended
-// wait.
-func (p *Plugin) waitForPublisher(timeout time.Duration) {
-	done := make(chan struct{})
-	go func() {
-		p.publisherWg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(timeout):
-		p.LogWarn("timed out waiting for room metadata publisher to exit")
-	}
+	return p.livekitUpdateRoomMetadata(ctx, channelID, string(data))
 }

--- a/server/livekit_state_test.go
+++ b/server/livekit_state_test.go
@@ -337,15 +337,63 @@ func TestPublishCallRoomMetadata(t *testing.T) {
 	})
 }
 
-func TestAnyConfirmedSession(t *testing.T) {
-	require.False(t, anyConfirmedSession(nil))
-	require.False(t, anyConfirmedSession(map[string]*public.CallSession{
+func TestConfirmedSessionCount(t *testing.T) {
+	require.Zero(t, confirmedSessionCount(nil))
+	require.Zero(t, confirmedSessionCount(map[string]*public.CallSession{
 		"a": {ConfirmedAt: 0},
 	}))
-	require.True(t, anyConfirmedSession(map[string]*public.CallSession{
+	require.Equal(t, 1, confirmedSessionCount(map[string]*public.CallSession{
 		"a": {ConfirmedAt: 0},
 		"b": {ConfirmedAt: 1},
 	}))
+	require.Equal(t, 2, confirmedSessionCount(map[string]*public.CallSession{
+		"a": {ConfirmedAt: 1},
+		"b": {ConfirmedAt: 2},
+	}))
+}
+
+func TestMarkCallDirtyOnFirstParticipant(t *testing.T) {
+	newPlugin := func() *Plugin {
+		return &Plugin{dirtyCalls: map[string]struct{}{}, dirtyCallsCh: make(chan struct{}, 1)}
+	}
+
+	t.Run("marks on the first confirmed participant", func(t *testing.T) {
+		p := newPlugin()
+		state := &callState{sessions: map[string]*public.CallSession{
+			"a": {ConfirmedAt: 1},
+		}}
+
+		p.markCallDirtyOnFirstParticipant(state, "channelA")
+		require.Equal(t, map[string]struct{}{"channelA": {}}, dirtySet(p))
+	})
+
+	t.Run("does not mark on later joins", func(t *testing.T) {
+		// LiveKit fans metadata out to every client in the room, so seeding per
+		// join would be quadratic in identical payloads. Later joiners get the
+		// metadata on connect instead.
+		p := newPlugin()
+		state := &callState{sessions: map[string]*public.CallSession{
+			"a": {ConfirmedAt: 1},
+			"b": {ConfirmedAt: 2},
+		}}
+
+		p.markCallDirtyOnFirstParticipant(state, "channelA")
+		require.Empty(t, dirtySet(p))
+	})
+
+	t.Run("pending sessions do not count as participants", func(t *testing.T) {
+		// Rows minted by the token endpoint are not in the room yet, so a join
+		// alongside them is still the first one LiveKit can deliver to.
+		p := newPlugin()
+		state := &callState{sessions: map[string]*public.CallSession{
+			"a": {ConfirmedAt: 1},
+			"b": {},
+			"c": {},
+		}}
+
+		p.markCallDirtyOnFirstParticipant(state, "channelA")
+		require.Equal(t, map[string]struct{}{"channelA": {}}, dirtySet(p))
+	})
 }
 
 func TestHostSwitchOffParticipantScreen(t *testing.T) {

--- a/server/livekit_state_test.go
+++ b/server/livekit_state_test.go
@@ -1,0 +1,410 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-calls/server/cluster"
+	"github.com/mattermost/mattermost-plugin-calls/server/public"
+
+	serverMocks "github.com/mattermost/mattermost-plugin-calls/server/mocks/github.com/mattermost/mattermost-plugin-calls/server/interfaces"
+	pluginMocks "github.com/mattermost/mattermost-plugin-calls/server/mocks/github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// setupStatePlugin builds a plugin wired to a real store, enough to exercise the
+// dirty set and the metadata publisher. LiveKit is deliberately left
+// unconfigured so a publish that reaches the network fails with a recognisable
+// error rather than silently doing nothing.
+func setupStatePlugin(t *testing.T) (*Plugin, *pluginMocks.MockAPI) {
+	t.Helper()
+
+	mockAPI := &pluginMocks.MockAPI{}
+	mockMetrics := &serverMocks.MockMetrics{}
+
+	store, tearDown := NewTestStore(t)
+	t.Cleanup(tearDown)
+
+	p := &Plugin{
+		MattermostPlugin:  plugin.MattermostPlugin{API: mockAPI},
+		metrics:           mockMetrics,
+		callsClusterLocks: map[string]*cluster.Mutex{},
+		store:             store,
+		nodeID:            "test-node",
+		dirtyCalls:        map[string]struct{}{},
+		dirtyCallsCh:      make(chan struct{}, 1),
+		stopCh:            make(chan struct{}),
+	}
+
+	cfg := &configuration{}
+	cfg.SetDefaults()
+	p.configuration = cfg
+
+	mockMetrics.On("IncStoreOp", mock.Anything).Maybe()
+	mockMetrics.On("ObserveStoreMethodsTime", mock.Anything, mock.AnythingOfType("float64")).Maybe()
+	mockMetrics.On("IncWebSocketEvent", mock.Anything, mock.Anything).Maybe()
+	mockMetrics.On("ObserveAppHandlersTime", mock.Anything, mock.AnythingOfType("float64")).Maybe()
+	mockMetrics.On("ObserveClusterMutexGrabTime", mock.Anything, mock.AnythingOfType("float64")).Maybe()
+	mockMetrics.On("ObserveClusterMutexLockedTime", mock.Anything, mock.AnythingOfType("float64")).Maybe()
+	mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
+	mockAPI.On("KVDelete", mock.Anything).Return(nil).Maybe()
+	mockAPI.On("PublishWebSocketEvent", mock.Anything, mock.Anything, mock.Anything).Maybe()
+	for _, method := range []string{"LogDebug", "LogInfo", "LogWarn", "LogError"} {
+		for n := 1; n <= 20; n++ {
+			args := make([]any, n)
+			for i := range args {
+				args[i] = mock.Anything
+			}
+			mockAPI.On(method, args...).Maybe()
+		}
+	}
+
+	return p, mockAPI
+}
+
+// dirtySet returns a copy of the current dirty set.
+func dirtySet(p *Plugin) map[string]struct{} {
+	p.dirtyCallsMut.Lock()
+	defer p.dirtyCallsMut.Unlock()
+	out := make(map[string]struct{}, len(p.dirtyCalls))
+	for k := range p.dirtyCalls {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+func TestNewCallRoomMetadata(t *testing.T) {
+	t.Run("nil state", func(t *testing.T) {
+		require.Nil(t, newCallRoomMetadata(nil))
+	})
+
+	t.Run("host only, jobs omitted", func(t *testing.T) {
+		state := &callState{}
+		state.Call.Props.Hosts = []string{"userA"}
+
+		md := newCallRoomMetadata(state)
+		require.Equal(t, "userA", md.HostID)
+		require.Nil(t, md.Recording)
+		require.Nil(t, md.Transcription)
+		require.Nil(t, md.LiveCaptions)
+
+		data, err := json.Marshal(md)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"host_id":"userA"}`, string(data))
+	})
+
+	t.Run("no host serializes as empty, not omitted", func(t *testing.T) {
+		// Clients need to be able to tell "nobody is host" from "the field was
+		// not sent", since the latter would leave a stale host badge up.
+		data, err := json.Marshal(newCallRoomMetadata(&callState{}))
+		require.NoError(t, err)
+		require.JSONEq(t, `{"host_id":""}`, string(data))
+	})
+
+	t.Run("jobs use the client shape", func(t *testing.T) {
+		state := &callState{}
+		state.Call.Props.Hosts = []string{"userA"}
+		state.Recording = &public.CallJob{
+			Type:    public.JobTypeRecording,
+			InitAt:  100,
+			StartAt: 200,
+		}
+		state.Transcription = &public.CallJob{
+			Type:   public.JobTypeTranscribing,
+			InitAt: 300,
+			EndAt:  400,
+			Props:  public.CallJobProps{Err: "boom"},
+		}
+		state.LiveCaptions = &public.CallJob{
+			Type:   public.JobTypeCaptioning,
+			InitAt: 500,
+		}
+
+		data, err := json.Marshal(newCallRoomMetadata(state))
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"host_id": "userA",
+			"recording": {"type":"recording","init_at":100,"start_at":200,"end_at":0},
+			"transcription": {"type":"transcribing","init_at":300,"start_at":0,"end_at":400,"err":"boom"},
+			"live_captions": {"type":"captioning","init_at":500,"start_at":0,"end_at":0}
+		}`, string(data))
+	})
+}
+
+func TestMarkCallDirty(t *testing.T) {
+	t.Run("deduplicates and wakes once", func(t *testing.T) {
+		p := &Plugin{dirtyCalls: map[string]struct{}{}, dirtyCallsCh: make(chan struct{}, 1)}
+
+		p.markCallDirty("channelA")
+		p.markCallDirty("channelA")
+		p.markCallDirty("channelB")
+
+		require.Equal(t, map[string]struct{}{
+			"channelA": {},
+			"channelB": {},
+		}, dirtySet(p))
+
+		// A full doorbell must not block: a pending wakeup already covers every
+		// mark made before it is serviced.
+		require.Len(t, p.dirtyCallsCh, 1)
+	})
+
+	t.Run("lazily allocates the set", func(t *testing.T) {
+		p := &Plugin{dirtyCallsCh: make(chan struct{}, 1)}
+		p.markCallDirty("channelA")
+		require.Equal(t, map[string]struct{}{"channelA": {}}, dirtySet(p))
+	})
+
+	t.Run("marks during a publish are not lost", func(t *testing.T) {
+		p, _ := setupStatePlugin(t)
+
+		p.markCallDirty("channelA")
+
+		// publishDirtyCalls swaps the set before publishing, so a mark made while
+		// it is working lands in the fresh set rather than being dropped with the
+		// batch being drained.
+		<-p.dirtyCallsCh
+		p.dirtyCallsMut.Lock()
+		p.dirtyCalls = map[string]struct{}{}
+		p.dirtyCallsMut.Unlock()
+
+		p.markCallDirty("channelB")
+		require.Equal(t, map[string]struct{}{"channelB": {}}, dirtySet(p))
+		require.Len(t, p.dirtyCallsCh, 1)
+	})
+
+	t.Run("publishDirtyCalls drains the set", func(t *testing.T) {
+		p, _ := setupStatePlugin(t)
+
+		// Neither channel has a call, so both publishes are no-ops. What matters
+		// is that the set comes back empty.
+		p.markCallDirty("channelA")
+		p.markCallDirty("channelB")
+		p.publishDirtyCalls()
+
+		require.Empty(t, dirtySet(p))
+	})
+}
+
+func TestSetCallHost(t *testing.T) {
+	t.Run("assigns and marks dirty", func(t *testing.T) {
+		p := &Plugin{dirtyCalls: map[string]struct{}{}, dirtyCallsCh: make(chan struct{}, 1)}
+		state := &callState{}
+
+		p.setCallHost(state, "channelA", "userA")
+
+		require.Equal(t, []string{"userA"}, state.Call.Props.Hosts)
+		require.Equal(t, map[string]struct{}{"channelA": {}}, dirtySet(p))
+	})
+
+	t.Run("empty host clears the list", func(t *testing.T) {
+		p := &Plugin{dirtyCalls: map[string]struct{}{}, dirtyCallsCh: make(chan struct{}, 1)}
+		state := &callState{}
+		state.Call.Props.Hosts = []string{"userA"}
+
+		p.setCallHost(state, "channelA", "")
+
+		require.Nil(t, state.Call.Props.Hosts)
+		require.Equal(t, "", state.Call.GetHostID())
+		require.Equal(t, map[string]struct{}{"channelA": {}}, dirtySet(p))
+	})
+}
+
+func TestCallJobDirtyMarking(t *testing.T) {
+	validJob := func(callID string) *public.CallJob {
+		return &public.CallJob{
+			ID:        model.NewId(),
+			CallID:    callID,
+			Type:      public.JobTypeRecording,
+			CreatorID: model.NewId(),
+			InitAt:    time.Now().UnixMilli(),
+		}
+	}
+
+	t.Run("createCallJob marks dirty", func(t *testing.T) {
+		p, _ := setupStatePlugin(t)
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			StartAt:   time.Now().UnixMilli(),
+			ChannelID: model.NewId(),
+			OwnerID:   model.NewId(),
+		}
+		require.NoError(t, p.store.CreateCall(call))
+
+		require.NoError(t, p.createCallJob(call.ChannelID, validJob(call.ID)))
+		require.Equal(t, map[string]struct{}{call.ChannelID: {}}, dirtySet(p))
+	})
+
+	t.Run("updateCallJob marks dirty", func(t *testing.T) {
+		p, _ := setupStatePlugin(t)
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			StartAt:   time.Now().UnixMilli(),
+			ChannelID: model.NewId(),
+			OwnerID:   model.NewId(),
+		}
+		require.NoError(t, p.store.CreateCall(call))
+
+		job := validJob(call.ID)
+		require.NoError(t, p.createCallJob(call.ChannelID, job))
+
+		p.dirtyCallsMut.Lock()
+		p.dirtyCalls = map[string]struct{}{}
+		p.dirtyCallsMut.Unlock()
+
+		job.StartAt = time.Now().UnixMilli()
+		require.NoError(t, p.updateCallJob(call.ChannelID, job))
+		require.Equal(t, map[string]struct{}{call.ChannelID: {}}, dirtySet(p))
+	})
+
+	t.Run("a failed write does not mark dirty", func(t *testing.T) {
+		// Nothing was persisted, so there is nothing for the room to be told
+		// about; marking would publish state that does not exist.
+		p, _ := setupStatePlugin(t)
+
+		require.Error(t, p.createCallJob("channelA", &public.CallJob{}))
+		require.Empty(t, dirtySet(p))
+
+		require.Error(t, p.updateCallJob("channelA", &public.CallJob{}))
+		require.Empty(t, dirtySet(p))
+	})
+}
+
+func TestPublishCallRoomMetadata(t *testing.T) {
+	newCall := func(t *testing.T, p *Plugin, channelID string) *public.Call {
+		t.Helper()
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			StartAt:   time.Now().UnixMilli(),
+			ChannelID: channelID,
+			OwnerID:   model.NewId(),
+			Props:     public.CallProps{NodeID: "test-node"},
+		}
+		require.NoError(t, p.store.CreateCall(call))
+		return call
+	}
+
+	t.Run("no call is a no-op", func(t *testing.T) {
+		// The call ended while the publish sat queued.
+		p, _ := setupStatePlugin(t)
+		require.NoError(t, p.publishCallRoomMetadata(model.NewId()))
+	})
+
+	t.Run("no confirmed session is a no-op", func(t *testing.T) {
+		// The token endpoint settles the host before the first client connects,
+		// so there is no room to update yet. Publishing anyway would fail on
+		// every single call start.
+		p, _ := setupStatePlugin(t)
+		channelID := model.NewId()
+		call := newCall(t, p, channelID)
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:     model.NewId(),
+			CallID: call.ID,
+			UserID: model.NewId(),
+			JoinAt: time.Now().UnixMilli(),
+		}))
+
+		require.NoError(t, p.publishCallRoomMetadata(channelID))
+	})
+
+	t.Run("a confirmed session publishes", func(t *testing.T) {
+		p, _ := setupStatePlugin(t)
+		channelID := model.NewId()
+		call := newCall(t, p, channelID)
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:          model.NewId(),
+			CallID:      call.ID,
+			UserID:      model.NewId(),
+			JoinAt:      time.Now().UnixMilli(),
+			ConfirmedAt: time.Now().UnixMilli(),
+		}))
+
+		// LiveKit is unconfigured in tests, so reaching the client is how we know
+		// both guards were passed.
+		require.ErrorIs(t, p.publishCallRoomMetadata(channelID), errLiveKitNotConfigured)
+	})
+}
+
+func TestAnyConfirmedSession(t *testing.T) {
+	require.False(t, anyConfirmedSession(nil))
+	require.False(t, anyConfirmedSession(map[string]*public.CallSession{
+		"a": {ConfirmedAt: 0},
+	}))
+	require.True(t, anyConfirmedSession(map[string]*public.CallSession{
+		"a": {ConfirmedAt: 0},
+		"b": {ConfirmedAt: 1},
+	}))
+}
+
+func TestHostSwitchOffParticipantScreen(t *testing.T) {
+	// The host control has to keep working while clients are still migrating: the
+	// LiveKit message is additive, the WebSocket event is what stops the share
+	// today, and LiveKit being unreachable must not swallow it.
+	t.Run("publishes the WebSocket event even when LiveKit is unreachable", func(t *testing.T) {
+		p, mockAPI := setupStatePlugin(t)
+
+		channelID := model.NewId()
+		hostID := model.NewId()
+		sessionID := model.NewId()
+
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			StartAt:   time.Now().UnixMilli(),
+			ChannelID: channelID,
+			OwnerID:   hostID,
+			Props: public.CallProps{
+				Hosts:                  []string{hostID},
+				ScreenSharingSessionID: sessionID,
+			},
+		}
+		require.NoError(t, p.store.CreateCall(call))
+		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
+			ID:          sessionID,
+			CallID:      call.ID,
+			UserID:      hostID,
+			JoinAt:      time.Now().UnixMilli(),
+			ConfirmedAt: time.Now().UnixMilli(),
+		}))
+
+		require.NoError(t, p.hostSwitchOffParticipantScreen(hostID, channelID, sessionID))
+
+		mockAPI.AssertCalled(t, "PublishWebSocketEvent", wsEventHostScreenOff,
+			mock.Anything, mock.Anything)
+	})
+
+	t.Run("no-op when the session is not the one sharing", func(t *testing.T) {
+		p, mockAPI := setupStatePlugin(t)
+
+		channelID := model.NewId()
+		hostID := model.NewId()
+		sessionID := model.NewId()
+
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			StartAt:   time.Now().UnixMilli(),
+			ChannelID: channelID,
+			OwnerID:   hostID,
+			Props:     public.CallProps{Hosts: []string{hostID}},
+		}
+		require.NoError(t, p.store.CreateCall(call))
+
+		require.NoError(t, p.hostSwitchOffParticipantScreen(hostID, channelID, sessionID))
+
+		mockAPI.AssertNotCalled(t, "PublishWebSocketEvent", wsEventHostScreenOff,
+			mock.Anything, mock.Anything)
+	})
+}

--- a/server/livekit_state_test.go
+++ b/server/livekit_state_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -189,7 +190,7 @@ func TestMarkCallDirty(t *testing.T) {
 		// is that the set comes back empty.
 		p.markCallDirty("channelA")
 		p.markCallDirty("channelB")
-		p.publishDirtyCalls()
+		p.publishDirtyCalls(context.Background())
 
 		require.Empty(t, dirtySet(p))
 	})
@@ -299,7 +300,7 @@ func TestPublishCallRoomMetadata(t *testing.T) {
 	t.Run("no call is a no-op", func(t *testing.T) {
 		// The call ended while the publish sat queued.
 		p, _ := setupStatePlugin(t)
-		require.NoError(t, p.publishCallRoomMetadata(model.NewId()))
+		require.NoError(t, p.publishCallRoomMetadata(context.Background(), model.NewId()))
 	})
 
 	t.Run("no confirmed session is a no-op", func(t *testing.T) {
@@ -316,7 +317,7 @@ func TestPublishCallRoomMetadata(t *testing.T) {
 			JoinAt: time.Now().UnixMilli(),
 		}))
 
-		require.NoError(t, p.publishCallRoomMetadata(channelID))
+		require.NoError(t, p.publishCallRoomMetadata(context.Background(), channelID))
 	})
 
 	t.Run("a confirmed session publishes", func(t *testing.T) {
@@ -333,7 +334,7 @@ func TestPublishCallRoomMetadata(t *testing.T) {
 
 		// LiveKit is unconfigured in tests, so reaching the client is how we know
 		// both guards were passed.
-		require.ErrorIs(t, p.publishCallRoomMetadata(channelID), errLiveKitNotConfigured)
+		require.ErrorIs(t, p.publishCallRoomMetadata(context.Background(), channelID), errLiveKitNotConfigured)
 	})
 }
 
@@ -454,5 +455,135 @@ func TestHostSwitchOffParticipantScreen(t *testing.T) {
 
 		mockAPI.AssertNotCalled(t, "PublishWebSocketEvent", wsEventHostScreenOff,
 			mock.Anything, mock.Anything)
+	})
+}
+
+func TestTranscriptionJobTimeoutChecker(t *testing.T) {
+	// A transcriber that never joins ends both the transcription job and the
+	// live-captions job that rides along with it. The live-captions row used to
+	// be left open because the update persisted the transcription job twice.
+	t.Run("ends the live captions job too", func(t *testing.T) {
+		p, _ := setupStatePlugin(t)
+
+		cfg := p.configuration.Clone()
+		cfg.EnableRecordings = model.NewPointer(true)
+		cfg.EnableTranscriptions = model.NewPointer(true)
+		cfg.EnableLiveCaptions = model.NewPointer(true)
+		p.configuration = cfg
+
+		channelID := model.NewId()
+		call := &public.Call{
+			ID:        model.NewId(),
+			CreateAt:  time.Now().UnixMilli(),
+			StartAt:   time.Now().UnixMilli(),
+			ChannelID: channelID,
+			OwnerID:   model.NewId(),
+		}
+		require.NoError(t, p.store.CreateCall(call))
+
+		jobID := model.NewId()
+		trJob := &public.CallJob{
+			ID:        model.NewId(),
+			CallID:    call.ID,
+			Type:      public.JobTypeTranscribing,
+			CreatorID: model.NewId(),
+			InitAt:    time.Now().UnixMilli(),
+			Props:     public.CallJobProps{JobID: jobID},
+		}
+		lcJob := &public.CallJob{
+			ID:        model.NewId(),
+			CallID:    call.ID,
+			Type:      public.JobTypeCaptioning,
+			CreatorID: model.NewId(),
+			InitAt:    time.Now().UnixMilli(),
+			Props:     public.CallJobProps{JobID: jobID},
+		}
+		require.NoError(t, p.store.CreateCallJob(trJob))
+		require.NoError(t, p.store.CreateCallJob(lcJob))
+
+		p.handleTranscriptionJobTimeout(channelID, jobID)
+
+		state, err := p.getCallState(channelID, true)
+		require.NoError(t, err)
+		require.Nil(t, state.Transcription, "the transcription job should no longer be active")
+		require.Nil(t, state.LiveCaptions, "the live captions job should no longer be active")
+	})
+}
+
+func TestRoomMetadataPublisherShutdown(t *testing.T) {
+	// Deactivation waits for the publisher with no timeout, so the publisher has
+	// to abandon a contended lock rather than run out lockTimeout against a store
+	// that is about to close.
+	//
+	// Note this covers the cross-node wait only. cluster.Mutex.Lock takes an
+	// in-process mutex before reaching its ctx-aware polling loop, so contention
+	// with another goroutine on this node is not cancellable; that wait is
+	// instead bounded by handlers not holding the call lock across network calls.
+	t.Run("abandons a contended lock instead of waiting out lockTimeout", func(t *testing.T) {
+		mockAPI := &pluginMocks.MockAPI{}
+		mockMetrics := &serverMocks.MockMetrics{}
+
+		p := &Plugin{
+			MattermostPlugin:  plugin.MattermostPlugin{API: mockAPI},
+			metrics:           mockMetrics,
+			callsClusterLocks: map[string]*cluster.Mutex{},
+			dirtyCalls:        map[string]struct{}{},
+			dirtyCallsCh:      make(chan struct{}, 1),
+			stopCh:            make(chan struct{}),
+		}
+		cfg := &configuration{}
+		cfg.SetDefaults()
+		p.configuration = cfg
+
+		// Another node holds the lock: tryLock never succeeds, so the publisher
+		// parks in the polling loop with our cancellable context.
+		locking := make(chan struct{}, 1)
+		mockAPI.On("KVSetWithOptions", mock.Anything, mock.Anything, mock.Anything).
+			Return(false, nil).
+			Run(func(_ mock.Arguments) {
+				select {
+				case locking <- struct{}{}:
+				default:
+				}
+			})
+		mockAPI.On("KVDelete", mock.Anything).Return(nil).Maybe()
+		mockMetrics.On("ObserveClusterMutexGrabTime", mock.Anything, mock.AnythingOfType("float64")).Maybe()
+		mockMetrics.On("IncClusterMutexLockRetries", mock.Anything).Maybe()
+		for _, method := range []string{"LogDebug", "LogInfo", "LogWarn", "LogError"} {
+			for n := 1; n <= 20; n++ {
+				args := make([]any, n)
+				for i := range args {
+					args[i] = mock.Anything
+				}
+				mockAPI.On(method, args...).Maybe()
+			}
+		}
+
+		p.publisherWg.Add(1)
+		go p.roomMetadataPublisher()
+
+		p.markCallDirty(model.NewId())
+
+		select {
+		case <-locking:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "publisher never attempted the lock")
+		}
+
+		close(p.stopCh)
+
+		done := make(chan struct{})
+		go func() {
+			p.publisherWg.Wait()
+			close(done)
+		}()
+
+		// Well inside lockTimeout, which is what it would take without
+		// cancellation.
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			require.Fail(t, "publisher did not exit; its lock wait was not cancelled")
+		}
 	})
 }

--- a/server/livekit_webhook.go
+++ b/server/livekit_webhook.go
@@ -129,7 +129,7 @@ func (p *Plugin) handleLiveKitParticipantJoined(event *livekit.WebhookEvent) {
 	}
 
 	if newHostID := state.getHostID(p.getBotID()); newHostID != state.Call.GetHostID() {
-		state.Call.Props.Hosts = []string{newHostID}
+		p.setCallHost(state, channelID, newHostID)
 		p.publishWebSocketEvent(wsEventCallHostChanged, map[string]interface{}{
 			"hostID":  newHostID,
 			"call_id": state.Call.ID,
@@ -228,11 +228,7 @@ func (p *Plugin) handleLiveKitParticipantLeft(event *livekit.WebhookEvent) {
 
 	if state.Call.GetHostID() == userID && len(state.sessions) > 0 {
 		if newHostID := state.getHostID(p.getBotID()); newHostID != userID {
-			if newHostID == "" {
-				state.Call.Props.Hosts = nil
-			} else {
-				state.Call.Props.Hosts = []string{newHostID}
-			}
+			p.setCallHost(state, channelID, newHostID)
 			p.publishWebSocketEvent(wsEventCallHostChanged, map[string]interface{}{
 				"hostID":  newHostID,
 				"call_id": state.Call.ID,

--- a/server/livekit_webhook.go
+++ b/server/livekit_webhook.go
@@ -136,6 +136,8 @@ func (p *Plugin) handleLiveKitParticipantJoined(event *livekit.WebhookEvent) {
 		}, &WebSocketBroadcast{ChannelID: channelID, ReliableClusterSend: true})
 	}
 
+	p.markCallDirtyOnFirstParticipant(state, channelID)
+
 	if err := p.store.UpdateCall(&state.Call); err != nil {
 		p.LogError("handleLiveKitParticipantJoined: failed to update call",
 			"channelID", channelID, "err", err.Error())

--- a/server/livekit_webhook_test.go
+++ b/server/livekit_webhook_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -383,7 +384,7 @@ func TestLiveKitParticipantWebhooks(t *testing.T) {
 
 			// And the seed is publishable: the same webhook confirmed the
 			// session, so the room exists by the time the publisher looks.
-			require.ErrorIs(t, p.publishCallRoomMetadata(channelID), errLiveKitNotConfigured)
+			require.ErrorIs(t, p.publishCallRoomMetadata(context.Background(), channelID), errLiveKitNotConfigured)
 
 			p.dirtyCallsMut.Lock()
 			p.dirtyCalls = map[string]struct{}{}

--- a/server/livekit_webhook_test.go
+++ b/server/livekit_webhook_test.go
@@ -353,20 +353,29 @@ func TestLiveKitParticipantWebhooks(t *testing.T) {
 	// Mattermost WebSocket. It is only published on change, so the events that
 	// change it have to say so.
 	t.Run("room metadata", func(t *testing.T) {
-		t.Run("room_started seeds it", func(t *testing.T) {
+		t.Run("participant_joined seeds it even when the host does not change", func(t *testing.T) {
 			// The token endpoint settles the host before anyone connects, so
 			// without this seed a call whose host never changed again would have
-			// no metadata at all.
+			// no metadata at all. room_started cannot do it: a room with no
+			// confirmed session has nothing to publish to.
 			p, _, _ := setupPlugin(t)
 			defer ResetTestStore(t, p.store)
 
 			channelID := model.NewId()
-			send(t, p, &livekit.WebhookEvent{
-				Event: "room_started",
-				Room:  &livekit.Room{Name: channelID},
-			})
+			userID, sessionID := model.NewId(), model.NewId()
+			call := createCall(t, p, channelID)
+			call.Props.Hosts = []string{userID}
+			require.NoError(t, p.store.UpdateCall(call))
+			createPendingSession(t, p, call, userID, sessionID)
+
+			send(t, p, participantEvent("participant_joined", channelID,
+				composeLivekitIdentity(userID, sessionID), "PA_first"))
 
 			require.Equal(t, map[string]struct{}{channelID: {}}, dirtySet(p))
+
+			// And the seed is publishable: the same webhook confirmed the
+			// session, so the room exists by the time the publisher looks.
+			require.ErrorIs(t, p.publishCallRoomMetadata(channelID), errLiveKitNotConfigured)
 		})
 
 		t.Run("a host change on join marks it stale", func(t *testing.T) {

--- a/server/livekit_webhook_test.go
+++ b/server/livekit_webhook_test.go
@@ -111,16 +111,24 @@ func TestLiveKitParticipantWebhooks(t *testing.T) {
 		return call
 	}
 
-	// createPendingSession persists an unconfirmed session, as the POST token
-	// endpoint would.
-	createPendingSession := func(t *testing.T, p *Plugin, call *public.Call, userID, sessionID string) {
+	// createPendingSessionAt persists an unconfirmed session with an explicit join
+	// time. Host selection breaks ties on map iteration order, so any test whose
+	// premise is "A is the host" has to space the joins apart.
+	createPendingSessionAt := func(t *testing.T, p *Plugin, call *public.Call, userID, sessionID string, joinAt int64) {
 		t.Helper()
 		require.NoError(t, p.store.CreateCallSession(&public.CallSession{
 			ID:     sessionID,
 			CallID: call.ID,
 			UserID: userID,
-			JoinAt: time.Now().UnixMilli(),
+			JoinAt: joinAt,
 		}))
+	}
+
+	// createPendingSession persists an unconfirmed session, as the POST token
+	// endpoint would.
+	createPendingSession := func(t *testing.T, p *Plugin, call *public.Call, userID, sessionID string) {
+		t.Helper()
+		createPendingSessionAt(t, p, call, userID, sessionID, time.Now().UnixMilli())
 	}
 
 	send := func(t *testing.T, p *Plugin, event *livekit.WebhookEvent) {
@@ -353,7 +361,7 @@ func TestLiveKitParticipantWebhooks(t *testing.T) {
 	// Mattermost WebSocket. It is only published on change, so the events that
 	// change it have to say so.
 	t.Run("room metadata", func(t *testing.T) {
-		t.Run("participant_joined seeds it even when the host does not change", func(t *testing.T) {
+		t.Run("the first participant_joined seeds it, later ones do not", func(t *testing.T) {
 			// The token endpoint settles the host before anyone connects, so
 			// without this seed a call whose host never changed again would have
 			// no metadata at all. room_started cannot do it: a room with no
@@ -376,6 +384,20 @@ func TestLiveKitParticipantWebhooks(t *testing.T) {
 			// And the seed is publishable: the same webhook confirmed the
 			// session, so the room exists by the time the publisher looks.
 			require.ErrorIs(t, p.publishCallRoomMetadata(channelID), errLiveKitNotConfigured)
+
+			p.dirtyCallsMut.Lock()
+			p.dirtyCalls = map[string]struct{}{}
+			p.dirtyCallsMut.Unlock()
+
+			// A second joiner adds nothing: the room already has the metadata and
+			// they receive it on connect. Re-publishing per join would fan an
+			// identical payload out to everyone already in the room.
+			userB, sessionB := model.NewId(), model.NewId()
+			createPendingSession(t, p, call, userB, sessionB)
+			send(t, p, participantEvent("participant_joined", channelID,
+				composeLivekitIdentity(userB, sessionB), "PA_second"))
+
+			require.Empty(t, dirtySet(p))
 		})
 
 		t.Run("a host change on join marks it stale", func(t *testing.T) {
@@ -401,13 +423,19 @@ func TestLiveKitParticipantWebhooks(t *testing.T) {
 			userA, sessionA := model.NewId(), model.NewId()
 			userB, sessionB := model.NewId(), model.NewId()
 			call := createCall(t, p, channelID)
-			createPendingSession(t, p, call, userA, sessionA)
-			createPendingSession(t, p, call, userB, sessionB)
+			now := time.Now().UnixMilli()
+			createPendingSessionAt(t, p, call, userA, sessionA, now)
+			createPendingSessionAt(t, p, call, userB, sessionB, now+1000)
 
 			send(t, p, participantEvent("participant_joined", channelID,
 				composeLivekitIdentity(userA, sessionA), "PA_a"))
 			send(t, p, participantEvent("participant_joined", channelID,
 				composeLivekitIdentity(userB, sessionB), "PA_b"))
+
+			// The premise of the test: A joined first, so A is the host.
+			state, err := p.getCallState(channelID, true)
+			require.NoError(t, err)
+			require.Equal(t, userA, state.Call.GetHostID())
 
 			p.dirtyCallsMut.Lock()
 			p.dirtyCalls = map[string]struct{}{}

--- a/server/livekit_webhook_test.go
+++ b/server/livekit_webhook_test.go
@@ -49,6 +49,8 @@ func TestLiveKitParticipantWebhooks(t *testing.T) {
 			callsClusterLocks: map[string]*cluster.Mutex{},
 			store:             store,
 			nodeID:            "test-node",
+			dirtyCalls:        map[string]struct{}{},
+			dirtyCallsCh:      make(chan struct{}, 1),
 		}
 		p.licenseChecker = enterprise.NewLicenseChecker(p.API)
 
@@ -345,6 +347,69 @@ func TestLiveKitParticipantWebhooks(t *testing.T) {
 		sessions, err := p.store.GetCallSessions(call.ID, db.GetCallSessionOpts{FromWriter: true})
 		require.NoError(t, err)
 		require.Empty(t, sessions)
+	})
+
+	// Room metadata carries host and job state to clients that have no
+	// Mattermost WebSocket. It is only published on change, so the events that
+	// change it have to say so.
+	t.Run("room metadata", func(t *testing.T) {
+		t.Run("room_started seeds it", func(t *testing.T) {
+			// The token endpoint settles the host before anyone connects, so
+			// without this seed a call whose host never changed again would have
+			// no metadata at all.
+			p, _, _ := setupPlugin(t)
+			defer ResetTestStore(t, p.store)
+
+			channelID := model.NewId()
+			send(t, p, &livekit.WebhookEvent{
+				Event: "room_started",
+				Room:  &livekit.Room{Name: channelID},
+			})
+
+			require.Equal(t, map[string]struct{}{channelID: {}}, dirtySet(p))
+		})
+
+		t.Run("a host change on join marks it stale", func(t *testing.T) {
+			p, _, _ := setupPlugin(t)
+			defer ResetTestStore(t, p.store)
+
+			channelID := model.NewId()
+			userID, sessionID := model.NewId(), model.NewId()
+			call := createCall(t, p, channelID)
+			createPendingSession(t, p, call, userID, sessionID)
+
+			send(t, p, participantEvent("participant_joined", channelID,
+				composeLivekitIdentity(userID, sessionID), "PA_first"))
+
+			require.Equal(t, map[string]struct{}{channelID: {}}, dirtySet(p))
+		})
+
+		t.Run("a host change on leave marks it stale", func(t *testing.T) {
+			p, _, _ := setupPlugin(t)
+			defer ResetTestStore(t, p.store)
+
+			channelID := model.NewId()
+			userA, sessionA := model.NewId(), model.NewId()
+			userB, sessionB := model.NewId(), model.NewId()
+			call := createCall(t, p, channelID)
+			createPendingSession(t, p, call, userA, sessionA)
+			createPendingSession(t, p, call, userB, sessionB)
+
+			send(t, p, participantEvent("participant_joined", channelID,
+				composeLivekitIdentity(userA, sessionA), "PA_a"))
+			send(t, p, participantEvent("participant_joined", channelID,
+				composeLivekitIdentity(userB, sessionB), "PA_b"))
+
+			p.dirtyCallsMut.Lock()
+			p.dirtyCalls = map[string]struct{}{}
+			p.dirtyCallsMut.Unlock()
+
+			// The host leaving hands the role to the remaining participant.
+			send(t, p, participantEvent("participant_left", channelID,
+				composeLivekitIdentity(userA, sessionA), "PA_a"))
+
+			require.Equal(t, map[string]struct{}{channelID: {}}, dirtySet(p))
+		})
 	})
 
 	t.Run("room_finished ends the call with a bot session still present", func(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -37,6 +37,8 @@ func main() {
 		addSessionsBatchers:    map[string]*batching.Batcher{},
 		removeSessionsBatchers: map[string]*batching.Batcher{},
 		dmNoAnswerTimers:       map[string]*time.Timer{},
+		dirtyCalls:             map[string]struct{}{},
+		dirtyCallsCh:           make(chan struct{}, 1),
 	}
 	p.apiRouter = p.newAPIRouter()
 	plugin.ClientMain(p)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -74,6 +74,14 @@ type Plugin struct {
 	dmNoAnswerTimers    map[string]*time.Timer
 	dmNoAnswerTimersMut sync.Mutex
 
+	// dirtyCalls is the set of channels whose LiveKit room metadata is stale.
+	// dirtyCallsCh is a doorbell: it signals that there is work, the set says
+	// what. See markCallDirty.
+	dirtyCalls    map[string]struct{}
+	dirtyCallsMut sync.Mutex
+	dirtyCallsCh  chan struct{}
+	publisherWg   sync.WaitGroup
+
 	// Database
 	store *db.Store
 

--- a/server/recording_api.go
+++ b/server/recording_api.go
@@ -48,7 +48,7 @@ func (p *Plugin) recJobTimeoutChecker(callID, jobID string) {
 
 		recState.Props.Err = "failed to start recording job: timed out waiting for bot to join call"
 		recState.EndAt = time.Now().UnixMilli()
-		if err := p.store.UpdateCallJob(recState); err != nil {
+		if err := p.updateCallJob(callID, recState); err != nil {
 			p.LogError("failed to update call job", "callID", callID, "jobID", jobID, "err", err.Error())
 		}
 
@@ -85,7 +85,7 @@ func (p *Plugin) startRecordingJob(state *callState, callID, userID string) (rst
 	recState.CreatorID = userID
 	recState.InitAt = time.Now().UnixMilli()
 
-	if err := p.store.CreateCallJob(recState); err != nil {
+	if err := p.createCallJob(callID, recState); err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create call job: %w", err)
 	}
 
@@ -134,7 +134,7 @@ func (p *Plugin) startRecordingJob(state *callState, callID, userID string) (rst
 	if jobErr != nil {
 		recState.EndAt = time.Now().UnixMilli()
 		recState.Props.Err = jobErr.Error()
-		if err := p.store.UpdateCallJob(recState); err != nil {
+		if err := p.updateCallJob(callID, recState); err != nil {
 			p.LogError("failed to update call job", "err", err.Error(), "jobID", recJobID, "callID", callID)
 		}
 
@@ -145,7 +145,7 @@ func (p *Plugin) startRecordingJob(state *callState, callID, userID string) (rst
 		return nil, http.StatusForbidden, fmt.Errorf("recording job already in progress")
 	}
 	recState.Props.JobID = recJobID
-	if err := p.store.UpdateCallJob(recState); err != nil {
+	if err := p.updateCallJob(callID, recState); err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to update call job: %w", err)
 	}
 
@@ -189,7 +189,7 @@ func (p *Plugin) stopRecordingJob(state *callState, callID string) (rst *JobStat
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to get recording state: %w", err)
 	}
 	recState.EndAt = time.Now().UnixMilli()
-	if err := p.store.UpdateCallJob(recState); err != nil {
+	if err := p.updateCallJob(callID, recState); err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to update call job: %w", err)
 	}
 

--- a/server/session.go
+++ b/server/session.go
@@ -151,7 +151,7 @@ func (p *Plugin) addUserSession(state *callState, callsEnabled *bool, userID, co
 			p.LogDebug("bot joined, recording job is starting", "jobID", jobID)
 			state.Recording.Props.BotConnID = connID
 
-			if err := p.store.UpdateCallJob(state.Recording); err != nil {
+			if err := p.updateCallJob(channelID, state.Recording); err != nil {
 				state.Recording.Props.BotConnID = ""
 				return nil, fmt.Errorf("%w: failed to update call job: %w", errStoreFailure, err)
 			}
@@ -162,13 +162,13 @@ func (p *Plugin) addUserSession(state *callState, callsEnabled *bool, userID, co
 			if state.LiveCaptions != nil && state.LiveCaptions.StartAt == 0 {
 				p.LogDebug("bot joined, live captions job is starting", "jobID", state.LiveCaptions.ID, "trID", jobID)
 				state.LiveCaptions.Props.BotConnID = connID
-				if err := p.store.UpdateCallJob(state.LiveCaptions); err != nil {
+				if err := p.updateCallJob(channelID, state.LiveCaptions); err != nil {
 					state.LiveCaptions.Props.BotConnID = ""
 					return nil, fmt.Errorf("%w: failed to update call job: %w", errStoreFailure, err)
 				}
 			}
 
-			if err := p.store.UpdateCallJob(state.Transcription); err != nil {
+			if err := p.updateCallJob(channelID, state.Transcription); err != nil {
 				state.Transcription.Props.BotConnID = ""
 				return nil, fmt.Errorf("%w: failed to update call job: %w", errStoreFailure, err)
 			}
@@ -188,7 +188,7 @@ func (p *Plugin) addUserSession(state *callState, callsEnabled *bool, userID, co
 	}
 
 	if newHostID := state.getHostID(p.getBotID()); newHostID != state.Call.GetHostID() {
-		state.Call.Props.Hosts = []string{newHostID}
+		p.setCallHost(state, channelID, newHostID)
 		defer func() {
 			if retErr == nil {
 				p.publishWebSocketEvent(wsEventCallHostChanged, map[string]interface{}{
@@ -345,7 +345,7 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		p.LogDebug("recording bot left the call", "channelID", channelID, "jobID", state.Recording.Props.JobID, "botConnID", originalConnID)
 
 		state.Recording.EndAt = time.Now().UnixMilli()
-		if err := p.store.UpdateCallJob(state.Recording); err != nil {
+		if err := p.updateCallJob(channelID, state.Recording); err != nil {
 			return fmt.Errorf("failed to update call job: %w", err)
 		}
 
@@ -372,7 +372,7 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 		p.LogDebug("transcribing bot left the call", "channelID", channelID, "jobID", state.Transcription.Props.JobID, "botConnID", originalConnID)
 
 		state.Transcription.EndAt = time.Now().UnixMilli()
-		if err := p.store.UpdateCallJob(state.Transcription); err != nil {
+		if err := p.updateCallJob(channelID, state.Transcription); err != nil {
 			return fmt.Errorf("failed to update call job: %w", err)
 		}
 
@@ -406,7 +406,7 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 
 	if state.LiveCaptions != nil && state.LiveCaptions.EndAt == 0 && connID == state.LiveCaptions.Props.BotConnID {
 		state.LiveCaptions.EndAt = time.Now().UnixMilli()
-		if err := p.store.UpdateCallJob(state.LiveCaptions); err != nil {
+		if err := p.updateCallJob(channelID, state.LiveCaptions); err != nil {
 			return fmt.Errorf("failed to update call job: %w", err)
 		}
 	}
@@ -419,11 +419,7 @@ func (p *Plugin) removeUserSession(state *callState, userID, originalConnID, con
 	// Change host if needed
 	if state.Call.GetHostID() == userID && len(state.sessions) > 0 {
 		if newHostID := state.getHostID(p.getBotID()); newHostID != userID {
-			if newHostID == "" {
-				state.Call.Props.Hosts = nil
-			} else {
-				state.Call.Props.Hosts = []string{newHostID}
-			}
+			p.setCallHost(state, channelID, newHostID)
 			p.publishWebSocketEvent(wsEventCallHostChanged, map[string]interface{}{
 				"hostID":  newHostID,
 				"call_id": state.Call.ID,

--- a/server/state.go
+++ b/server/state.go
@@ -407,7 +407,7 @@ func (p *Plugin) cleanCallState(call *public.Call, reason string, endReason call
 	for _, job := range jobs {
 		if job.EndAt == 0 {
 			job.EndAt = time.Now().UnixMilli()
-			if err := p.store.UpdateCallJob(job); err != nil {
+			if err := p.updateCallJob(call.ChannelID, job); err != nil {
 				p.LogError("failed to update call job", "err", err.Error())
 			}
 

--- a/server/sync.go
+++ b/server/sync.go
@@ -17,6 +17,14 @@ const (
 
 // lockCall locks the global (cluster) mutex for the given channelID.
 func (p *Plugin) lockCall(channelID string) error {
+	return p.lockCallCtx(context.Background(), channelID)
+}
+
+// lockCallCtx locks the global (cluster) mutex for the given channelID, giving
+// up early if ctx is done. Background workers that must not outlive plugin
+// shutdown pass a cancellable context; everything else uses lockCall, since a
+// request handler waiting out lockTimeout is the desired behaviour.
+func (p *Plugin) lockCallCtx(ctx context.Context, channelID string) error {
 	p.callsClusterLocksMut.Lock()
 	mut := p.callsClusterLocks[channelID]
 	if mut == nil {
@@ -36,7 +44,7 @@ func (p *Plugin) lockCall(channelID string) error {
 	}
 	p.callsClusterLocksMut.Unlock()
 
-	lockCtx, cancelCtx := context.WithTimeout(context.Background(), lockTimeout)
+	lockCtx, cancelCtx := context.WithTimeout(ctx, lockTimeout)
 	defer cancelCtx()
 
 	if err := mut.Lock(lockCtx); err != nil {
@@ -49,7 +57,13 @@ func (p *Plugin) lockCall(channelID string) error {
 // lockCallReturnState locks the global (cluster) mutex for the given channelID and
 // returns the current state.
 func (p *Plugin) lockCallReturnState(channelID string) (*callState, error) {
-	if err := p.lockCall(channelID); err != nil {
+	return p.lockCallReturnStateCtx(context.Background(), channelID)
+}
+
+// lockCallReturnStateCtx is lockCallReturnState with a cancellable lock wait.
+// See lockCallCtx.
+func (p *Plugin) lockCallReturnStateCtx(ctx context.Context, channelID string) (*callState, error) {
+	if err := p.lockCallCtx(ctx, channelID); err != nil {
 		return nil, fmt.Errorf("failed to create call lock: %w", err)
 	}
 

--- a/server/transcription_api.go
+++ b/server/transcription_api.go
@@ -53,13 +53,13 @@ func (p *Plugin) transcriptionJobTimeoutChecker(callID, jobID string) {
 
 		trState.EndAt = time.Now().UnixMilli()
 		trState.Props.Err = "failed to start transcriber job: timed out waiting for bot to join call"
-		if err := p.store.UpdateCallJob(trState); err != nil {
+		if err := p.updateCallJob(callID, trState); err != nil {
 			p.LogError("failed to update call job", "callID", callID, "jobID", jobID, "err", err.Error())
 		}
 
 		if lcState != nil {
 			lcState.EndAt = time.Now().UnixMilli()
-			if err := p.store.UpdateCallJob(trState); err != nil {
+			if err := p.updateCallJob(callID, trState); err != nil {
 				p.LogError("failed to update call job", "callID", callID, "jobID", jobID, "err", err.Error())
 			}
 		}
@@ -115,7 +115,7 @@ func (p *Plugin) startTranscribingJob(state *callState, callID, userID, trID str
 	trState.CreatorID = userID
 	trState.InitAt = time.Now().UnixMilli()
 
-	if err := p.store.CreateCallJob(trState); err != nil {
+	if err := p.createCallJob(callID, trState); err != nil {
 		return fmt.Errorf("failed to create call job: %w", err)
 	}
 
@@ -128,7 +128,7 @@ func (p *Plugin) startTranscribingJob(state *callState, callID, userID, trID str
 		lcState.Type = public.JobTypeCaptioning
 		lcState.CreatorID = userID
 		lcState.InitAt = time.Now().UnixMilli()
-		if err := p.store.CreateCallJob(lcState); err != nil {
+		if err := p.createCallJob(callID, lcState); err != nil {
 			return fmt.Errorf("failed to create call job: %w", err)
 		}
 	}
@@ -189,12 +189,12 @@ func (p *Plugin) startTranscribingJob(state *callState, callID, userID, trID str
 	if jobErr != nil {
 		trState.EndAt = time.Now().UnixMilli()
 		trState.Props.Err = jobErr.Error()
-		if err := p.store.UpdateCallJob(trState); err != nil {
+		if err := p.updateCallJob(callID, trState); err != nil {
 			p.LogError("failed to update call job", "err", err.Error(), "jobID", trJobID, "callID", callID)
 		}
 		if lcState != nil {
 			state.LiveCaptions.EndAt = time.Now().UnixMilli()
-			if err := p.store.UpdateCallJob(lcState); err != nil {
+			if err := p.updateCallJob(callID, lcState); err != nil {
 				p.LogError("failed to update call job", "err", err.Error(), "jobID", trJobID, "callID", callID)
 			}
 		}
@@ -205,12 +205,12 @@ func (p *Plugin) startTranscribingJob(state *callState, callID, userID, trID str
 		return fmt.Errorf("transcription job already in progress")
 	}
 	trState.Props.JobID = trJobID
-	if err := p.store.UpdateCallJob(trState); err != nil {
+	if err := p.updateCallJob(callID, trState); err != nil {
 		return fmt.Errorf("failed to update call job: %w", err)
 	}
 	if lcState != nil {
 		lcState.Props.JobID = trJobID
-		if err := p.store.UpdateCallJob(lcState); err != nil {
+		if err := p.updateCallJob(callID, lcState); err != nil {
 			return fmt.Errorf("failed to update call job: %w", err)
 		}
 	}
@@ -243,13 +243,13 @@ func (p *Plugin) stopTranscribingJob(state *callState, callID string) (rerr erro
 		return fmt.Errorf("failed to get transcription state: %w", err)
 	}
 	trState.EndAt = time.Now().UnixMilli()
-	if err := p.store.UpdateCallJob(trState); err != nil {
+	if err := p.updateCallJob(callID, trState); err != nil {
 		return fmt.Errorf("failed to update call job: %w", err)
 	}
 	lcState, _ := state.getLiveCaptions()
 	if lcState != nil {
 		lcState.EndAt = time.Now().UnixMilli()
-		if err := p.store.UpdateCallJob(lcState); err != nil {
+		if err := p.updateCallJob(callID, lcState); err != nil {
 			return fmt.Errorf("failed to update call job: %w", err)
 		}
 	}

--- a/server/transcription_api.go
+++ b/server/transcription_api.go
@@ -18,7 +18,12 @@ const transcriptionJobStartTimeout = time.Minute
 
 func (p *Plugin) transcriptionJobTimeoutChecker(callID, jobID string) {
 	time.Sleep(transcriptionJobStartTimeout)
+	p.handleTranscriptionJobTimeout(callID, jobID)
+}
 
+// handleTranscriptionJobTimeout is the body of transcriptionJobTimeoutChecker,
+// split out so it can be exercised without waiting out the timeout.
+func (p *Plugin) handleTranscriptionJobTimeout(callID, jobID string) {
 	state, err := p.lockCallReturnState(callID)
 	if err != nil {
 		p.LogError("failed to lock call", "err", err.Error())
@@ -59,7 +64,7 @@ func (p *Plugin) transcriptionJobTimeoutChecker(callID, jobID string) {
 
 		if lcState != nil {
 			lcState.EndAt = time.Now().UnixMilli()
-			if err := p.updateCallJob(callID, trState); err != nil {
+			if err := p.updateCallJob(callID, lcState); err != nil {
 				p.LogError("failed to update call job", "callID", callID, "jobID", jobID, "err", err.Error())
 			}
 		}

--- a/server/utils.go
+++ b/server/utils.go
@@ -276,14 +276,35 @@ func humanParticipantsRemain(sessions map[string]*public.CallSession, botID stri
 	return false
 }
 
-// anyConfirmedSession reports whether any session has been confirmed connected
-// by LiveKit, which is also the test for whether the room exists: LiveKit
-// creates it when the first participant connects.
-func anyConfirmedSession(sessions map[string]*public.CallSession) bool {
+// confirmedSessionCount returns how many sessions LiveKit has confirmed as
+// connected. Zero is also the test for whether the room exists, since LiveKit
+// creates it when the first participant connects, and one means the caller is
+// looking at that first participant.
+func confirmedSessionCount(sessions map[string]*public.CallSession) int {
+	var n int
 	for _, s := range sessions {
 		if s.ConfirmedAt > 0 {
-			return true
+			n++
 		}
 	}
-	return false
+	return n
+}
+
+// markCallDirtyOnFirstParticipant seeds the LiveKit room metadata when the room
+// first has someone in it to receive it.
+//
+// Metadata is otherwise only published on change, so a call whose host was
+// settled by the token endpoint and never changed again would have none. The
+// seed cannot happen any earlier: a room with no confirmed participant has
+// nothing to publish to. It must not happen on every join either — LiveKit fans
+// each metadata update out to every client in the room, so seeding per join
+// would make a burst join quadratic in identical payloads, and every publish
+// takes the channel lock the joins are contending for. Later joiners get the
+// metadata on connect.
+//
+// The caller must hold the channel lock and have confirmed its own session.
+func (p *Plugin) markCallDirtyOnFirstParticipant(state *callState, channelID string) {
+	if confirmedSessionCount(state.sessions) == 1 {
+		p.markCallDirty(channelID)
+	}
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -275,3 +275,15 @@ func humanParticipantsRemain(sessions map[string]*public.CallSession, botID stri
 	}
 	return false
 }
+
+// anyConfirmedSession reports whether any session has been confirmed connected
+// by LiveKit, which is also the test for whether the room exists: LiveKit
+// creates it when the first participant connects.
+func anyConfirmedSession(sessions map[string]*public.CallSession) bool {
+	for _, s := range sessions {
+		if s.ConfirmedAt > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1107,7 +1107,7 @@ func (p *Plugin) handleBotWSReconnect(connID, prevConnID, originalConnID, channe
 		)
 		state.Recording.Props.BotConnID = connID
 
-		if err := p.store.UpdateCallJob(state.Recording); err != nil {
+		if err := p.updateCallJob(channelID, state.Recording); err != nil {
 			return fmt.Errorf("failed to update call job: %w", err)
 		}
 	} else if state != nil && state.Transcription != nil && state.Transcription.Props.BotConnID == prevConnID {
@@ -1118,12 +1118,12 @@ func (p *Plugin) handleBotWSReconnect(connID, prevConnID, originalConnID, channe
 			"botConnID", connID,
 		)
 		state.Transcription.Props.BotConnID = connID
-		if err := p.store.UpdateCallJob(state.Transcription); err != nil {
+		if err := p.updateCallJob(channelID, state.Transcription); err != nil {
 			return fmt.Errorf("failed to update call job: %w", err)
 		}
 		if state.LiveCaptions != nil && state.LiveCaptions.Props.BotConnID == prevConnID {
 			state.LiveCaptions.Props.BotConnID = connID
-			if err := p.store.UpdateCallJob(state.LiveCaptions); err != nil {
+			if err := p.updateCallJob(channelID, state.LiveCaptions); err != nil {
 				return fmt.Errorf("failed to update call job: %w", err)
 			}
 		}


### PR DESCRIPTION
PR 3 of the [MM-69502](https://mattermost.atlassian.net/browse/MM-69502) stack, on top of #1292. Design in [comment 221932](https://mattermost.atlassian.net/browse/MM-69502?focusedCommentId=221932).

Server-side only, and additive: nothing that works today stops working. Clients pick these up in PRs 4 and 5, and the WebSocket equivalents are removed in PR 7.

### Why

Standalone — the popout and the Desktop widget — has no main Mattermost WebSocket. It receives everything over the Calls WebSocket this ticket deletes. Most of what it needs comes from LiveKit itself (participants, mute, hand, speaking, screen sharing, call end), but three things do not:

- who the host is
- recording / transcription / live-caption state
- host controls with no observable LiveKit effect

HTTP refetch is not a substitute for the first two: the host badge and the recording banner are live UI, and with no push they sit stale until something triggers a fetch. Giving standalone a second socket is the non-answer.

### Room metadata for state

`UpdateRoomMetadata` carries `{host_id, recording, transcription, live_captions}`. Jobs reuse `JobStateClient`, the shape clients already consume from `call_job_state`, so the client change is rewiring rather than reinterpretation. Only mutable state is included — `owner_id`, `start_at` and `post_id` are immutable and already in the join response, and metadata has a size limit.

Metadata is delivered on connect and again on every change, so no resync path is needed. Host is metadata rather than an `is_host` participant attribute because a host change would otherwise be two non-atomic admin calls with an observable window of zero or two hosts.

**Write path.** `setCallHost`, `createCallJob` and `updateCallJob` mark the channel dirty; a background goroutine publishes. The dirty set is a map (dedup) plus a size-1 channel (a doorbell). Deduplication is load-bearing: `stopRecordingJob` and `stopTranscribingJob` call each other, so one job stop marks the same channel two or three times.

The publisher reads **under the channel lock** and makes the LiveKit call after releasing it. That is what lets `markCallDirty` be called anywhere, including before the caller's own `UpdateCall` — the publisher cannot observe a half-finished critical section. It is also why the setters do not persist: several callers commit the call once at the end of their own transaction, and `addUserSession` has no call row to update yet on the first join.

Publishing is best-effort: a failure is logged, not retried, since retrying would spin while LiveKit is down. MM-69510's reconciliation sweep is the retry.

The metadata is seeded on the **first confirmed participant**, in both the human and SIP join handlers. Without a seed, a call whose host was settled by the token endpoint and never changed again would have no metadata at all.

It has to be that moment. `room_started` is too early — a room with no confirmed participant has nothing to publish to, and the `participant_joined` handlers are what confirm the session, so a seed there is guaranteed to be skipped. Every join is too many: LiveKit fans each metadata update out to every client in the room, so seeding per join would make a burst join quadratic in identical payloads, and every publish takes the channel lock those joins are contending for. Later joiners get the metadata on connect.

### A data message for stopping a screen share

Four of the five host controls are already LiveKit-enforced (MM-69107) and their effects are observable: `TrackMuted` for mutes, an attribute change for a lowered hand, a disconnect for a removal. Standalone already consumes exactly those through MM-69148's `CALL_EVENT` bridge, so they keep working after the Calls WebSocket goes — only the explanatory notice is lost, which is UX, not correctness.

Screen-off is the exception, and the message *is* the mechanism: `MutePublishedTrack` does not stop the client publishing, so the capture stays live and the browser's sharing indicator stays lit while nobody receives anything. Only the client can tear the track down. Once it does, PR 2's `track_unpublished` handler already clears the sharing state and banks `ScreenDuration`.

One topic (`host_control`) with an `{action}` field rather than a topic per command: any future host action the admin API cannot carry out has this same shape. Requesting an unmute is the clearest case — the server can mute someone but can never unmute them.

During the transition both are sent, and a LiveKit send failure is logged rather than returned, because the WebSocket event is still the working path for every client today. That must become the returned error in PR 7.

### Notes for the client PRs

- `handleDataReceivedFromParticipant` in `call_client.ts` early-returns on `!participant`. Server-sent data messages have no participant, so that guard has to move.
- The job-error paths in `startRecordingJob` / `startTranscribingJob` broadcast an error over the WebSocket that is never persisted. The publisher reads the database, so metadata cannot carry it. Standalone will not show a job start error until that is reconciled — worth a follow-up, not fixed here.

### Also in this change

SIP sessions now get `ConfirmedAt` set. LiveKit reports them connected in `participant_joined` like anyone else, and leaving them at zero would have made MM-69510's sweep reap live SIP participants.

### A pre-existing bug fixed along the way

`transcription_api.go` set `lcState.EndAt` and then persisted `trState` again, so the live-caption job stayed active after a transcriber start timeout until `cleanCallState` closed it at call end. With `updateCallJob` now marking the call dirty, it also meant the room metadata reported live captions still running.

`handleTranscriptionJobTimeout` is split out of `transcriptionJobTimeoutChecker` to test it — the checker's first statement is `time.Sleep(transcriptionJobStartTimeout)`, so the function is the timer and was untestable as written.

### Testing

`server/livekit_state_test.go`: metadata serialization (including that `host_id` is sent empty rather than omitted, so clients can tell "no host" from "not sent"), dirty-set dedup and swap semantics, marks arriving during a publish, `setCallHost`, that a failed job write does *not* mark dirty, both publisher guards, and that the screen-off control still publishes its WebSocket event when LiveKit is unreachable.

`server/livekit_webhook_test.go`: `room_started` seeds the metadata, and host changes on join and on leave mark it stale.

Shutdown: the publisher gets a context cancelled by `stopCh`, threaded through a new `lockCallCtx` (existing `lockCall` callers unchanged) and into `livekitUpdateRoomMetadata`, so `OnDeactivate` can wait for it unconditionally instead of on a timeout that could expire while a publish was still in flight. Note the bound this does *not* remove: `cluster.Mutex.Lock` takes an in-process mutex before its ctx-aware polling loop, so same-node lock contention is not cancellable — that wait is bounded by handlers not holding the call lock across network calls.

`make golangci-lint` and `go test ./server/...` are green.



