### PR TITLE
[MM-70689] Keep DM call tile order stable from ringing to answered

### DIFF
--- a/webapp/src/components/expanded_view/index.ts
+++ b/webapp/src/components/expanded_view/index.ts
@@ -38,7 +38,7 @@ import {
     threadIDForCallInChannel,
     transcriptionsEnabled,
 } from 'src/selectors';
-import {alphaSortSessions, getUserIdFromDM, isDMChannel, stateSortSessions} from 'src/utils';
+import {alphaSortSessions, getUserIdFromDM, isDMChannel, selfFirstSortSessions, stateSortSessions} from 'src/utils';
 import {closeRhs, getIsRhsOpen, getRhsSelectedPostId, modals, selectRhsPost} from 'src/webapp_globals';
 
 import ExpandedView from './component';
@@ -52,12 +52,13 @@ const mapStateToProps = (state: GlobalState) => {
     const threadID = threadIDForCallInChannel(state, channel?.id || '');
 
     const profiles = profilesInCurrentCallMap(state);
+    const isDM = isDMChannel(channel);
     const sessions = sessionsInCurrentCall(state)
         .sort(alphaSortSessions(profiles))
-        .sort(stateSortSessions(screenSharingSession?.session_id || '', true));
+        .sort(isDM ? selfFirstSortSessions(currentUserID) : stateSortSessions(screenSharingSession?.session_id || '', true));
 
     let connectedDMUser;
-    if (channel && isDMChannel(channel)) {
+    if (channel && isDM) {
         const otherID = getUserIdFromDM(channel.name, currentUserID);
         connectedDMUser = getUser(state, otherID);
     }
@@ -94,7 +95,7 @@ const mapStateToProps = (state: GlobalState) => {
         transcriptionsEnabled: transcriptionsEnabled(state),
         isAdmin: isCurrentUserSystemAdmin(state),
         hostControlsAllowed: areHostControlsAllowed(state),
-        enableVideo: callsConfig(state).EnableVideo && isDMChannel(channel),
+        enableVideo: callsConfig(state).EnableVideo && isDM,
         otherSessions: sessionsForOtherUsersInCall(state),
         isDMCalling: isCurrentDMCallInCallingState(state),
         clientConnecting: clientConnecting(state),

--- a/webapp/src/components/expanded_view/participant_cell.test.tsx
+++ b/webapp/src/components/expanded_view/participant_cell.test.tsx
@@ -197,6 +197,12 @@ describe('ParticipantCell', () => {
         expect(screen.queryByTestId('host-badge')).not.toBeInTheDocument();
     });
 
+    test('should not badge the host when the badge is turned off', () => {
+        renderCell({isHost: true, showHostBadge: false});
+
+        expect(screen.queryByTestId('host-badge')).not.toBeInTheDocument();
+    });
+
     test.each([
         ['a small', TileSize.Small, '96px', '12px', '8px'],
         ['a medium', TileSize.Medium, '128px', '16px', '12px'],

--- a/webapp/src/components/expanded_view/participant_cell.tsx
+++ b/webapp/src/components/expanded_view/participant_cell.tsx
@@ -38,6 +38,7 @@ export type Props = {
     isYou: boolean,
     isHost: boolean,
     iAmHost: boolean,
+    showHostBadge?: boolean,
     callID?: string,
     userID: string,
     sessionID: string,
@@ -99,6 +100,7 @@ export default function ParticipantCell({
     isYou,
     isHost,
     iAmHost,
+    showHostBadge = true,
     callID,
     userID,
     sessionID,
@@ -170,7 +172,7 @@ export default function ParticipantCell({
                 {name}
             </span>
 
-            {isHost && <HostBadge data-testid={'host-badge'}/>}
+            {isHost && showHostBadge && <HostBadge data-testid={'host-badge'}/>}
         </>
     );
 

--- a/webapp/src/components/expanded_view/participant_tile.tsx
+++ b/webapp/src/components/expanded_view/participant_tile.tsx
@@ -20,6 +20,7 @@ interface Props {
     currentUserID?: UserProfile['id'];
     callHostID: UserProfile['id'];
     callID: string;
+    showHostBadge?: boolean;
     onParticipantRemove?: (sessionID: string, userID: string) => void,
 }
 
@@ -68,6 +69,7 @@ export function ParticipantTile(props: Props) {
             isYou={isYou}
             isHost={isHost}
             iAmHost={iAmHost}
+            showHostBadge={props.showHostBadge}
             callID={props.callID}
             userID={props.session.user_id}
             sessionID={props.session.session_id}

--- a/webapp/src/components/expanded_view/participants_grid.test.tsx
+++ b/webapp/src/components/expanded_view/participants_grid.test.tsx
@@ -92,4 +92,23 @@ describe('ParticipantsGrid', () => {
         expect(screen.getAllByTestId('participant-tile')).toHaveLength(1);
         expect(screen.getByTestId('participant-tile-loading')).toHaveTextContent(calleeID);
     });
+
+    test('should keep the caller and callee in place when a DM call is answered', () => {
+        const tileOrder = (container: HTMLElement) => Array.from(
+            container.querySelectorAll('#calls-expanded-view-participants-grid > li'),
+        ).map((tile) => tile.textContent);
+
+        const ringing = renderGrid(
+            [session(callerID, 'caller-session-id')],
+            {isDMCalling: true, dmCalleeID: calleeID, dmCallee: callee},
+        );
+
+        expect(tileOrder(ringing.container)).toEqual([callerID, calleeID]);
+
+        ringing.unmount();
+
+        const answered = renderGrid([session(callerID, 'caller-session-id'), session(calleeID, 'callee-session-id')]);
+
+        expect(tileOrder(answered.container)).toEqual([callerID, calleeID]);
+    });
 });

--- a/webapp/src/components/expanded_view/participants_grid.test.tsx
+++ b/webapp/src/components/expanded_view/participants_grid.test.tsx
@@ -21,8 +21,11 @@ jest.mock('src/components/dot_menu/dot_menu', () => ({
 
 // Each tile has its own tests; here they only have to say who they were pointed at.
 jest.mock('./participant_tile', () => ({
-    ParticipantTile: ({session}: { session: UserSessionState }) => (
-        <li data-testid={'participant-tile'}>{session.user_id}</li>
+    ParticipantTile: ({session, showHostBadge}: { session: UserSessionState, showHostBadge?: boolean }) => (
+        <li
+            data-testid={'participant-tile'}
+            data-show-host-badge={String(showHostBadge)}
+        >{session.user_id}</li>
     ),
 }));
 
@@ -46,6 +49,7 @@ const session = (userID: string, sessionID: string) => ({
 } as UserSessionState);
 
 type DMCallingState = {
+    isDM?: boolean;
     isDMCalling: boolean;
     dmCalleeID?: string;
     dmCallee?: UserProfile;
@@ -91,6 +95,18 @@ describe('ParticipantsGrid', () => {
 
         expect(screen.getAllByTestId('participant-tile')).toHaveLength(1);
         expect(screen.getByTestId('participant-tile-loading')).toHaveTextContent(calleeID);
+    });
+
+    test('should not point out the host in a DM call', () => {
+        renderGrid([session(callerID, 'caller-session-id')], {isDM: true, isDMCalling: false});
+
+        expect(screen.getByTestId('participant-tile')).toHaveAttribute('data-show-host-badge', 'false');
+    });
+
+    test('should point out the host in a group call', () => {
+        renderGrid([session(callerID, 'caller-session-id')], {isDM: false, isDMCalling: false});
+
+        expect(screen.getByTestId('participant-tile')).toHaveAttribute('data-show-host-badge', 'true');
     });
 
     test('should keep the caller and callee in place when a DM call is answered', () => {

--- a/webapp/src/components/expanded_view/participants_grid.tsx
+++ b/webapp/src/components/expanded_view/participants_grid.tsx
@@ -160,8 +160,6 @@ export function ParticipantsGrid({
                         currentUserID={currentUserID}
                         callHostID={callHostID}
                         callID={callID}
-
-                        // A 1:1 call has no meaningful host to point out.
                         showHostBadge={!isDM}
                         onParticipantRemove={onParticipantRemove}
                     />

--- a/webapp/src/components/expanded_view/participants_grid.tsx
+++ b/webapp/src/components/expanded_view/participants_grid.tsx
@@ -56,8 +56,7 @@ export function ParticipantsGrid({
 }: Props) {
     const {isDMCalling, dmCalleeID, dmCallee} = useDMCallingState();
 
-    // The ringing placeholder occupies a tile, so sizing has to account for it or tiles would
-    // resize and shift the moment the callee answers.
+    // The ringing placeholder occupies a tile, so sizing has to account for it
     const tileCount = sessions.length + (isDMCalling ? 1 : 0);
 
     const ref = useRef<HTMLDivElement>(null);

--- a/webapp/src/components/expanded_view/participants_grid.tsx
+++ b/webapp/src/components/expanded_view/participants_grid.tsx
@@ -56,6 +56,10 @@ export function ParticipantsGrid({
 }: Props) {
     const {isDMCalling, dmCalleeID, dmCallee} = useDMCallingState();
 
+    // The ringing placeholder occupies a tile, so sizing has to account for it or tiles would
+    // resize and shift the moment the callee answers.
+    const tileCount = sessions.length + (isDMCalling ? 1 : 0);
+
     const ref = useRef<HTMLDivElement>(null);
 
     const [tileSize, setTileSize] = useState(TileSize.Small);
@@ -98,7 +102,7 @@ export function ParticipantsGrid({
             const tilesPerRow = Math.floor((availableWidth + tileSpacing) / tileWidthWithSpacing); // Adjust for effective width with spacing
 
             // Calculate rows needed based on tiles per row
-            const requiredRows = Math.ceil(sessions.length / tilesPerRow);
+            const requiredRows = Math.ceil(tileCount / tilesPerRow);
 
             // Calculate the total height required including the spacing between rows
             const totalHeightNeeded = (requiredRows * tileHeightWithSpacing) - tileSpacing; // Adjust for last row not needing spacing
@@ -135,7 +139,7 @@ export function ParticipantsGrid({
         setTileSize(res.tileSize);
         setPaddingH(res.paddingH);
         setPaddingV(res.paddingV);
-    }, [sessions.length, resize]);
+    }, [tileCount, resize]);
 
     return (
         <ParticipantsGridContainer

--- a/webapp/src/components/expanded_view/participants_grid.tsx
+++ b/webapp/src/components/expanded_view/participants_grid.tsx
@@ -54,7 +54,7 @@ export function ParticipantsGrid({
     onParticipantRemove,
     profileImages,
 }: Props) {
-    const {isDMCalling, dmCalleeID, dmCallee} = useDMCallingState();
+    const {isDM, isDMCalling, dmCalleeID, dmCallee} = useDMCallingState();
 
     // The ringing placeholder occupies a tile, so sizing has to account for it
     const tileCount = sessions.length + (isDMCalling ? 1 : 0);
@@ -160,6 +160,9 @@ export function ParticipantsGrid({
                         currentUserID={currentUserID}
                         callHostID={callHostID}
                         callID={callID}
+
+                        // A 1:1 call has no meaningful host to point out.
+                        showHostBadge={!isDM}
                         onParticipantRemove={onParticipantRemove}
                     />
                 ))}

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {UserSessionState} from '@mattermost/calls-common/lib/types';
 import {Post} from '@mattermost/types/posts';
 import {Duration} from 'luxon';
 import {createIntl} from 'react-intl';
@@ -18,6 +19,7 @@ import {
     getWSConnectionURL,
     maxAttemptsReachedErr,
     runWithRetry,
+    selfFirstSortSessions,
     shouldRenderCallsIncoming,
     shouldRenderDesktopWidget,
     sleep,
@@ -642,6 +644,38 @@ describe('utils', () => {
             expect(shouldRenderCallsIncoming()).toBe(false);
 
             global.window = originalWindow;
+        });
+    });
+
+    describe('selfFirstSortSessions', () => {
+        const selfID = 'self-user-id';
+        const otherID = 'other-user-id';
+
+        const session = (userID: string, state = {}) => ({
+            session_id: `${userID}-session`,
+            user_id: userID,
+            ...state,
+        }) as UserSessionState;
+
+        test('should place the current user first', () => {
+            const sessions = [session(otherID), session(selfID)];
+
+            expect(sessions.sort(selfFirstSortSessions(selfID)).map((s) => s.user_id)).toEqual([selfID, otherID]);
+        });
+
+        test('should keep the current user first regardless of speaking state', () => {
+            const sessions = [
+                session(selfID),
+                session(otherID, {unmuted: true, voice: true, raised_hand: 1234}),
+            ];
+
+            expect(sessions.sort(selfFirstSortSessions(selfID)).map((s) => s.user_id)).toEqual([selfID, otherID]);
+        });
+
+        test('should preserve the incoming order of sessions that are not the current user', () => {
+            const sessions = [session('a-user-id'), session('b-user-id'), session(selfID)];
+
+            expect(sessions.sort(selfFirstSortSessions(selfID)).map((s) => s.user_id)).toEqual([selfID, 'a-user-id', 'b-user-id']);
         });
     });
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -217,6 +217,23 @@ export function alphaSortSessions(profiles: IDMappedObjects<UserProfile>) {
     };
 }
 
+// DM calls hold a fixed order — the current user, then the other party — so tiles stay put
+// when the callee answers and when speaking, mute or raised hand state changes.
+export function selfFirstSortSessions(currentUserID: string) {
+    return (elA: UserSessionState, elB: UserSessionState) => {
+        if (elA.user_id === elB.user_id) {
+            return 0;
+        }
+        if (elA.user_id === currentUserID) {
+            return -1;
+        }
+        if (elB.user_id === currentUserID) {
+            return 1;
+        }
+        return 0;
+    };
+}
+
 export function stateSortSessions(presenterID: string, considerReaction = false) {
     return (stateA: UserSessionState, stateB: UserSessionState) => {
         if (stateA.session_id === presenterID) {

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -217,8 +217,7 @@ export function alphaSortSessions(profiles: IDMappedObjects<UserProfile>) {
     };
 }
 
-// DM calls hold a fixed order — the current user, then the other party — so tiles stay put
-// when the callee answers and when speaking, mute or raised hand state changes.
+// In DM calls, always list current user first, then the other participant.
 export function selfFirstSortSessions(currentUserID: string) {
     return (elA: UserSessionState, elB: UserSessionState) => {
         if (elA.user_id === elB.user_id) {


### PR DESCRIPTION
#### Summary
This pull request improves the participant ordering logic for Direct Message (DM) calls, ensuring the current user is always displayed first in the participant list.

It also removes the host badge from participant tiles in DM calls, since a 1:1 call has no meaningful host to point out.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-70689


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the Schema Migration Template as a starting point to capture these details as release notes.
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.

Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.

NONE
-->
```release-note
NONE
```
