### PR TITLE
Calls v1: clear stale join-call popups on WS reconnect [MM-70670]

### DIFF
--- a/webapp/src/reducers.test.ts
+++ b/webapp/src/reducers.test.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import type {AnyAction} from 'redux';
-import {CALL_END, CALL_STATE, DM_CALLEE_ANSWERED_AT, UNINIT} from 'src/action_types';
+import {ADD_INCOMING_CALL, CALL_END, CALL_STATE, DM_CALLEE_ANSWERED_AT, REMOVE_INCOMING_CALL, UNINIT} from 'src/action_types';
 
 import reducer from './reducers';
 
@@ -73,5 +73,38 @@ describe('dmCalleeAnsweredAt', () => {
         const state = apply(callState(callID), callAnswered(callID, answeredAt), {type: UNINIT});
 
         expect(state.dmCalleeAnsweredAt).toEqual({});
+    });
+});
+
+const incomingCall = (cID: string, cAllID: string) => ({
+    type: ADD_INCOMING_CALL,
+    data: {callID: cAllID, channelID: cID, callerID: 'caller-id', startAt, type: 'D'},
+});
+
+const removeIncomingCall = (cAllID: string) => ({
+    type: REMOVE_INCOMING_CALL,
+    data: {callID: cAllID},
+});
+
+describe('incomingCalls', () => {
+    it('should add and remove incoming call notifications', () => {
+        const state = apply(incomingCall(channelID, callID));
+
+        expect(state.incomingCalls).toHaveLength(1);
+        expect(state.incomingCalls[0].callID).toBe(callID);
+
+        const state2 = apply(incomingCall(channelID, callID), removeIncomingCall(callID));
+
+        expect(state2.incomingCalls).toHaveLength(0);
+    });
+
+    it('should clear all incoming call notifications on UNINIT', () => {
+        const state = apply(
+            incomingCall(channelID, callID),
+            incomingCall('other-channel-id', 'other-call-id'),
+            {type: UNINIT},
+        );
+
+        expect(state.incomingCalls).toHaveLength(0);
     });
 });

--- a/webapp/src/reducers.ts
+++ b/webapp/src/reducers.ts
@@ -978,6 +978,8 @@ type IncomingCallAction = {
 
 const incomingCalls = (state: IncomingCallNotification[] = [], action: IncomingCallAction) => {
     switch (action.type) {
+    case UNINIT:
+        return [];
     case ADD_INCOMING_CALL:
         return [...state, {...action.data}];
     case REMOVE_INCOMING_CALL:


### PR DESCRIPTION
## Summary

- The `incomingCalls` reducer had no `UNINIT` case, so a \"Join Call\" popup could survive indefinitely if the `call_end` WS event arrived during a reconnect dead window.
- Adding `case UNINIT: return []` clears all pending notifications on reconnect; `onActivate`'s channel fetch re-adds only still-active calls.
- Added reducer tests for add/remove and UNINIT behaviour.

## Test plan

- [ ] Start a DM call (User A). Confirm User B sees the \"Join Call\" popup.
- [ ] Simulate User B's WS disconnect (e.g. `! fiber-walk` reconnect trick or brief network blip).
- [ ] End the call while User B is reconnecting.
- [ ] Confirm the popup is gone after User B reconnects (no stale popup, no accidental new call on click).
- [ ] Repeat with a call that is still active when User B reconnects — confirm popup reappears after reconnect.
- [ ] `make test` passes.